### PR TITLE
Allow to override language

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -6,7 +6,7 @@ export interface SearchDocument {
 }
 
 export interface EventBaseRequest {
-    language?: string;
+    language: string;
     userAgent?: string;
     customData?: any;
     anonymous?: boolean;

--- a/src/simpleanalytics.ts
+++ b/src/simpleanalytics.ts
@@ -42,7 +42,7 @@ export class SimpleAPI {
                 this.client.sendViewEvent({
                     location: window.location.toString(),
                     referrer: document.referrer,
-                    language: document.documentElement.lang,
+                    language: popFromObject(customData, 'contentLanguage') || document.documentElement.lang,
                     title: document.title,
                     contentIdKey: popFromObject(customData, 'contentIdKey'),
                     contentIdValue: popFromObject(customData, 'contentIdValue'),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 export function popFromObject(object: any, key: string): string {
-    if (object) {
+    if (object && object[key]) {
         var value = object[key];
         delete object[key];
         return value;


### PR DESCRIPTION
Since UA's strict validation in the Cloud rejects Page Views that have an empty `language`, we want to provide the language from within Sitecore which is more reliable than the `<html lang='X'>` attribute.