### PR TITLE
Put back internalTime because it is used internally by the historySto…

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -20,7 +20,7 @@ export class HistoryStore {
     addElement(elem: HistoryElement) {
         elem.internalTime = new Date().getTime();
         this.cropQueryElement(elem);
-        let currentHistory = this.getHistory(false);
+        let currentHistory = this.getHistoryWithInternalTime();
         if (currentHistory != null) {
             if (this.isValidEntry(elem)) {
                 this.setHistory([elem].concat(currentHistory));
@@ -30,21 +30,19 @@ export class HistoryStore {
         }
     }
 
-    getHistory(stripInternalTime: boolean = true): HistoryElement[] {
-        let history: HistoryElement[] = [];
+    getHistory(): HistoryElement[] {
+        let history = this.getHistoryWithInternalTime();
+        return this.stripInternalTime(history);
+    }
+
+    private getHistoryWithInternalTime(): HistoryElement[] {
         try {
-            history = <HistoryElement[]> JSON.parse(this.store.getItem(STORE_KEY));
+            return <HistoryElement[]> JSON.parse(this.store.getItem(STORE_KEY));
         } catch (e) {
             // When using the Storage APIs (localStorage/sessionStorage)
             // Safari says that those APIs are available but throws when making
             // a call to them.
             return [];
-        }
-
-        if (stripInternalTime) {
-            return this.stripInternalTime(history);
-        } else {
-            return history;
         }
     }
 
@@ -61,7 +59,7 @@ export class HistoryStore {
     }
 
     getMostRecentElement(): HistoryElement {
-        let currentHistory = this.getHistory(false);
+        let currentHistory = this.getHistoryWithInternalTime();
         if (currentHistory != null) {
             const sorted = currentHistory.sort((first: HistoryElement, second: HistoryElement) => {
                 // Internal time might not be set for all history element (on upgrade).

--- a/src/history.ts
+++ b/src/history.ts
@@ -31,18 +31,20 @@ export class HistoryStore {
     }
 
     getHistory(stripInternalTime: boolean = true): HistoryElement[] {
+        let history: HistoryElement[] = [];
         try {
-            let history = <HistoryElement[]> JSON.parse(this.store.getItem(STORE_KEY));
-            if (stripInternalTime) {
-                return this.stripInternalTime(history);
-            } else {
-                return history;
-            }
+            history = <HistoryElement[]> JSON.parse(this.store.getItem(STORE_KEY));
         } catch (e) {
             // When using the Storage APIs (localStorage/sessionStorage)
             // Safari says that those APIs are available but throws when making
             // a call to them.
             return [];
+        }
+
+        if (stripInternalTime) {
+            return this.stripInternalTime(history);
+        } else {
+            return history;
         }
     }
 
@@ -96,9 +98,8 @@ export class HistoryStore {
     }
 
     private stripInternalTime(history: HistoryElement[]): HistoryElement[] {
-        history.forEach(function(part, index, array) {
+        history.forEach((part, index, array) => {
                 delete part.internalTime;
-                array[index] = part;
             });
         return history;
     }

--- a/src/library.d.ts
+++ b/src/library.d.ts
@@ -108,7 +108,7 @@ declare namespace CoveoAnalytics {
     class HistoryStore {
         constructor();
         addElement(elem: HistoryElement): void;
-        getHistory(stripInternalTime?: boolean): HistoryElement[];
+        getHistory(): HistoryElement[];
         setHistory(history: HistoryElement[]): void;
         clear(): void;
     }

--- a/src/library.d.ts
+++ b/src/library.d.ts
@@ -108,7 +108,7 @@ declare namespace CoveoAnalytics {
     class HistoryStore {
         constructor();
         addElement(elem: HistoryElement): void;
-        getHistory(): HistoryElement[];
+        getHistory(stripInternalTime?: boolean): HistoryElement[];
         setHistory(history: HistoryElement[]): void;
         clear(): void;
     }

--- a/test/history_test.ts
+++ b/test/history_test.ts
@@ -28,7 +28,7 @@ test.afterEach( t => {
 });
 
 test('HistoryStore should be able to add an element in the history', t => {
-  storageMock.expects('setItem').once().withArgs(history.STORE_KEY, sinon.match(/"value":"value"/));
+  storageMock.expects('setItem').once().withArgs(history.STORE_KEY, sinon.match(/"value":"value"/).and(sinon.match(/"time"/)).and(sinon.match(/"internalTime"/)));
   historyStore.addElement(data);
   storageMock.verify();
 });
@@ -76,6 +76,28 @@ test('HistoryStore should be able to get the history', t => {
   storageMock.expects('getItem').once().withArgs(history.STORE_KEY);
   historyStore.getHistory();
   storageMock.verify();
+});
+
+test('HistoryStore should be able to remove all internalTime', t => {
+    var historyElements: history.HistoryElement[] = [];
+    for (var i = 0; i < 5; i++) {
+        historyElements.push({
+            name: 'name' + i,
+            value: 'value' + i,
+            time: JSON.stringify(new Date()),
+            internalTime: new Date().getTime()
+        });
+    }
+
+    for (let elem of historyElements) {
+        t.true(elem.hasOwnProperty('internalTime'));
+    }
+
+    historyStore["stripInternalTime"](historyElements);
+
+    for (let elem of historyElements) {
+        t.false(elem.hasOwnProperty('internalTime'));
+    }
 });
 
 test('HistoryStore should remove item when cleared', t => {

--- a/test/history_test.ts
+++ b/test/history_test.ts
@@ -93,7 +93,7 @@ test('HistoryStore should be able to remove all internalTime', t => {
         t.true(elem.hasOwnProperty('internalTime'));
     }
 
-    historyStore["stripInternalTime"](historyElements);
+    historyStore['stripInternalTime'](historyElements);
 
     for (let elem of historyElements) {
         t.false(elem.hasOwnProperty('internalTime'));


### PR DESCRIPTION
Put back internalTime because it is used internally by the historyStore. It should not have been removed completely in the last pull request (153).
Internally, the internalTime is kept, but by defaut, getHistory removes the internalTime, because it is not necessary in the actionHistory sent to Coveo ML.