### PR TITLE
Add pageViewId to EC events according to spec

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -9,7 +9,6 @@ describe('ec events', () => {
     const aVisitorId = '123';
 
     const defaultContextValues = {
-        cid: '',
         dl: `${location.protocol}//${location.hostname}${location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`}${location.search}`,
         sr: `${screen.width}x${screen.height}`,
         sd: `${screen.colorDepth}-bit`,
@@ -58,8 +57,8 @@ describe('ec events', () => {
         assertRequestSentContainsEqual({
             ...defaultContextValues,
             page: 'page',
-            title: 'wow',
-            location: 'http://right.here'
+            dt: 'wow',
+            dl: 'http://right.here'
         });
     });
 
@@ -88,9 +87,9 @@ describe('ec events', () => {
         expect(body).not.toBeUndefined();
 
         const parsedBody = JSON.parse(body.toString());
-        Object.keys((key: string) => expect(parsedBody).toContainEqual({
+        Object.keys(toContain).map((key: string) => ({
             [key]: toContain[key]
-        }));
+        })).forEach((toTest) => expect(parsedBody).toMatchObject(toTest));
     };
 
     const getParsedBody = (): any[] => {

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -5,9 +5,12 @@ describe('EC plugin', () => {
     let ec: EC;
     let client: ReturnType<typeof createAnalyticsClientMock>;
 
+    const someUUID = '13ccebdb-0138-45e8-bf70-884817ead190';
+    const defaultResult = { 'a': someUUID };
+
     beforeEach(() => {
         client = createAnalyticsClientMock();
-        ec = new EC({ client });
+        ec = new EC({ client, uuidGenerator: () => someUUID });
     });
 
     it('should register a hook in the client', () => {
@@ -23,7 +26,7 @@ describe('EC plugin', () => {
 
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({ 'pr1something' : 'useful' });
+        expect(result).toEqual({ ...defaultResult, 'pr1something' : 'useful' });
     });
 
     it('should append the product with the pageview event', () => {
@@ -31,7 +34,7 @@ describe('EC plugin', () => {
 
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({ 'pr1something' : 'useful' });
+        expect(result).toEqual({ ...defaultResult, 'pr1something' : 'useful' });
     });
 
     it('should not append the product with a random event type', () => {
@@ -50,7 +53,7 @@ describe('EC plugin', () => {
         executeRegisteredHook('💀', {});
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({ 'pr1something' : 'useful' });
+        expect(result).toEqual({ ...defaultResult, 'pr1something' : 'useful' });
     });
 
     it('should convert known product keys into the measurement protocol format', () => {
@@ -58,7 +61,7 @@ describe('EC plugin', () => {
 
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({ 'pr1nm' : '🧀', 'pr1pr': '5.99$' });
+        expect(result).toEqual({ ...defaultResult, 'pr1nm' : '🧀', 'pr1pr': '5.99$' });
     });
 
     it('should allow adding multiple products', () => {
@@ -69,6 +72,7 @@ describe('EC plugin', () => {
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
         expect(result).toEqual({
+            ...defaultResult,
             'pr1nm' : '🍟',
             'pr1pr': '1.99$',
             'pr2nm' : '🍿',
@@ -88,7 +92,7 @@ describe('EC plugin', () => {
 
         const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(secondResult).toEqual({});
+        expect(secondResult).toEqual({...defaultResult});
     });
 
     it('should be able to set an action', () => {
@@ -97,6 +101,7 @@ describe('EC plugin', () => {
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
         expect(result).toEqual({
+            ...defaultResult,
             'pa': 'ok'
         });
     });
@@ -110,7 +115,7 @@ describe('EC plugin', () => {
 
         const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(secondResult).toEqual({});
+        expect(secondResult).toEqual({...defaultResult});
     });
 
     it('should be able to clear all the data', () => {
@@ -119,7 +124,7 @@ describe('EC plugin', () => {
 
         const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({});
+        expect(result).toEqual({...defaultResult});
     });
 
     it('should convert known EC keys to the measurement protocol format in the hook', () => {
@@ -132,6 +137,7 @@ describe('EC plugin', () => {
         const result = executeRegisteredHook(ECPluginEventTypes.event, payload);
 
         expect(result).toEqual({
+            ...defaultResult,
             'cid': payload.clientId,
             'de': payload.encoding,
             'pa': payload.action

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,14 @@
 const nodeCrypto = require('crypto');
 global.crypto = {
-    getRandomValues: (buffer) =>  nodeCrypto.randomFillSync(buffer)
+    getRandomValues: (buffer) => nodeCrypto.randomFillSync(buffer)
 };
+
+Object.defineProperty(document, 'referrer', {
+    value: 'http://somewhere.over/therainbow',
+});
+Object.defineProperty(document, 'title', {
+    value: 'MAH PAGE',
+});
+Object.defineProperty(document, 'characterSet', {
+    value: 'UTF-8',
+});


### PR DESCRIPTION
I followed the document that Luca made for us.

What I understood, is that we must change the PageViewID if a second pageview is sent.

If you are on a traditional site, each page will generate a new UUID, this is fine.

But if you are on a Simple Page App, you should be able to send a "pageview" on each page change. Thus, it follows those rules:

* Any event sent will keep the first UUID generated. So three calls [event, pageview, event] should send the same UUID, since it is the same page.
* As soon as a second pageview occurs, we change the UUID like this: [event, pageview, event, pageview (change!), event, pageview (change!)].

Hope it makes sense :D 