### PR TITLE
Kind of support the `ec:addProduct` action

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,21 @@
             "type": "npm",
             "script": "start",
             "isBackground": true,
-            "problemMatcher": "$ts-webpack-watch"
+            "problemMatcher": [
+                {
+                    "base": "$ts-webpack",
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": {
+                            "regexp": "^.*Compiling....*$"
+                        },
+                        "endsPattern": {
+                            "regexp": "^.*Compiled successfully.*$"
+                        }
+                    }
+                },
+                "$tslint-webpack-watch"
+            ]
         }
     ]
 }

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@ O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
 
 // Replace YOUR-TOKEN with your real token
 // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
-coveoua('init','YOUR-TOKEN');
-coveoua('ec:addProduct', {wow: "cool"});
+coveoua('init','YOUR-TOKEN', 'https://usageanalyticsdev.coveo.com');
+coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
 coveoua('send', 'pageview');
 </script>

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -42,7 +42,7 @@ test('Analytics: can post a view event', t => {
         res.status(200).send(JSON.stringify(response));
     });
 
-    const client = new analytics.Client({
+    const client = new analytics.CoveoAnalyticsClient({
         token: 'token',
         endpoint: `http://localhost:${server.address().port}`,
         version: A_VERSION

--- a/src/coveoua/params.ts
+++ b/src/coveoua/params.ts
@@ -1,0 +1,35 @@
+export interface AllParams {
+    products: Product[];
+    [name: string]: any;
+}
+
+export interface Product {
+    [name: string]: string;
+}
+
+export class Params {
+    private params: AllParams = {products: []};
+
+    getParam(name: string) {
+        return this.params[name];
+    }
+
+    setParam(name: string, value: any): void {
+        this.params[name] = value;
+    }
+
+    getParams(names: string[]) {
+        return names.reduce((all, name) => ({
+            ...all,
+            [name]: this.getParam(name)
+        }), {});
+    }
+
+    get products(): Product[] {
+        return this.getParam('products');
+    }
+
+    set products(products: Product[]) {
+        this.setParam('products', products);
+    }
+}

--- a/src/coveoua/plugins.ts
+++ b/src/coveoua/plugins.ts
@@ -1,0 +1,15 @@
+export type UAPluginOptions = any[];
+
+export class Plugins {
+    private plugins: {[name: string]: any} = {};
+
+    register(name: string, plugin: any): void {
+        this.plugins[name] = plugin;
+    }
+
+    execute(name: string, fn: string, ...pluginOptions: UAPluginOptions[]) {
+        const plugin = this.plugins[name];
+        const actionFunction = plugin[fn];
+        return actionFunction.apply(plugin, pluginOptions);
+    }
+}

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -64,38 +64,6 @@ test('SimpleAnalytics: can send pageview with analyticsClient', t => {
     handleOneAnalyticsEvent('send', 'pageview');
 });
 
-test('SimpleAnalytics: can send pageview with content attributes', t => {
-    let spy = sinon.spy(analyticsClientMock, 'sendViewEvent');
-
-    handleOneAnalyticsEvent('init', analyticsClientMock);
-    handleOneAnalyticsEvent('send', 'pageview', {
-        contentIdKey: 'key',
-        contentIdValue: 'value',
-        contentType: 'type'
-    });
-
-    t.is(spy.getCall(0).args[0]['contentIdKey'], 'key');
-    t.is(spy.getCall(0).args[0]['contentIdValue'], 'value');
-    t.is(spy.getCall(0).args[0]['contentType'], 'type');
-});
-
-test('SimpleAnalytics: can send pageview without sending content attributes in the customdata', t => {
-    let spy = sinon.spy(analyticsClientMock, 'sendViewEvent');
-
-    handleOneAnalyticsEvent('init', analyticsClientMock);
-    handleOneAnalyticsEvent('send', 'pageview', {
-        contentIdKey: 'key',
-        contentIdValue: 'value',
-        contentType: 'type',
-        otherData: 'data'
-    });
-
-    t.is(spy.getCall(0).args[0]['customData']['contentIdKey'], undefined);
-    t.is(spy.getCall(0).args[0]['customData']['contentIdValue'], undefined);
-    t.is(spy.getCall(0).args[0]['customData']['contentType'], undefined);
-    t.is(spy.getCall(0).args[0]['customData']['otherData'], 'data');
-});
-
 test('SimpleAnalytics: can execute callback with onLoad event', t => {
     var numberOfTimesExecuted = 0;
     var callback = () => numberOfTimesExecuted++;

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,13 +4,16 @@ export enum EventType {
     search = 'search',
     click = 'click',
     custom = 'custom',
-    view = 'view'
+    view = 'view',
+    collect = 'collect'
 }
 
 export interface SearchDocument {
     documentUri: string;
     documentUriHash: string;
 }
+
+export type SendEventArguments = [EventType, ...any[]];
 
 export interface EventBaseRequest {
     language?: string;

--- a/src/hook/addDefaultValues.ts
+++ b/src/hook/addDefaultValues.ts
@@ -1,0 +1,9 @@
+import { AnalyticsClientSendEventHook } from '../client/analytics';
+
+export const addDefaultValues: AnalyticsClientSendEventHook = (eventType, payload) => {
+    return {
+        language: document.documentElement.lang,
+        userAgent: navigator.userAgent,
+        ...payload
+    };
+};

--- a/src/hook/enhanceViewEvent.ts
+++ b/src/hook/enhanceViewEvent.ts
@@ -1,0 +1,16 @@
+import { AnalyticsClientSendEventHook } from '../client/analytics';
+import { ViewEventRequest, EventType } from '../events';
+
+export const enhanceViewEvent: AnalyticsClientSendEventHook = (
+    eventType,
+    payload
+) => {
+    return eventType === EventType.view
+        ? ({
+              location: window.location.toString(),
+              referrer: document.referrer,
+              title: document.title,
+              ...payload
+          } as ViewEventRequest)
+        : payload;
+};

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -1,0 +1,59 @@
+import { AnalyticsClient } from '../client/analytics';
+import { Params, Product } from '../coveoua/params';
+import { EventType } from '../events';
+
+// Based off: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#enhanced-ecomm
+const productKeysMapping: {[name: string]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    position: 'ps',
+    price: 'pr',
+    quantity: 'qt',
+    coupon: 'cc'
+};
+
+export const ECPluginEventTypes = {
+    pageview: 'pageview'
+};
+
+export class EC {
+    private client: AnalyticsClient;
+    private params: Params;
+    constructor({  client, params }: { client: AnalyticsClient;  params: Params; }) {
+        this.client = client;
+        this.params = params;
+
+        this.client.addEventTypeMapping(ECPluginEventTypes.pageview, EventType.collect);
+        this.client.registerBeforeSendEventHook((eventType, payload) => {
+            return eventType === ECPluginEventTypes.pageview
+                ? this.enhancePayload(payload)
+                : payload;
+        });
+    }
+
+    addProduct(product: Product) {
+        this.params.products = [...this.params.products, product];
+    }
+
+    private enhancePayload(payload: any) {
+        return this.params.products.reduce((newPayload, product, index) => {
+            return {
+                ...newPayload,
+                ...this.convertProductToMeasurementProtocol(product, index),
+            };
+        }, payload);
+    }
+
+    private convertProductToMeasurementProtocol(product: Product, index: number) {
+        return Object.keys(product).reduce((mappedProduct, key) => {
+            const newKey = `pr${index}${productKeysMapping[key] || key}`;
+            return {
+                ...mappedProduct,
+                [newKey]: product[key]
+            };
+        }, {});
+    }
+}

--- a/test/analyticsclientmock.ts
+++ b/test/analyticsclientmock.ts
@@ -35,6 +35,12 @@ export class AnalyticsClientMock implements AnalyticsClient {
     getHealth(): Promise<HealthResponse> {
         return Promise.resolve({} as HealthResponse);
     }
+    registerBeforeSendEventHook() {
+
+    }
+    addEventTypeMapping() {
+
+    }
 }
 
 export default AnalyticsClientMock;


### PR DESCRIPTION
Changelog:

* Can use the `ec` plugin which uses hooks to change stuff
* Split payload enhancer into hooks
* Created a very simple "params" container

I wanted to get some feedback on the direction this is going. 

For now, each product is stored in a local array and will be appended to the payload when the `pageview` event is sent.

I borrowed many things from `commerce-ca-js` and adapted some others :)