### PR TITLE
Spec for the exact addToCart event

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -161,9 +161,10 @@ describe('ec events', () => {
             'category': 'category',
             'brand': 'brand',
             'variant': 'variant',
-            'price': 'price',
-            'quantity': '1'
+            'price': 0,
+            'quantity': 0
         };
+        await coveoua('set', 'currencyCode', 'EUR');
         await coveoua('ec:addProduct', product);
         await coveoua('ec:setAction', 'add');
         await coveoua('send', 'event', 'UX', 'click', 'add to cart');
@@ -174,6 +175,7 @@ describe('ec events', () => {
         expect(event).toEqual({
             pid: expect.stringMatching(guidFormat), // Key changed from `a`
             cid: expect.stringMatching(guidFormat),
+            cu: 'EUR',
             de: defaultContextValues.de,
             dl: defaultContextValues.dl,
             dr: defaultContextValues.dr,

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -38,6 +38,7 @@ describe('ec events', () => {
                 visitorId,
             } as DefaultEventResponse;
         });
+        coveoua('reset');
         coveoua('init', aToken, anEndpoint);
     });
 
@@ -150,6 +151,54 @@ describe('ec events', () => {
             t: 'pageview',
             uid: aUser
         });
+    });
+
+    it('should be able to follow the complete addToCart flow', async () => {
+        // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#add-remove-cart
+        const product = {
+            'id': 'id',
+            'name': 'name',
+            'category': 'category',
+            'brand': 'brand',
+            'variant': 'variant',
+            'price': 'price',
+            'quantity': '1'
+        };
+        await coveoua('ec:addProduct', product);
+        await coveoua('ec:setAction', 'add');
+        await coveoua('send', 'event', 'UX', 'click', 'add to cart');
+
+        const [event] = getParsedBody();
+
+        // Event directly extracted from `ca.js` with the same sequence of event.
+        expect(event).toEqual({
+            pid: expect.stringMatching(guidFormat), // Key changed from `a`
+            cid: expect.stringMatching(guidFormat),
+            de: defaultContextValues.de,
+            dl: defaultContextValues.dl,
+            dr: defaultContextValues.dr,
+            dt: defaultContextValues.dt,
+            ea: 'click',
+            ec: 'UX',
+            el: 'add to cart',
+            pa: 'add',
+            pr1br: product.brand,
+            pr1ca: product.category,
+            pr1id: product.id,
+            pr1nm: product.name,
+            pr1va: product.variant,
+            pr1pr: product.price,
+            pr1qt: product.quantity,
+            sd: defaultContextValues.sd,
+            sr: defaultContextValues.sr,
+            t: 'event',
+            // tid: "toosogoogleanalyticsevents0l18in4y", removed, this one is picked up from the `ca("create", TID)` call.
+            tm: expect.stringMatching(numberFormat),
+            ua: defaultContextValues.ua, // Added
+            ul: defaultContextValues.ul,
+            // v: 1, removed, we don't send version as of now.
+            z: expect.stringMatching(guidFormat)
+          });
     });
 
     const getParsedBody = (): any[] => {

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -110,6 +110,24 @@ describe('Analytics', () => {
         assertResponseHasCustomDataWithIndex(thirdResponse, 2);
     });
 
+    it('should should only clean null, undefined, and empty string values', async () => {
+        mockFetchRequestForEventType(EventType.view);
+        await client.sendEvent(EventType.view, {
+            fine: 1,
+            ok: 0,
+            notok: '',
+            invalid: null,
+            ohno: undefined
+        });
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            fine: 1,
+            ok: 0
+        });
+    });
+
     describe('with event type mapping with variable arguments', () => {
         const specialEventType = '🌟special🌟';
         const argumentNames = ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'];

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -251,8 +251,9 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private removeEmptyPayloadValues(payload: IRequestPayload): IRequestPayload {
+        const isNotEmptyValue = (value: any) => (typeof (value) !== 'undefined' && value !== null && value !== '');
         return Object.keys(payload)
-            .filter(key => !!payload[key])
+            .filter(key => isNotEmptyValue(payload[key]))
             .reduce((newPayload, key) => ({
                 ...newPayload,
                 [key]: payload[key]

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -21,7 +21,8 @@ const eventKeysMapping: {[name: string]: string} = {
     page: 'dp',
     visitorId: 'cid',
     clientId: 'cid',
-    userId: 'uid'
+    userId: 'uid',
+    currencyCode: 'cu'
 };
 
 const productActionsKeysMapping: {[name: string]: string} = {

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -95,6 +95,12 @@ export class CoveoUA {
     callPlugin(pluginName: string, fn: string, ...args: any): void {
         this.plugins.execute(pluginName, fn, ...args);
     }
+
+    reset() {
+        this.client = undefined;
+        this.plugins = new Plugins();
+        this.params = {};
+    }
 }
 
 export const coveoua = new CoveoUA();


### PR DESCRIPTION
A final one that acts as a very strong validation of the `addToCart` event according to the GA spec VS what is currently returned by the `ca.js` implementation.

I wanted to have the event as close as what the `ca` script was returning, so I kept everything and commented on the changes.

Let me know what you think! 

I consider this my final stamp of proof, so when this gets merged, I think we can consider the goal from this sprint achieved :)