### PR TITLE
Unit tests for analytics and EC

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -48,6 +48,21 @@ describe('ec events', () => {
         });
     });
 
+    it('can send a pageview event with options', async () => {
+        coveoua('init', aToken, anEndpoint);
+        await coveoua('send', 'pageview', 'page', {
+            title: 'wow',
+            location: 'http://right.here',
+        });
+
+        assertRequestSentContainsEqual({
+            ...defaultContextValues,
+            page: 'page',
+            title: 'wow',
+            location: 'http://right.here'
+        });
+    });
+
     const assertRequestSentContainsEqual = (toContain: {[name: string]: any}) => {
         expect(fetchMock.called()).toBe(true);
 

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -1,0 +1,62 @@
+import 'isomorphic-fetch';
+import * as fetchMock from 'fetch-mock';
+import { DefaultEventResponse } from '../src/events';
+import coveoua from '../src/coveoua/browser';
+
+describe('ec events', () => {
+    const aToken = 'token';
+    const anEndpoint = 'http://bloup';
+    const aVisitorId = '123';
+
+    const defaultContextValues = {
+        cid: '',
+        dl: `${location.protocol}//${location.hostname}${location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`}${location.search}`,
+        sr: `${screen.width}x${screen.height}`,
+        sd: `${screen.colorDepth}-bit`,
+        ul: navigator.language,
+        ua: navigator.userAgent,
+        dr: document.referrer,
+        dt: document.title,
+        de: document.characterSet,
+    };
+
+    beforeEach(() => {
+        const address = `${anEndpoint}/rest/v15/analytics/collect`;
+        const eventResponse: DefaultEventResponse = {
+            visitId : 'firsttimevisiting',
+            visitorId: aVisitorId
+        };
+        fetchMock.reset();
+        fetchMock.post(address, eventResponse);
+        fetchMock.post(`${address}?visitor=${aVisitorId}`, eventResponse);
+    });
+
+    it('can send a product detail view event', async () => {
+        coveoua('init', aToken, anEndpoint);
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', custom: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        await coveoua('send', 'pageview');
+
+        assertRequestSentContainsEqual({
+            ...defaultContextValues,
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pr1custom: 'ok',
+            pa: 'detail',
+            storeid: 'amazing',
+        });
+    });
+
+    const assertRequestSentContainsEqual = (toContain: {[name: string]: any}) => {
+        expect(fetchMock.called()).toBe(true);
+
+        const [, { body }] = fetchMock.lastCall();
+        expect(body).not.toBeUndefined();
+
+        const parsedBody = JSON.parse(body.toString());
+        Object.keys((key: string) => expect(parsedBody).toContainEqual({
+            [key]: toContain[key]
+        }));
+    };
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    roots: ['<rootDir>/src'],
+    roots: ['<rootDir>/src', '<rootDir>/functional'],
     preset: 'ts-jest',
     moduleNameMapper: {
         '@App/(.*)': '<rootDir>/src/$1',

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -43,7 +43,7 @@ describe('Analytics', () => {
 
         expect(fetchMock.called()).toBe(true);
 
-        const [path, { headers: headers, body }] = fetchMock.lastCall();
+        const [path, { headers, body }] = fetchMock.lastCall();
         expect(path).toBe(endpointForEventType(EventType.view));
 
         const h = headers as Record<string, string>;
@@ -105,7 +105,7 @@ describe('Analytics', () => {
 
     describe('with event type mapping with variable arguments', () => {
         const specialEventType = '🌟special🌟';
-        const argumentNames = ['1️⃣', '2️⃣', '3️⃣'];
+        const argumentNames = ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'];
         beforeEach(() => {
             mockFetchRequestForEventType(EventType.custom);
             client.addEventTypeMapping(specialEventType, {
@@ -125,38 +125,38 @@ describe('Analytics', () => {
         });
 
         it('should properly parse 1 argument', async () => {
-            await client.sendEvent(specialEventType, 'something');
+            await client.sendEvent(specialEventType, 'Video');
 
             const [, { body }] = fetchMock.lastCall();
 
             const parsedBody = JSON.parse(body.toString());
             expect(parsedBody).toEqual({
-                [argumentNames[0]]: 'something'
+                [argumentNames[0]]: 'Video'
             });
         });
 
         it('should properly parse all arguments', async () => {
-            await client.sendEvent(specialEventType, 'something', 'another', '🌈');
+            await client.sendEvent(specialEventType, 'Video', 'play', 'campaign');
 
             const [, { body }] = fetchMock.lastCall();
 
             const parsedBody = JSON.parse(body.toString());
             expect(parsedBody).toEqual({
-                [argumentNames[0]]: 'something',
-                [argumentNames[1]]: 'another',
-                [argumentNames[2]]: '🌈'
+                [argumentNames[0]]: 'Video',
+                [argumentNames[1]]: 'play',
+                [argumentNames[2]]: 'campaign'
             });
         });
 
         it('should properly handle a finished object argument', async () => {
-            await client.sendEvent(specialEventType, 'something', { mergethis: 'plz' });
+            await client.sendEvent(specialEventType, 'Video', { nonInteraction: true });
 
             const [, { body }] = fetchMock.lastCall();
 
             const parsedBody = JSON.parse(body.toString());
             expect(parsedBody).toEqual({
-                [argumentNames[0]]: 'something',
-                mergethis: 'plz'
+                [argumentNames[0]]: 'Video',
+                nonInteraction: true
             });
         });
     });

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -1,42 +1,191 @@
-import * as analytics from './analytics';
 import * as fetchMock from 'fetch-mock';
-import * as events from '../events';
+import { EventType, ViewEventRequest, DefaultEventResponse } from '../events';
+import { CoveoAnalyticsClient } from './analytics';
+import { CookieStorage } from '../storage';
 
 describe('Analytics', () => {
     const aToken = 'token';
     const anEndpoint = 'http://bloup';
     const A_VERSION = 'v1337';
+    const aVisitorId = '123';
 
-    const client = new analytics.CoveoAnalyticsClient({
-        token: aToken,
-        endpoint: anEndpoint,
-        version: A_VERSION
-    });
-    const viewEvent: events.ViewEventRequest = { location: 'here', contentIdKey: 'key', contentIdValue: 'value', language: 'en' };
-    const viewEventResponse: events.ViewEventResponse = {
-        visitId : '123',
-        visitorId: '213'
+    const viewEvent: ViewEventRequest = { location: 'here', contentIdKey: 'key', contentIdValue: 'value', language: 'en' };
+    const eventResponse: DefaultEventResponse = {
+        visitId : 'firsttimevisiting',
+        visitorId: aVisitorId
     };
 
+    const endpointForEventType = (eventType: EventType) => `${anEndpoint}/rest/${A_VERSION}/analytics/${eventType}`;
+    const mockFetchRequestForEventType = (eventType: EventType) => {
+        const address = endpointForEventType(eventType);
+        fetchMock.post(address, eventResponse);
+        fetchMock.post(`${address}?visitor=${aVisitorId}`, eventResponse);
+    };
+
+    let client: CoveoAnalyticsClient;
+
+    beforeEach(() => {
+        new CookieStorage().removeItem('visitorId');
+        localStorage.clear();
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: anEndpoint,
+            version: A_VERSION
+        });
+        fetchMock.reset();
+    });
+
     it('should call fetch with the parameters', async () => {
-        const address = `${anEndpoint}/rest/${A_VERSION}/analytics/view`;
-        fetchMock.post(address, viewEventResponse);
+        mockFetchRequestForEventType(EventType.view);
 
         const response = await client.sendViewEvent(viewEvent);
-        expect(response).toEqual(viewEventResponse);
+        expect(response).toEqual(eventResponse);
 
         expect(fetchMock.called()).toBe(true);
 
-        const [path, params] = fetchMock.lastCall();
-        expect(path).toBe(address);
+        const [path, { headers: headers, body }] = fetchMock.lastCall();
+        expect(path).toBe(endpointForEventType(EventType.view));
 
-        const headers = params.headers as Record<string, string>;
-        expect(headers['Authorization']).toBe(`Bearer ${aToken}`);
-        expect(headers['Content-Type']).toBe('application/json');
+        const h = headers as Record<string, string>;
+        expect(h['Authorization']).toBe(`Bearer ${aToken}`);
+        expect(h['Content-Type']).toBe('application/json');
 
-        expect(params.body).not.toBeUndefined();
+        expect(body).not.toBeUndefined();
 
-        const parsedBody = JSON.parse(params.body.toString());
+        const parsedBody = JSON.parse(body.toString());
         expect(parsedBody).toMatchObject(viewEvent);
+    });
+
+    it('should append default values to the view event', async () => {
+        mockFetchRequestForEventType(EventType.view);
+
+        await client.sendViewEvent(viewEvent);
+
+        const [, { body }] = fetchMock.lastCall();
+
+        const parsedBody = JSON.parse(body.toString());
+        expect(parsedBody).toMatchObject({
+            language: 'en',
+            userAgent: navigator.userAgent
+        });
+    });
+
+    it('should send the events in the order they were called', async () => {
+        mockFetchRequestForEventType(EventType.view);
+        const firstRequest = client.sendViewEvent({
+            ...viewEvent,
+            'customData': {
+                index: 0
+            }
+        });
+        const secondRequest = client.sendViewEvent({
+            ...viewEvent,
+            'customData': {
+                index: 1
+            }
+        });
+        const thirdRequest = client.sendViewEvent({
+            ...viewEvent,
+            'customData': {
+                index: 2
+            }
+        });
+
+        await Promise.all([firstRequest, secondRequest, thirdRequest]);
+
+        const assertResponseHasCustomDataWithIndex = (response: RequestInit, index: number) => {
+            const parsedBody = JSON.parse(response.body.toString());
+            expect(parsedBody.customData.index).toBe(index);
+        };
+        const [[, firstResponse], [, secondResponse], [, thirdResponse]] = fetchMock.calls();
+        assertResponseHasCustomDataWithIndex(firstResponse, 0);
+        assertResponseHasCustomDataWithIndex(secondResponse, 1);
+        assertResponseHasCustomDataWithIndex(thirdResponse, 2);
+    });
+
+    describe('with event type mapping with variable arguments', () => {
+        const specialEventType = '🌟special🌟';
+        const argumentNames = ['1️⃣', '2️⃣', '3️⃣'];
+        beforeEach(() => {
+            mockFetchRequestForEventType(EventType.custom);
+            client.addEventTypeMapping(specialEventType, {
+                newEventType: EventType.custom,
+                variableLengthArgumentsNames: argumentNames
+            });
+        });
+
+        it('should properly parse empty arguments', async () => {
+            await client.sendEvent(specialEventType);
+
+            const [path, { body }] = fetchMock.lastCall();
+            expect(path).toBe(endpointForEventType(EventType.custom));
+
+            const parsedBody = JSON.parse(body.toString());
+            expect(parsedBody).toEqual({});
+        });
+
+        it('should properly parse 1 argument', async () => {
+            await client.sendEvent(specialEventType, 'something');
+
+            const [, { body }] = fetchMock.lastCall();
+
+            const parsedBody = JSON.parse(body.toString());
+            expect(parsedBody).toEqual({
+                [argumentNames[0]]: 'something'
+            });
+        });
+
+        it('should properly parse all arguments', async () => {
+            await client.sendEvent(specialEventType, 'something', 'another', '🌈');
+
+            const [, { body }] = fetchMock.lastCall();
+
+            const parsedBody = JSON.parse(body.toString());
+            expect(parsedBody).toEqual({
+                [argumentNames[0]]: 'something',
+                [argumentNames[1]]: 'another',
+                [argumentNames[2]]: '🌈'
+            });
+        });
+
+        it('should properly handle a finished object argument', async () => {
+            await client.sendEvent(specialEventType, 'something', { mergethis: 'plz' });
+
+            const [, { body }] = fetchMock.lastCall();
+
+            const parsedBody = JSON.parse(body.toString());
+            expect(parsedBody).toEqual({
+                [argumentNames[0]]: 'something',
+                mergethis: 'plz'
+            });
+        });
+    });
+
+    describe('with event type mapping activating context values', () => {
+        const locationContextKeys = ['location'];
+        const screenContextKeys = ['screenResolution', 'screenColor'];
+        const navigatorContextKeys = ['language', 'userAgent'];
+
+        const specialEventType = '🌟special🌟';
+        beforeEach(() => {
+            mockFetchRequestForEventType(EventType.custom);
+            client.addEventTypeMapping(specialEventType, {
+                newEventType: EventType.custom,
+                addDefaultContextInformation: true
+            });
+        });
+
+        it('should properly add location, screen and navigator context keys', async () => {
+            await client.sendEvent(specialEventType);
+
+            const [, { body }] = fetchMock.lastCall();
+
+            const parsedBody = JSON.parse(body.toString());
+            assertHaveAllProperties(parsedBody, [...locationContextKeys, ...screenContextKeys, ...navigatorContextKeys]);
+        });
+
+        const assertHaveAllProperties = (object: any, properties: string[]) => {
+            properties.forEach(property => expect(object).toHaveProperty(property));
+        };
     });
 });

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -250,13 +250,22 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             title: document.title,
             encoding: document.characterSet,
         };
-        return {
-            clientId: this.visitorId,
+        const locationContext = {
             location: `${location.protocol}//${location.hostname}${location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`}${location.search}`,
+        };
+        const screenContext = {
             screenResolution: `${screen.width}x${screen.height}`,
             screenColor: `${screen.colorDepth}-bit`,
+        };
+        const navigatorContext = {
             language: navigator.language,
             userAgent: navigator.userAgent,
+        };
+        return {
+            clientId: this.visitorId,
+            ...screenContext,
+            ...navigatorContext,
+            ...locationContext,
             ...documentContext
         };
     }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -128,9 +128,9 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         }
     }
 
