### PR TITLE
Support parsing variable arguments for specific event types

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,5 +9,6 @@ O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
 // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
 coveoua('init','YOUR-TOKEN', 'https://usageanalyticsdev.coveo.com');
 coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
-coveoua('send', 'pageview');
+coveoua('send', "pageview");
+coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue", {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
 </script>

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -1,4 +1,4 @@
-import { AnyEventResponse, SendEventArguments } from '../events';
+import { AnyEventResponse, SendEventArguments, VariableArgumentsPayload } from '../events';
 import {
     AnalyticsClient,
     CoveoAnalyticsClient,
@@ -58,12 +58,12 @@ export class CoveoUA {
         });
     }
 
-    send(...[event, payload]: SendEventArguments): Promise<AnyEventResponse | void> {
+    send(...[event, ...payload]: SendEventArguments): Promise<AnyEventResponse | void> {
         if (typeof this.client == 'undefined') {
             throw new Error(`You must call init before sending an event`);
         }
 
-        return this.client.sendEvent(event, payload);
+        return this.client.sendEvent(event, ...payload as VariableArgumentsPayload);
 
     }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,6 +14,7 @@ export interface SearchDocument {
 }
 
 export type SendEventArguments = [EventType, ...any[]];
+export type VariableArgumentsPayload = [any] | [string, any] | [string, string, any] | [string, string, string, any] | [string, string, string, string, any];
 
 export interface EventBaseRequest {
     language?: string;

--- a/src/hook/enhanceViewEvent.ts
+++ b/src/hook/enhanceViewEvent.ts
@@ -1,11 +1,11 @@
 import { AnalyticsClientSendEventHook } from '../client/analytics';
-import { ViewEventRequest, EventType } from '../events';
+import { ViewEventRequest } from '../events';
 
 export const enhanceViewEvent: AnalyticsClientSendEventHook = (
     eventType,
     payload
 ) => {
-    return eventType === EventType.view
+    return eventType === 'view'
         ? ({
               location: window.location.toString(),
               referrer: document.referrer,

--- a/src/hook/enhanceViewEvent.ts
+++ b/src/hook/enhanceViewEvent.ts
@@ -1,16 +1,30 @@
 import { AnalyticsClientSendEventHook } from '../client/analytics';
-import { ViewEventRequest } from '../events';
+import { ViewEventRequest, EventType } from '../events';
+import { HistoryStore } from '../history';
 
 export const enhanceViewEvent: AnalyticsClientSendEventHook = (
     eventType,
     payload
 ) => {
-    return eventType === 'view'
-        ? ({
-              location: window.location.toString(),
-              referrer: document.referrer,
-              title: document.title,
-              ...payload
-          } as ViewEventRequest)
-        : payload;
+    if (eventType === EventType.view) {
+        addPageViewToHistory(payload.contentIdValue);
+        return {
+            location: window.location.toString(),
+            referrer: document.referrer,
+            title: document.title,
+            ...payload
+        } as ViewEventRequest;
+    }
+
+    return payload;
+};
+
+const addPageViewToHistory = (pageViewValue: string) => {
+    const store = new HistoryStore();
+    const historyElement = {
+        name: 'PageView',
+        value: pageViewValue,
+        time: JSON.stringify(new Date()),
+    };
+    store.addElement(historyElement);
 };


### PR DESCRIPTION
The signature is defined here: https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation

I tried multiple things to not disturb too much the code, I feel like the simple configuration allows mapping the arguments in the right order quite easily