### PR TITLE
Always send visitorId if found in Cookies or localStorage

### DIFF
--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -21,7 +21,9 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
             visitorIdProvider
         } = this.opts;
 
-        const response = await fetch(`${baseUrl}/analytics/${eventType}`, {
+        const visitorId = visitorIdProvider.currentVisitorId;
+
+        const response = await fetch(`${baseUrl}/analytics/${eventType}${visitorId ? `?visitor=${visitorId}` : ''}`, {
             method: 'POST',
             headers: this.getHeaders(),
             mode: 'cors',

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,14 +26,15 @@ export function getAvailableStorage(): WebStorage {
 }
 
 export class CookieStorage implements WebStorage {
+    static prefix = 'coveo_';
     getItem(key: string): string | null {
-        return Cookie.get(key);
+        return Cookie.get(`${CookieStorage.prefix}${key}`);
     }
     removeItem(key: string) {
-        Cookie.erase(key);
+        Cookie.erase(`${CookieStorage.prefix}${key}`);
     }
     setItem(key: string, data: string): void {
-        Cookie.set(key, data);
+        Cookie.set(`${CookieStorage.prefix}${key}`, data);
     }
 }
 


### PR DESCRIPTION
This fixes visitorId always changing in Safari when the setting "Safari -> Preferences -> Privacy -> Prevent cross-site tracking" is checked (it is by default)

The ❤️ of the fix is in AnalyticsFetchClient that will forward `visitorId` when found, and the `get/set` for the `currentVisitorId` that now reads and writes from cookies and localStorage.

I also added the `coveo_` prefix since the JS UI is always using this prefix, so if you search _before_ sending a page view, we _should_, in theory, pick this cookie up.