### PR TITLE
Add fix for store that gets encoded multiple time

### DIFF
--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -47,11 +47,7 @@ test('HistoryStore should be able to retrieve most recent element in the history
     const storageInMemory = new TestMemoryStorage()
     historyStore = new history.HistoryStore(storageInMemory)
 
-    const doubleEncoded = JSON.stringify(JSON.stringify([{
-        name: 'name',
-        value: 'value',
-        time: JSON.stringify(new Date())
-    }]))
+    const doubleEncoded = JSON.stringify(JSON.stringify([data]))
     storageInMemory.setItem(STORE_KEY, doubleEncoded)
 
     const mostRecent = historyStore.getMostRecentElement();

--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -47,10 +47,13 @@ test('HistoryStore should be able to retrieve most recent element in the history
     const storageInMemory = new TestMemoryStorage()
     historyStore = new history.HistoryStore(storageInMemory)
 
+    let mostRecent = historyStore.getMostRecentElement();
+    t.true(mostRecent === undefined)
+
     const doubleEncoded = JSON.stringify(JSON.stringify([data]))
     storageInMemory.setItem(STORE_KEY, doubleEncoded)
 
-    const mostRecent = historyStore.getMostRecentElement();
+    mostRecent = historyStore.getMostRecentElement();
     t.true(mostRecent.name == 'name')
 });
 
@@ -59,13 +62,16 @@ test('HistoryStore should bail out on an object that has been encoded more than 
     const spyOnClear = sinon.spy(storageInMemory, 'removeItem');
     historyStore = new history.HistoryStore(storageInMemory);
 
+    let mostRecent = historyStore.getMostRecentElement();
+    t.true(mostRecent === undefined)
+
     let multiEncoded = JSON.stringify([data])
-    for(let i = 0; i < 11; i ++) {
+    for (let i = 0; i < 11; i++) {
         multiEncoded = JSON.stringify(multiEncoded)
     }
 
     storageInMemory.setItem(STORE_KEY, multiEncoded)
-    const mostRecent = historyStore.getMostRecentElement();
+    mostRecent = historyStore.getMostRecentElement();
     t.true(mostRecent === undefined)
     t.true(spyOnClear.called)
 });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -40,6 +40,19 @@ export class CookieStorage implements WebStorage {
 
 export class NullStorage implements WebStorage {
     getItem(key: string): string | null { return null; }
-    removeItem(key: string) {/**/}
-    setItem(key: string, data: string): void {/**/}
+    removeItem(key: string) {/**/ }
+    setItem(key: string, data: string): void {/**/ }
+}
+
+export class TestMemoryStorage implements WebStorage {
+    private store: Record<string, string> = {};
+    getItem(key: string): string | null {
+        return this.store[key];
+    }
+    removeItem(key: string) {
+        delete this.store[key];
+    }
+    setItem(key: string, data: string) {
+        this.store[key] = data;
+    }
 }


### PR DESCRIPTION
If you have different version of coveoua included in a single page, it seems that older version will encode values differently than newer version, so we can end up with a string when the `getItem` functionality was called on the store.

And then all kind of random stuff would start to break.

This tries to add some logic to Parse until we get back a valid object if possible, with a bail if everything is fubar.