### PR TITLE
Set global variables before Initialization

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -17,6 +17,11 @@ export interface CoveoUAGlobal {
 // on `window` in a browser
 const coveoua: CoveoUAGlobal = global.coveoua || {};
 
+// Replace the quick shim with the real thing.
+global.coveoua = SimpleAnalytics;
+
+global.coveoanalytics = analytics;
+
 // On normal execution this library should be loaded after the snippet execution
 // so we will execute the actions in the `q` array
 if (coveoua.q) {
@@ -37,10 +42,5 @@ if (!coveoua.disableAutoHistory) {
     };
     store.addElement(historyElement);
 }
-
-// Replace the quick shim with the real thing.
-global.coveoua = SimpleAnalytics;
-//
-global.coveoanalytics = analytics;
 
 export default coveoua;


### PR DESCRIPTION
coveo-search-ui recommendations need to call `Coveo.initRecommendations()` on the recommendations component BEFORE the search interface is initialized. It uses the history from the `coveoua` module to send recommendations, thus giving us no results.

I implemented a quick workaround to re-execute the query with `coveoua("onLoad")`. However, since the globals variables are not defined when calling the "onLoad" callback, the result is the same as before and gives no results.

This PR sets the global variables before calling the `onLoad` callbacks to allow refreshing the Recommendations component when the `coveoua` module is eventually loaded.