### PR TITLE
Allow to init with a proxy endpoint

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -28,7 +28,7 @@ export const Endpoints = {
 };
 
 export interface ClientOptions {
-    token: string;
+    token?: string;
     endpoint: string;
     version: string;
 }

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -3,7 +3,7 @@ import { EventType, IRequestPayload } from '../events';
 
 export interface IAnalyticsBeaconClientOptions {
     baseUrl: string;
-    token: string;
+    token?: string;
     visitorIdProvider: VisitorIdProvider;
 }
 
@@ -24,8 +24,8 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         const parsedRequestDataKey = this.getParsedRequestDataKey(eventType);
         const parsedRequestData = `${parsedRequestDataKey}=${encodeURIComponent(JSON.stringify(payload))}`;
         const visitorId = visitorIdProvider.currentVisitorId;
-        const queryParams = `?access_token=${token}${visitorId ? `&visitorId=${visitorId}` : ''}`;
-        const url = `${baseUrl}/analytics/${eventType}${queryParams}`;
+        const paramsFragments = [(token ? `access_token=${token}` : ''), (visitorId ? `visitorId=${visitorId}` : '')].filter(p => !!p).join('&');
+        const url = `${baseUrl}/analytics/${eventType}?${paramsFragments}`;
         // tslint:disable-next-line: no-console
         console.log(`Sending beacon for "${eventType}" with: `, JSON.stringify(payload));
         navigator.sendBeacon(url, new Blob([parsedRequestData], { type: 'application/x-www-form-urlencoded' }));

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -7,7 +7,7 @@ import {
 
 export interface IAnalyticsFetchClientOptions {
     baseUrl: string;
-    token: string;
+    token?: string;
     visitorIdProvider: VisitorIdProvider;
 }
 
@@ -43,7 +43,7 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
             token
         } = this.opts;
         return {
-            'Authorization': `Bearer ${token}`,
+            ...(token ? { 'Authorization': `Bearer ${token}`} : {}),
             'Content-Type': `application/json`
         };
     }

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -51,6 +51,11 @@ test('SimpleAnalytics: can send any event to the endpoint', t => {
     handleOneAnalyticsEvent('send', someRandomEventName);
 });
 
+test('SimpleAnalytics: can send an event with a proxy endpoint', t => {
+    handleOneAnalyticsEvent('initForProxy', `http://localhost:${server.address().port}`);
+    handleOneAnalyticsEvent('send', someRandomEventName);
+});
+
 test('SimpleAnalytics: can initialize with analyticsClient', t => {
     handleOneAnalyticsEvent('init', analyticsClientMock);
 });

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -36,6 +36,22 @@ export class CoveoUA {
         }
     }
 
+    // init initializes a new client intended to be used with a proxy that injects the access token.
+    // @param endpoint is the endpoint of your proxy.
+    initForProxy(endpoint: string): void {
+        if (!endpoint) {
+            throw new Error(`You must pass your endpoint when you call 'initForProxy'`);
+        }
+
+        if (typeof endpoint !== 'string') {
+            throw new Error(`You must pass a string as the endpoint parameter when you call 'initForProxy'`);
+        }
+
+        this.client = new CoveoAnalyticsClient({
+            endpoint: endpoint
+        });
+    }
+
     send(event: EventType | DeprecatedEventType, payload: any = {}): Promise<AnyEventResponse | void> {
         if (typeof this.client == 'undefined') {
             throw new Error(`You must call init before sending an event`);


### PR DESCRIPTION
Required for Sitecore since they use a proxy to add the `Bearer X` header in the back-end.

It was supported in <1.0 (versionless) but I added some validations in V1 that made it unusable for Sitecore people.

I still wanted to keep the same featureset, thus split the init with a second one.