### PR TITLE
Added way to hook on the module Load

### DIFF
--- a/src/simpleanalytics.ts
+++ b/src/simpleanalytics.ts
@@ -54,6 +54,14 @@ export class SimpleAPI {
                 throw new Error(`Event type: '${event}' not implemented`);
         }
     }
+
+    onLoad(callback: Function) {
+        if (typeof callback == 'undefined') {
+            throw new Error(`You must pass a function when you call 'onLoad'`);
+        }
+
+        callback();
+    }
 }
 
 export type EventType = 'pageview';

--- a/test/simpleanalytics_test.ts
+++ b/test/simpleanalytics_test.ts
@@ -84,3 +84,12 @@ test('SimpleAnalytics: can send pageview without sending content attributes in t
     t.is(spy.getCall(0).args[0]['customData']['contentType'], undefined);
     t.is(spy.getCall(0).args[0]['customData']['otherData'], 'data');
 });
+
+test('SimpleAnalytics: can execute callback with onLoad event', t => {
+    var numberOfTimesExecuted = 0;
+    var callback = () => numberOfTimesExecuted++;
+
+    simpleanalytics('onLoad', callback);
+
+    t.is(numberOfTimesExecuted, 1);
+});

--- a/test/simpleanalytics_test.ts
+++ b/test/simpleanalytics_test.ts
@@ -93,3 +93,7 @@ test('SimpleAnalytics: can execute callback with onLoad event', t => {
 
     t.is(numberOfTimesExecuted, 1);
 });
+
+test('SimpleAnalytics: can\'t register an invalid onLoad event', t => {
+    t.throws(() => simpleanalytics('onLoad', undefined));
+});


### PR DESCRIPTION
Since the script is fetched in an async way, the coveoua script is sometimes not loaded BEFORE the Recommendations component is initialized, thus giving no recommendation on a semi-random basis.

Hooking on this callback would solve the problem very easily 😉 