### PR TITLE
Implement dl and dr logic, bring context into EC plugin

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -27,10 +27,10 @@ describe('ec events', () => {
         };
         fetchMock.reset();
         fetchMock.post(address, eventResponse);
+        coveoua('init', aToken, anEndpoint);
     });
 
     it('can send a product detail view event', async () => {
-        coveoua('init', aToken, anEndpoint);
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', custom: 'ok'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
         await coveoua('send', 'pageview');
@@ -48,7 +48,6 @@ describe('ec events', () => {
     });
 
     it('can send a pageview event with options', async () => {
-        coveoua('init', aToken, anEndpoint);
         await coveoua('send', 'pageview', 'page', {
             title: 'wow',
             location: 'http://right.here',
@@ -57,14 +56,13 @@ describe('ec events', () => {
         assertRequestSentContainsEqual({
             ...defaultContextValues,
             t: 'pageview',
-            page: 'page',
+            dp: 'page',
             dt: 'wow',
             dl: 'http://right.here'
         });
     });
 
     it('should change the pageViewId only when sending a second page view event', async () => {
-        coveoua('init', aToken, anEndpoint);
         await coveoua('send', 'event');
         await coveoua('send', 'event');
         await coveoua('send', 'pageview');
@@ -81,6 +79,33 @@ describe('ec events', () => {
         expect(secondPageView.a).toBe(afterSecondPageView.a);
     });
 
+    it('should update the current location and referrer on a second page view', async () => {
+        const initialLocation = `${window.location}`;
+        const secondLocation = 'http://very.new/';
+
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        await coveoua('send', 'pageview');
+
+        const [event, secondEvent] = getParsedBody();
+
+        expect(event.dl).toBe(initialLocation);
+        expect(event.dr).toBe(document.referrer);
+
+        expect(secondEvent.dl).toBe(secondLocation);
+        expect(secondEvent.dr).toBe(initialLocation);
+    });
+
+    it('should updated the current location and referrer when a pageview is sent with the page parameter', async () => {
+        const initialLocation = `${window.location}`;
+
+        await coveoua('send', 'pageview', '/page');
+
+        const [event] = getParsedBody();
+
+        expect(event.dl).toBe(`${initialLocation}page`);
+    });
+
     const assertRequestSentContainsEqual = (toContain: {[name: string]: any}) => {
         expect(fetchMock.called()).toBe(true);
 
@@ -95,5 +120,12 @@ describe('ec events', () => {
 
     const getParsedBody = (): any[] => {
         return fetchMock.calls().map(([, { body }]) => JSON.parse(body.toString()));
+    };
+
+    const changeDocumentLocation = (url: string) => {
+        delete window.location;
+        // @ts-ignore
+        // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.
+        window.location = new URL(url);
     };
 });

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -84,19 +84,37 @@ describe('ec events', () => {
         const secondLocation = 'http://very.new/';
 
         await coveoua('send', 'pageview');
+        await coveoua('send', 'event', '1');
         changeDocumentLocation(secondLocation);
         await coveoua('send', 'pageview');
+        await coveoua('send', 'event', '2');
+
+        const [pageView, afterFirst, secondPageView, afterSecond] = getParsedBody();
+
+        expect(pageView.dl).toBe(initialLocation);
+        expect(pageView.dr).toBe(document.referrer);
+        expect(afterFirst.dl).toBe(initialLocation);
+        expect(afterFirst.dr).toBe(document.referrer);
+
+        expect(secondPageView.dl).toBe(secondLocation);
+        expect(secondPageView.dr).toBe(initialLocation);
+        expect(afterSecond.dl).toBe(secondLocation);
+        expect(afterSecond.dr).toBe(initialLocation);
+    });
+
+    it('should update the current location when a pageview is sent with the page parameter and keep it', async () => {
+        const initialLocation = `${window.location}`;
+
+        await coveoua('send', 'pageview', '/page');
+        await coveoua('send', 'event', '1');
 
         const [event, secondEvent] = getParsedBody();
 
-        expect(event.dl).toBe(initialLocation);
-        expect(event.dr).toBe(document.referrer);
-
-        expect(secondEvent.dl).toBe(secondLocation);
-        expect(secondEvent.dr).toBe(initialLocation);
+        expect(event.dl).toBe(`${initialLocation}page`);
+        expect(secondEvent.dl).toBe(`${initialLocation}page`);
     });
 
-    it('should updated the current location and referrer when a pageview is sent with the page parameter', async () => {
+    it('should keep the current location when a pageview is sent with the page parameter', async () => {
         const initialLocation = `${window.location}`;
 
         await coveoua('send', 'pageview', '/page');

--- a/public/index.html
+++ b/public/index.html
@@ -14,4 +14,5 @@ coveoua('send', "pageview", "/firstpage");
 coveoua('ec:setAction', 'purchase', {storeid: "amazing"});
 coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue");
 coveoua('send', "pageview", "/secondpage");
+coveoua('send', "event");
 </script>

--- a/public/index.html
+++ b/public/index.html
@@ -7,12 +7,11 @@ O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
 
 // Replace YOUR-TOKEN with your real token
 // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
-coveoua('init','YOUR-TOKEN', 'https://usageanalyticsdev.coveo.com');
-coveoua('send', "custom", { 'page': 'http://123'});
-coveoua('send', "view", { 'page': 'http://123'});
+coveoua('init','YOUR-TOKEN');
 coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: 'ok'});
 coveoua('ec:setAction', 'detail', {storeid: "amazing"});
-coveoua('send', "pageview");
+coveoua('send', "pageview", "/firstpage");
 coveoua('ec:setAction', 'purchase', {storeid: "amazing"});
 coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue");
+coveoua('send', "pageview", "/secondpage");
 </script>

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -166,40 +166,22 @@ describe('Analytics', () => {
     });
 
     describe('with event type mapping activating context values', () => {
-        const locationContextKeys = ['location'];
-        const screenContextKeys = ['screenResolution', 'screenColor'];
-        const navigatorContextKeys = ['language', 'userAgent'];
-
         const specialEventType = '🌟special🌟';
         beforeEach(() => {
             mockFetchRequestForEventType(EventType.custom);
             client.addEventTypeMapping(specialEventType, {
                 newEventType: EventType.custom,
-                addDefaultContextInformation: true
+                addVisitorIdParameter: true
             });
         });
 
-        it('should properly add location, screen and navigator context keys', async () => {
+        it('should properly add visitorId key', async () => {
             await client.sendEvent(specialEventType);
 
             const [body] = getParsedBodyCalls();
 
-            assertHaveAllProperties(body, [...locationContextKeys, ...screenContextKeys, ...navigatorContextKeys]);
+            expect(body).toHaveProperty('visitorId');
         });
-
-        it('should each call the uuidv4 method', async () => {
-            uuidv4Mock.mockReset();
-
-            await client.sendEvent(specialEventType);
-            await client.sendEvent(specialEventType);
-            await client.sendEvent(specialEventType);
-
-            expect(uuidv4Mock).toHaveBeenCalledTimes(3);
-        });
-
-        const assertHaveAllProperties = (object: any, properties: string[]) => {
-            properties.forEach(property => expect(object).toHaveProperty(property));
-        };
     });
 
     const getParsedBodyCalls = (): any[] => {

--- a/src/client/location.ts
+++ b/src/client/location.ts
@@ -1,0 +1,1 @@
+export const getFormattedLocation = (location: Location) => `${location.protocol}//${location.hostname}${location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`}${location.search}`;

--- a/src/detector.ts
+++ b/src/detector.ts
@@ -17,11 +17,3 @@ export function hasSessionStorage(): boolean {
 export function hasCookieStorage(): boolean {
     return navigator.cookieEnabled;
 }
-
-export function hasDocument(): boolean {
-    return document !== null;
-}
-
-export function hasDocumentLocation(): boolean {
-    return hasDocument() && document.location !== null;
-}

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -173,12 +173,18 @@ describe('EC plugin', () => {
             page: '/somepage'
         };
 
-        const result = await executeRegisteredHook(ECPluginEventTypes.pageview, payload);
+        const pageview = await executeRegisteredHook(ECPluginEventTypes.pageview, payload);
+        const event = await executeRegisteredHook(ECPluginEventTypes.event, {});
 
-        expect(result).toEqual({
+        expect(pageview).toEqual({
             ...defaultResult,
             't': ECPluginEventTypes.pageview,
             'dp': payload.page,
+            'dl': `${defaultResult.dl}${payload.page.substring(1)}`,
+        });
+        expect(event).toEqual({
+            ...defaultResult,
+            't': ECPluginEventTypes.event,
             'dl': `${defaultResult.dl}${payload.page.substring(1)}`,
         });
      });


### PR DESCRIPTION
This one has more substantial changes:

* The third argument is used to explicitly pass a page name: `coveoua("send", "pageview", "/PAGE")`, so I brought back `ca.js` logic to properly update the location using the page.
* Subsequent pageview event should use the previous pageview location as their referrer. This is useful for SPA.
* I brought back the `contextInformation`, because there was more complicated logic to it, it required direct access to the `ec` state to properly infer the values, depending on `pageview` and everything. It was just less trouble to bring the whole thing.