-    async sendEvent(eventType: EventType, ...payload: VariableArgumentsPayload): Promise<AnyEventResponse | void> {
+    async sendEvent(eventType: EventType | string, ...payload: VariableArgumentsPayload): Promise<AnyEventResponse | void> {
         const {
-            newEventType: eventTypeToSend = eventType,
+            newEventType: eventTypeToSend = eventType as EventType,
             variableLengthArgumentsNames = [],
             addDefaultContextInformation = false
         } = this.eventTypeMapping[eventType] || {};
@@ -245,16 +245,19 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     get defaultContextInformation() {
+        const documentContext = {
+            referrer: document.referrer,
+            title: document.title,
+            encoding: document.characterSet,
+        };
         return {
             clientId: this.visitorId,
             location: `${location.protocol}//${location.hostname}${location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`}${location.search}`,
-            referrer: document.referrer,
             screenResolution: `${screen.width}x${screen.height}`,
             screenColor: `${screen.colorDepth}-bit`,
-            encoding: document.characterSet,
             language: navigator.language,
-            title: document.title,
             userAgent: navigator.userAgent,
+            ...documentContext
         };
     }
 }

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -15,14 +15,14 @@ if (!(fetch instanceof Function)) {
 // CoveoUAGlobal is the interface for the global function which also has a
 // queue `q` of unexecuted parameters
 export interface CoveoUAGlobal {
-    (action: string, ...params: string[]): void;
+    (action: string, ...params: any[]): void;
     // CoveoAnalytics.q is the queue of last called actions before lib was included
     q?: [string, any[]][];
 }
 
 // On load of this script we get the global object `coveoua` (which would be)
 // on `window` in a browser
-const coveoua: CoveoUAGlobal = global.coveoua || {};
+const coveoua: CoveoUAGlobal = global.coveoua || handleOneAnalyticsEvent;
 
 // Replace the quick shim with the real thing.
 global.coveoua = handleOneAnalyticsEvent;

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -1,20 +1,11 @@
 import * as express from 'express';
 import * as http from 'http';
 import { handleOneAnalyticsEvent } from './simpleanalytics';
-import { Version, AnalyticsClient } from '../client/analytics';
+import { Version } from '../client/analytics';
+import { createAnalyticsClientMock } from '../../tests/analyticsClientMock';
 
 describe('simpleanalytics', () => {
-    const analyticsClientMock: jest.Mocked<AnalyticsClient> = {
-        sendEvent: jest.fn((eventType, payload) => Promise.resolve()),
-        sendClickEvent: jest.fn((request) => Promise.resolve()),
-        sendCustomEvent: jest.fn((request) => Promise.resolve()),
-        sendSearchEvent: jest.fn((request) => Promise.resolve()),
-        sendViewEvent: jest.fn((request) => Promise.resolve()),
-        getHealth: jest.fn(() => Promise.resolve({status: 'ok'})),
-        getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),
-        addEventTypeMapping: jest.fn(),
-        registerBeforeSendEventHook: jest.fn(),
-    };
+    const analyticsClientMock = createAnalyticsClientMock();
 
     const someRandomEventName = 'kawabunga';
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,7 +14,7 @@ export interface SearchDocument {
 }
 
 export type SendEventArguments = [EventType, ...any[]];
-export type VariableArgumentsPayload = [any] | [string, any] | [string, string, any] | [string, string, string, any] | [string, string, string, string, any];
+export type VariableArgumentsPayload = [] | [any] | [string, any] | [string, string, any] | [string, string, string, any] | [string, string, string, string, any];
 
 export interface EventBaseRequest {
     language?: string;

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -1,0 +1,145 @@
+import { EC, ECPluginEventTypes } from './ec';
+import { createAnalyticsClientMock } from '../../tests/analyticsClientMock';
+
+describe('EC plugin', () => {
+    let ec: EC;
+    let client: ReturnType<typeof createAnalyticsClientMock>;
+
+    beforeEach(() => {
+        client = createAnalyticsClientMock();
+        ec = new EC({ client });
+    });
+
+    it('should register a hook in the client', () => {
+        expect(client.registerBeforeSendEventHook).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register a mapping for each EC type', () => {
+        expect(client.addEventTypeMapping).toHaveBeenCalledTimes(Object.keys(ECPluginEventTypes).length);
+    });
+
+    it('should append the product with the specific format when the hook is called', () => {
+        ec.addProduct({ 'something': 'useful' });
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({ 'pr1something' : 'useful' });
+    });
+
+    it('should append the product with the pageview event', () => {
+        ec.addProduct({ 'something': 'useful' });
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({ 'pr1something' : 'useful' });
+    });
+
+    it('should not append the product with a random event type', () => {
+        ec.addProduct({ 'something': 'useful' });
+
+        const result = executeRegisteredHook('🎲', {});
+
+        expect(result).toEqual({});
+    });
+
+    it('should keep the products until a valid event type is used', () => {
+        ec.addProduct({ 'something': 'useful' });
+
+        executeRegisteredHook('🎲', {});
+        executeRegisteredHook('🐟', {});
+        executeRegisteredHook('💀', {});
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({ 'pr1something' : 'useful' });
+    });
+
+    it('should convert known product keys into the measurement protocol format', () => {
+        ec.addProduct({ 'name': '🧀', price: '5.99$' });
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({ 'pr1nm' : '🧀', 'pr1pr': '5.99$' });
+    });
+
+    it('should allow adding multiple products', () => {
+        ec.addProduct({ 'name': '🍟', price: '1.99$' });
+        ec.addProduct({ 'name': '🍿', price: '3$' });
+        ec.addProduct({ 'name': '🥤', price: '2$' });
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({
+            'pr1nm' : '🍟',
+            'pr1pr': '1.99$',
+            'pr2nm' : '🍿',
+            'pr2pr': '3$',
+            'pr3nm' : '🥤' ,
+            'pr3pr': '2$',
+        });
+    });
+
+    it('should flush the products once they are sent', () => {
+        ec.addProduct({ 'name': '🍟', price: '1.99$' });
+        ec.addProduct({ 'name': '🍿', price: '3$' });
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).not.toEqual({});
+
+        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(secondResult).toEqual({});
+    });
+
+    it('should be able to set an action', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({
+            'pa': 'ok'
+        });
+    });
+
+    it('should flush the action once it is sent', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).not.toEqual({});
+
+        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(secondResult).toEqual({});
+    });
+
+    it('should be able to clear all the data', () => {
+        ec.addProduct({ 'name': '🍨', price: '2.99$' });
+        ec.clearData();
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({});
+    });
+
+    it('should convert known EC keys to the measurement protocol format in the hook', () => {
+        const payload = {
+            clientId: '1234',
+            encoding: 'en-GB',
+            action: 'bloup'
+        };
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, payload);
+
+        expect(result).toEqual({
+            'cid': payload.clientId,
+            'de': payload.encoding,
+            'pa': payload.action
+        });
+    });
+
+    const executeRegisteredHook = (eventType: string, payload: any) => {
+        const [hook] = client.registerBeforeSendEventHook.mock.calls[0];
+        return hook(eventType, payload);
+    };
+});

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -121,7 +121,7 @@ export class EC {
 
     private addECDataToPayload(payload: any) {
         const payloadWithConvertedKeys = this.convertKeysToMeasurementProtocol({
-            action: this.action,
+            ...(this.action ? { action: this.action } : {}),
             ...(this.actionData || {}),
             ...payload
         });

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -1,0 +1,13 @@
+import { AnalyticsClient } from '../src/client/analytics';
+
+export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
+    sendEvent: jest.fn((eventType, payload) => Promise.resolve()),
+    sendClickEvent: jest.fn((request) => Promise.resolve()),
+    sendCustomEvent: jest.fn((request) => Promise.resolve()),
+    sendSearchEvent: jest.fn((request) => Promise.resolve()),
+    sendViewEvent: jest.fn((request) => Promise.resolve()),
+    getHealth: jest.fn(() => Promise.resolve({status: 'ok'})),
+    getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),
+    addEventTypeMapping: jest.fn(),
+    registerBeforeSendEventHook: jest.fn(),
+});


### PR DESCRIPTION
It already found some bugs:

* action was set even if the value was "undefined"
* VariableArgumentsPayload type didn't support "no additional argument" like `send("send", "x")`
* sendEvent didn't allow `string`, so you could not use the API with a custom event type, such as the ones supported in `ec`.

All of those didn't block JS-code from calling them properly, but now they all have better typings.