### PR TITLE
Change compilation target to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2015",
+        "target": "es5",
         "outDir": "dist",
         "declaration": true,
         "noImplicitAny": true,
         "removeComments": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": ["es5", "dom", "scripthost", "es6"]
     },
     "include": [
         "src/**/*.ts"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,13 +1,14 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2015",
+        "target": "es5",
         "outDir": "dist_test",
         "declaration": false,
         "noImplicitAny": true,
         "removeComments": true,
         // Inline source map are required for coverage (nyc) to map correctly to good files.
-        "inlineSourceMap": true
+        "inlineSourceMap": true,
+        "lib": ["es5", "dom", "scripthost", "es6"]
     },
     "include": [
         "test/**/*.ts"


### PR DESCRIPTION
Otherwise, importing the lib and using it inside a browser which do not have perfect support for es2015/es6 will break (looking at you Safari).