### PR TITLE
Added missing hitType (t) parameter

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -37,6 +37,7 @@ describe('ec events', () => {
 
         assertRequestSentContainsEqual({
             ...defaultContextValues,
+            t: 'pageview',
             pr1nm: 'wow',
             pr1id: 'something',
             pr1br: 'brand',
@@ -55,6 +56,7 @@ describe('ec events', () => {
 
         assertRequestSentContainsEqual({
             ...defaultContextValues,
+            t: 'pageview',
             page: 'page',
             dt: 'wow',
             dl: 'http://right.here'

--- a/public/index.html
+++ b/public/index.html
@@ -13,5 +13,6 @@ coveoua('send', "view", { 'page': 'http://123'});
 coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
 coveoua('ec:setAction', 'detail', {storeid: "amazing"});
 coveoua('send', "pageview");
+coveoua('ec:setAction', 'purchase', {storeid: "amazing"});
 coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue");
 </script>

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -39,6 +39,7 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
 
             return visit;
         } else {
+            try { response.json(); } catch { /* If you don't parse the response, it won't appear in the network tab. */ }
             console.error(`An error has occured when sending the "${eventType}" event.`, response, payload);
             throw new Error(`An error has occurred when sending the "${eventType}" event. Check the console logs for more details.`);
         }

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -6,7 +6,7 @@ describe('EC plugin', () => {
     let client: ReturnType<typeof createAnalyticsClientMock>;
 
     const someUUID = '13ccebdb-0138-45e8-bf70-884817ead190';
-    const defaultResult = { 'a': someUUID };
+    const defaultResult = { 'a': someUUID, t: ECPluginEventTypes.event };
 
     beforeEach(() => {
         client = createAnalyticsClientMock();

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -21,6 +21,7 @@ const eventKeysMapping: {[name: string]: string} = {
     eventLabel: 'el',
     eventValue: 'ev',
     pageViewId: 'a',
+    hitType: 't',
 };
 
 const productActionsKeysMapping: {[name: string]: string} = {
@@ -132,6 +133,7 @@ export class EC {
 
     private addECDataToPayload(eventType: string, payload: any) {
         const payloadWithConvertedKeys = this.convertKeysToMeasurementProtocol({
+            hitType: eventType,
             pageViewId: this.getPageViewId(eventType),
             ...(this.action ? { action: this.action } : {}),
             ...(this.actionData || {}),


### PR DESCRIPTION
So, I tried the collect endpoint in dev with all the recent changes and it was missing the `t` parameter.

There it is! I also found out that if you don't parse the response after `fetch`, the response stays empty in Chrome! Weird feature!