### PR TITLE
Added generic parameter override

### DIFF
--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -1,0 +1,85 @@
+import { EC, Product } from '../plugins/ec';
+
+// Based off: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#enhanced-ecomm
+const productKeysMapping: {[name: string]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    position: 'ps',
+    price: 'pr',
+    quantity: 'qt',
+    coupon: 'cc'
+};
+
+const eventKeysMapping: {[name: string]: string} = {
+    eventCategory: 'ec',
+    eventAction: 'ea',
+    eventLabel: 'el',
+    eventValue: 'ev',
+    page: 'dp',
+    visitorId: 'cid',
+    clientId: 'cid',
+    userId: 'uid'
+};
+
+const productActionsKeysMapping: {[name: string]: string} = {
+    action: 'pa',
+    list: 'pal',
+    listSource: 'pls'
+};
+
+const transactionActionsKeysMappings: {[name: string]: string} = {
+    id: 'ti',
+    revenue: 'tr',
+    tax: 'tt',
+    shipping: 'ts',
+    coupon: 'tcc',
+    affiliation: 'ta',
+    step: 'cos',
+    option: 'col'
+};
+
+type DefaultContextInformation = ReturnType<typeof EC.prototype.getDefaultContextInformation> & ReturnType<typeof EC.prototype.getLocationInformation>;
+const contextInformationMapping: {[key in keyof DefaultContextInformation]: string} = {
+    hitType: 't',
+    pageViewId: 'pid',
+    encoding: 'de',
+    location: 'dl',
+    referrer: 'dr',
+    screenColor: 'sd',
+    screenResolution: 'sr',
+    title: 'dt',
+    userAgent: 'ua',
+    language: 'ul',
+    eventId: 'z',
+    time: 'tm',
+};
+
+const measurementProtocolKeysMapping: {[name: string]: string} = {
+    ...eventKeysMapping,
+    ...productActionsKeysMapping,
+    ...transactionActionsKeysMappings,
+    ...contextInformationMapping
+};
+
+export const convertKeysToMeasurementProtocol = (params: any) => {
+    return Object.keys(params).reduce((mappedKeys, key) => {
+        const newKey = measurementProtocolKeysMapping[key] || key;
+        return {
+            ...mappedKeys,
+            [newKey]: params[key],
+        };
+    }, {});
+};
+
+export const convertProductToMeasurementProtocol = (product: Product, index: number) => {
+    return Object.keys(product).reduce((mappedProduct, key) => {
+        const newKey = `pr${index + 1}${productKeysMapping[key] || key}`;
+        return {
+            ...mappedProduct,
+            [newKey]: product[key]
+        };
+    }, {});
+};

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -63,6 +63,16 @@ describe('simpleanalytics', () => {
             handleOneAnalyticsEvent('initForProxy', fakeServerAddress);
             handleOneAnalyticsEvent('send', someRandomEventName);
         });
+
+        it('can set a new parameter', () => {
+            handleOneAnalyticsEvent('set', 'userId', 'something');
+        });
+
+        it('can set parameters using an object', () => {
+            handleOneAnalyticsEvent('set', {
+                userId: 'something'
+            });
+        });
     });
 
     it('can initialize with analyticsClient', () => {

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -8,18 +8,18 @@ describe('EC plugin', () => {
     const someUUIDGenerator = jest.fn(() => someUUID);
     const someUUID = '13ccebdb-0138-45e8-bf70-884817ead190';
     const defaultResult = {
-        a: someUUID,
-        de: document.characterSet,
-        dl: 'http://localhost/',
-        dr: 'http://somewhere.over/therainbow',
-        dt: 'MAH PAGE',
-        sd: '24-bit',
-        sr: '0x0',
-        tm: expect.any(String),
-        ua: navigator.userAgent,
-        ul: 'en-US',
-        t: ECPluginEventTypes.event,
-        z: someUUID,
+        pageViewId: someUUID,
+        encoding: document.characterSet,
+        location: 'http://localhost/',
+        referrer: 'http://somewhere.over/therainbow',
+        title: 'MAH PAGE',
+        screenColor: '24-bit',
+        screenResolution: '0x0',
+        time: expect.any(String),
+        userAgent: navigator.userAgent,
+        language: 'en-US',
+        hitType: ECPluginEventTypes.event,
+        eventId: someUUID,
     };
 
     beforeEach(() => {
@@ -117,7 +117,7 @@ describe('EC plugin', () => {
 
         expect(result).toEqual({
             ...defaultResult,
-            'pa': 'ok'
+            action: 'ok'
         });
     });
 
@@ -153,9 +153,9 @@ describe('EC plugin', () => {
 
         expect(result).toEqual({
             ...defaultResult,
-            'cid': payload.clientId,
-            'de': payload.encoding,
-            'pa': payload.action
+            clientId: payload.clientId,
+            encoding: payload.encoding,
+            action: payload.action
         });
     });
 
@@ -178,14 +178,14 @@ describe('EC plugin', () => {
 
         expect(pageview).toEqual({
             ...defaultResult,
-            't': ECPluginEventTypes.pageview,
-            'dp': payload.page,
-            'dl': `${defaultResult.dl}${payload.page.substring(1)}`,
+            hitType: ECPluginEventTypes.pageview,
+            page: payload.page,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
         });
         expect(event).toEqual({
             ...defaultResult,
-            't': ECPluginEventTypes.event,
-            'dl': `${defaultResult.dl}${payload.page.substring(1)}`,
+            hitType: ECPluginEventTypes.event,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
         });
      });
 


### PR DESCRIPTION
So I wanted to allow setting `userId` and potentially other keys that could be overridden by our clients.

However, the `params` had to be injected *after* the context keys were added, but also should be converted to the measurement protocol.

This is why I migrated the measurement protocol translating into the client.

Products were a little trickier to "translate", so I left them in the `ec` plugin :/ 

I also improved the `ec-events` spec to be a little stricter on the content returned using matchers, and it now also simulates getting back the `visitorId` 💪 