### PR TITLE
DA-535 Use the contentIdValue instead of the URL in the Page View actionHistory

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.16.0",
+    "babel-register": "^6.24.1",
     "body-parser": "1.15.1",
     "coveralls": "2.11.15",
     "es6-promise": "4.0.2",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -72,17 +72,13 @@ export class Client implements AnalyticsClient {
     sendViewEvent(request: ViewEventRequest): Promise<ViewEventResponse> {
         if (request.referrer === '') { delete request.referrer; }
 
-        // Check if we are in a browser env
-        if (hasDocumentLocation()) {
-            const store = new HistoryStore();
-            const historyElement = {
-                name: 'PageView',
-                value: document.location.toString(),
-                time: JSON.stringify(new Date()),
-                title: document.title
-            };
-            store.addElement(historyElement);
-        }
+        const store = new HistoryStore();
+        const historyElement = {
+            name: 'PageView',
+            value: request.contentIdValue,
+            time: JSON.stringify(new Date()),
+        };
+        store.addElement(historyElement);
 
         return this.sendEvent('view', request).then(defaultResponseTransformer);
     }

--- a/src/events.ts
+++ b/src/events.ts
@@ -56,11 +56,11 @@ export interface CustomEventRequest extends EventBaseRequest {
 }
 
 export interface ViewEventRequest extends EventBaseRequest {
-    location: string;
+    location?: string;
     referrer?: string;
     title?: string;
-    contentIdKey?: string;
-    contentIdValue?: string;
+    contentIdKey: string;
+    contentIdValue: string;
     contentType?: string;
 }
 

--- a/src/history.ts
+++ b/src/history.ts
@@ -18,7 +18,6 @@ export class HistoryStore {
     };
 
     addElement(elem: HistoryElement) {
-        elem.internalTime = new Date().getTime();
         this.cropQueryElement(elem);
         let currentHistory = this.getHistory();
         if (currentHistory != null) {

--- a/test/analytics_test.ts
+++ b/test/analytics_test.ts
@@ -13,7 +13,7 @@ const A_VERSION = 'v1337';
 
 test('Analytics: can post a view event', t => {
 
-    const viewEvent: events.ViewEventRequest = {location: 'here'};
+    const viewEvent: events.ViewEventRequest = {location: 'here', contentIdKey: 'key', contentIdValue: 'value'};
     const response: events.ViewEventResponse = {
         raw: undefined,
         visitId : '123',
@@ -36,6 +36,8 @@ test('Analytics: can post a view event', t => {
         }
 
         t.is(req.body.location, viewEvent.location);
+        t.is(req.body.contentIdKey, viewEvent.contentIdKey);
+        t.is(req.body.contentIdValue, viewEvent.contentIdValue);
 
         res.status(200).send(JSON.stringify(response));
     });


### PR DESCRIPTION
Coveo ML recommendation now supports receiving the contentIdValue at query time in the page view. This will allow to remove the url from the action history and thus have smaller history.
Moreover, the Id is more reliable than the url. 
Moreover, I removed the internalTime in the elements since it is not used by Coveo ML.