### PR TITLE
Allow to queue init after queuing sends

### DIFF
--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -32,7 +32,15 @@ global.coveoanalytics = analytics;
 // On normal execution this library should be loaded after the snippet execution
 // so we will execute the actions in the `q` array
 if (coveoua.q) {
-    coveoua.q.forEach((args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args));
+    const isInitEvent = (args: [string, any[]]) => args[0] === 'init';
+    const isNotInitEvent = (args: [string, any[]]) => isInitEvent(args);
+    const processEvent = (args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args);
+    coveoua.q
+        .filter(isInitEvent)
+        .forEach(processEvent);
+    coveoua.q
+        .filter(isNotInitEvent)
+        .forEach(processEvent);
 }
 
 export default coveoua;

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -32,15 +32,9 @@ global.coveoanalytics = analytics;
 // On normal execution this library should be loaded after the snippet execution
 // so we will execute the actions in the `q` array
 if (coveoua.q) {
-    const isInitEvent = (args: [string, any[]]) => args[0] === 'init';
-    const isNotInitEvent = (args: [string, any[]]) => !isInitEvent(args);
-    const processEvent = (args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args);
-    coveoua.q
-        .filter(isInitEvent)
-        .forEach(processEvent);
-    coveoua.q
-        .filter(isNotInitEvent)
-        .forEach(processEvent);
+    const initEvents = coveoua.q.filter((args: [string, any[]]) => args[0] === 'init');
+    const otherEvents = coveoua.q.filter((args: [string, any[]]) => args[0] !== 'init');
+    [...initEvents, ...otherEvents].forEach((args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args));
 }
 
 export default coveoua;

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -33,7 +33,7 @@ global.coveoanalytics = analytics;
 // so we will execute the actions in the `q` array
 if (coveoua.q) {
     const isInitEvent = (args: [string, any[]]) => args[0] === 'init';
-    const isNotInitEvent = (args: [string, any[]]) => isInitEvent(args);
+    const isNotInitEvent = (args: [string, any[]]) => !isInitEvent(args);
     const processEvent = (args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args);
     coveoua.q
         .filter(isInitEvent)


### PR DESCRIPTION
Just a little safeguard, in case you have multiple async scripts.

We pre-process `init` events from the queue, then dequeue the rest.