### PR TITLE
Create visitorId before the first request is sent

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -27,7 +27,6 @@ describe('ec events', () => {
         };
         fetchMock.reset();
         fetchMock.post(address, eventResponse);
-        fetchMock.post(`${address}?visitor=${aVisitorId}`, eventResponse);
     });
 
     it('can send a product detail view event', async () => {

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,8 @@ O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
 // Replace YOUR-TOKEN with your real token
 // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
 coveoua('init','YOUR-TOKEN', 'https://usageanalyticsdev.coveo.com');
+coveoua('send', "custom", { 'page': 'http://123'});
+coveoua('send', "view", { 'page': 'http://123'});
 coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
 coveoua('ec:setAction', 'detail', {storeid: "amazing"});
 coveoua('send', "pageview");

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -105,6 +105,8 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         ];
         this.eventTypeMapping = {};
 
+        this.initVisitorId();
+
         const clientsOptions = {
             baseUrl: this.baseUrl,
             token,
@@ -115,8 +117,13 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         window.addEventListener('beforeunload', () => this.flushBufferWithBeacon());
     }
 
+    private initVisitorId() {
+        const existingVisitorId = this.visitorId || (hasCookieStorage() && this.cookieStorage.getItem('visitorId')) || (hasLocalStorage() && localStorage.getItem('visitorId')) || '';
+        this.currentVisitorId = existingVisitorId || uuidv4();
+    }
+
     get currentVisitorId() {
-        return this.visitorId || (hasCookieStorage() && this.cookieStorage.getItem('visitorId')) || (hasLocalStorage() && localStorage.getItem('visitorId')) || '';
+        return this.visitorId;
     }
 
     set currentVisitorId(visitorId: string) {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,12 +3,10 @@ global.crypto = {
     getRandomValues: (buffer) => nodeCrypto.randomFillSync(buffer)
 };
 
-Object.defineProperty(document, 'referrer', {
-    value: 'http://somewhere.over/therainbow',
-});
-Object.defineProperty(document, 'title', {
-    value: 'MAH PAGE',
-});
-Object.defineProperty(document, 'characterSet', {
-    value: 'UTF-8',
-});
+const documentMock = {
+    referrer: 'http://somewhere.over/therainbow',
+    title: 'MAH PAGE',
+    characterSet: 'UTF-8'
+};
+
+Object.keys(documentMock).forEach(key => Object.defineProperty(document, key, { value: documentMock[key] }));


### PR DESCRIPTION
Instead of relying on the first call to get a visitorId, we can automatically generate one when the script is loaded.

It will be set in the Cookies as usual, so the JSUI should read this one