### PR TITLE
Fix empty value + custom events support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         ".nyc_output": true,
         "dist": true,
         "dist_test": true
-    }
+    },
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
 }

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -134,6 +134,20 @@ describe('Analytics', () => {
         });
     });
 
+    it('should not remove #queryText for search events even if empty', async () => {
+        mockFetchRequestForEventType(EventType.search);
+        await client.sendEvent(EventType.search, {
+            queryText: "",
+        });
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            queryText: "",
+        });
+    });
+
+
     describe('with event type mapping with variable arguments', () => {
         const specialEventType = '🌟special🌟';
         const argumentNames = ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'];

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -1,5 +1,5 @@
-import { AnalyticsBeaconClient } from './analyticsBeaconClient';
-import { AnalyticsFetchClient } from './analyticsFetchClient';
+import {AnalyticsBeaconClient} from './analyticsBeaconClient';
+import {AnalyticsFetchClient} from './analyticsFetchClient';
 import {
     AnyEventResponse,
     ClickEventRequest,
@@ -16,13 +16,13 @@ import {
     IRequestPayload,
     VariableArgumentsPayload,
 } from '../events';
-import { VisitorIdProvider } from './analyticsRequestClient';
-import { WebStorage, CookieStorage } from '../storage';
-import { hasLocalStorage, hasCookieStorage } from '../detector';
-import { addDefaultValues } from '../hook/addDefaultValues';
-import { enhanceViewEvent } from '../hook/enhanceViewEvent';
-import { uuidv4 } from './crypto';
-import { convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys } from './measurementProtocolMapper';
+import {VisitorIdProvider} from './analyticsRequestClient';
+import {WebStorage, CookieStorage} from '../storage';
+import {hasLocalStorage, hasCookieStorage} from '../detector';
+import {addDefaultValues} from '../hook/addDefaultValues';
+import {enhanceViewEvent} from '../hook/enhanceViewEvent';
+import {uuidv4} from './crypto';
+import {convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys} from './measurementProtocolMapper';
 
 export const Version = 'v15';
 
@@ -79,7 +79,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private analyticsFetchClient: AnalyticsFetchClient;
     private bufferedRequests: BufferedRequest[];
     private beforeSendHooks: AnalyticsClientSendEventHook[];
-    private eventTypeMapping: { [name: string]: EventTypeConfig };
+    private eventTypeMapping: {[name: string]: EventTypeConfig};
     private options: ClientOptions;
 
     constructor(opts: Partial<ClientOptions>) {
@@ -92,7 +92,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             ...opts,
         };
 
-        const { token } = this.options;
+        const {token} = this.options;
 
         this.cookieStorage = new CookieStorage();
         this.visitorId = '';
@@ -193,7 +193,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     private flushBufferWithBeacon(): void {
         while (this.hasPendingRequests()) {
-            const { eventType, payload } = this.bufferedRequests.pop() as BufferedRequest;
+            const {eventType, payload} = this.bufferedRequests.pop() as BufferedRequest;
             this.analyticsBeaconClient.sendEvent(eventType, payload);
         }
     }
@@ -201,7 +201,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private async sendFromBufferWithFetch(): Promise<AnyEventResponse | void> {
         const popped = this.bufferedRequests.shift();
         if (popped) {
-            const { eventType, payload } = popped;
+            const {eventType, payload} = popped;
             return this.analyticsFetchClient.sendEvent(eventType, payload);
         }
     }
@@ -247,7 +247,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {
-        const parsedArguments: { [name: string]: any } = {};
+        const parsedArguments: {[name: string]: any} = {};
         for (let i = 0, length = payload.length; i < length; i++) {
             const currentArgument = payload[i];
             if (typeof currentArgument === 'string') {
@@ -307,7 +307,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private processCustomParameters(payload: IRequestPayload): IRequestPayload {
-        const { custom, ...rest } = payload;
+        const {custom, ...rest} = payload;
 
         const newPayload = convertCustomMeasurementProtocolKeys(rest);
 
@@ -318,7 +318,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private validateParams(payload: IRequestPayload): IRequestPayload {
-        const { anonymizeIp, ...rest } = payload;
+        const {anonymizeIp, ...rest} = payload;
         if (anonymizeIp !== undefined) {
             if (['0', 'false', 'undefined', 'null', '{}', '[]', ''].indexOf(`${anonymizeIp}`.toLowerCase()) == -1) {
                 rest['anonymizeIp'] = 1;
@@ -328,7 +328,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private get baseUrl(): string {
-        const { version, endpoint } = this.options;
+        const {version, endpoint} = this.options;
         return `${endpoint}/rest/${version}`;
     }
 }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -1,5 +1,5 @@
-import {AnalyticsBeaconClient} from './analyticsBeaconClient';
-import {AnalyticsFetchClient} from './analyticsFetchClient';
+import { AnalyticsBeaconClient } from './analyticsBeaconClient';
+import { AnalyticsFetchClient } from './analyticsFetchClient';
 import {
     AnyEventResponse,
     ClickEventRequest,
@@ -16,13 +16,13 @@ import {
     IRequestPayload,
     VariableArgumentsPayload,
 } from '../events';
-import {VisitorIdProvider} from './analyticsRequestClient';
-import {WebStorage, CookieStorage} from '../storage';
-import {hasLocalStorage, hasCookieStorage} from '../detector';
-import {addDefaultValues} from '../hook/addDefaultValues';
-import {enhanceViewEvent} from '../hook/enhanceViewEvent';
-import {uuidv4} from './crypto';
-import {convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys} from './measurementProtocolMapper';
+import { VisitorIdProvider } from './analyticsRequestClient';
+import { WebStorage, CookieStorage } from '../storage';
+import { hasLocalStorage, hasCookieStorage } from '../detector';
+import { addDefaultValues } from '../hook/addDefaultValues';
+import { enhanceViewEvent } from '../hook/enhanceViewEvent';
+import { uuidv4 } from './crypto';
+import { convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys, keysOf } from './measurementProtocolMapper';
 
 export const Version = 'v15';
 
@@ -79,7 +79,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private analyticsFetchClient: AnalyticsFetchClient;
     private bufferedRequests: BufferedRequest[];
     private beforeSendHooks: AnalyticsClientSendEventHook[];
-    private eventTypeMapping: {[name: string]: EventTypeConfig};
+    private eventTypeMapping: { [name: string]: EventTypeConfig };
     private options: ClientOptions;
 
     constructor(opts: Partial<ClientOptions>) {
@@ -92,7 +92,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             ...opts,
         };
 
-        const {token} = this.options;
+        const { token } = this.options;
 
         this.cookieStorage = new CookieStorage();
         this.visitorId = '';
@@ -157,7 +157,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         });
         const processBeforeSendHooksStep: ProcessPayloadStep = (currentPayload) =>
             this.beforeSendHooks.reduce((newPayload, current) => current(eventType, newPayload), currentPayload);
-        const cleanPayloadStep: ProcessPayloadStep = (currentPayload) => this.removeEmptyPayloadValues(currentPayload);
+        const cleanPayloadStep: ProcessPayloadStep = (currentPayload) => this.removeEmptyPayloadValues(currentPayload, eventType);
         const validateParams: ProcessPayloadStep = (currentPayload) => this.validateParams(currentPayload);
         const processMeasurementProtocolConversionStep: ProcessPayloadStep = (currentPayload) =>
             usesMeasurementProtocol ? convertKeysToMeasurementProtocol(currentPayload) : currentPayload;
@@ -193,7 +193,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     private flushBufferWithBeacon(): void {
         while (this.hasPendingRequests()) {
-            const {eventType, payload} = this.bufferedRequests.pop() as BufferedRequest;
+            const { eventType, payload } = this.bufferedRequests.pop() as BufferedRequest;
             this.analyticsBeaconClient.sendEvent(eventType, payload);
         }
     }
@@ -201,7 +201,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private async sendFromBufferWithFetch(): Promise<AnyEventResponse | void> {
         const popped = this.bufferedRequests.shift();
         if (popped) {
-            const {eventType, payload} = popped;
+            const { eventType, payload } = popped;
             return this.analyticsFetchClient.sendEvent(eventType, payload);
         }
     }
@@ -247,7 +247,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {
-        const parsedArguments: {[name: string]: any} = {};
+        const parsedArguments: { [name: string]: any } = {};
         for (let i = 0, length = payload.length; i < length; i++) {
             const currentArgument = payload[i];
             if (typeof currentArgument === 'string') {
@@ -263,10 +263,21 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         return parsedArguments;
     }
 
-    private removeEmptyPayloadValues(payload: IRequestPayload): IRequestPayload {
+    private getValidEmptyValuesForEvent(evtType: EventType | string): string[] {
+        switch (evtType) {
+            case 'search':
+                return ['queryText'] as (keyof Pick<SearchEventRequest, 'queryText'>)[]
+        }
+        return []
+    }
+
+    private removeEmptyPayloadValues(payload: IRequestPayload, eventType: EventType | string): IRequestPayload {
+        const keysThatCanBeEmpty = this.getValidEmptyValuesForEvent(eventType)
+
         const isNotEmptyValue = (value: any) => typeof value !== 'undefined' && value !== null && value !== '';
         return Object.keys(payload)
             .filter((key) => isNotEmptyValue(payload[key]))
+            .concat(keysThatCanBeEmpty)
             .reduce(
                 (newPayload, key) => ({
                     ...newPayload,
@@ -296,7 +307,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private processCustomParameters(payload: IRequestPayload): IRequestPayload {
-        const {custom, ...rest} = payload;
+        const { custom, ...rest } = payload;
 
         const newPayload = convertCustomMeasurementProtocolKeys(rest);
 
@@ -307,7 +318,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private validateParams(payload: IRequestPayload): IRequestPayload {
-        const {anonymizeIp, ...rest} = payload;
+        const { anonymizeIp, ...rest } = payload;
         if (anonymizeIp !== undefined) {
             if (['0', 'false', 'undefined', 'null', '{}', '[]', ''].indexOf(`${anonymizeIp}`.toLowerCase()) == -1) {
                 rest['anonymizeIp'] = 1;
@@ -317,7 +328,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private get baseUrl(): string {
-        const {version, endpoint} = this.options;
+        const { version, endpoint } = this.options;
         return `${endpoint}/rest/${version}`;
     }
 }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -263,16 +263,16 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         return parsedArguments;
     }
 
-    private isKeyAllowedEmpty(evtType: EventType | string, key: string) {
-        const keysThatCanBeEmpty: Partial<Record<EventType | string, string[]>> = {
+    private isKeyAllowedEmpty(evtType: string, key: string) {
+        const keysThatCanBeEmpty: Record<string, string[]> = {
             [EventType.search]: ['queryText'],
         };
-        const match = keysThatCanBeEmpty[evtType] || [];
 
+        const match = keysThatCanBeEmpty[evtType] || [];
         return match.indexOf(key) !== -1
     }
 
-    private removeEmptyPayloadValues(payload: IRequestPayload, eventType: EventType | string): IRequestPayload {
+    private removeEmptyPayloadValues(payload: IRequestPayload, eventType: string): IRequestPayload {
         const isNotEmptyValue = (value: any) => typeof value !== 'undefined' && value !== null && value !== '';
         return Object.keys(payload)
             .filter((key) => this.isKeyAllowedEmpty(eventType, key) || isNotEmptyValue(payload[key]))

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -22,7 +22,7 @@ import { hasLocalStorage, hasCookieStorage } from '../detector';
 import { addDefaultValues } from '../hook/addDefaultValues';
 import { enhanceViewEvent } from '../hook/enhanceViewEvent';
 import { uuidv4 } from './crypto';
-import { convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys, keysOf } from './measurementProtocolMapper';
+import { convertKeysToMeasurementProtocol, isMeasurementProtocolKey, convertCustomMeasurementProtocolKeys } from './measurementProtocolMapper';
 
 export const Version = 'v15';
 

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -5,6 +5,6 @@ import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
 export {CoveoAnalyticsClient} from '../client/analytics';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
-export {CoveoSearchPageClient} from '../searchPage/searchPageClient'
+export {CoveoSearchPageClient,SearchPageClientProvider} from '../searchPage/searchPageClient'
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/events.ts
+++ b/src/events.ts
@@ -66,8 +66,7 @@ export interface DocumentInformation {
     rankingModifier: string;
 }
 
-export interface ClickEventRequest extends EventBaseRequest, DocumentInformation {
-}
+export interface ClickEventRequest extends EventBaseRequest, DocumentInformation {}
 
 export interface CustomEventRequest extends EventBaseRequest {
     eventType: string;

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -57,6 +57,29 @@ export enum SearchPageEvents {
      * Identifies the search event that gets logged when a suggested search query is selected from a standalone searchbox.
      */
     omniboxFromLink = 'omniboxFromLink',
+    /**
+     * Identifies the custom event that gets logged when a user action triggers a notification set in the effective query pipeline on the search page.
+     */
+    triggerNotify = 'notify',
+    /**
+     * Identifies the custom event that gets logged when a user action executes a JavaScript function set in the effective query pipeline on the search page.
+     */
+    triggerExecute = 'execute',
+    /**
+     * Identifies the custom event that gets logged when a user action triggers a new query set in the effective query pipeline on the search page.
+     */
+    triggerQuery = 'query',
+    /**
+     * Identifies the custom event that gets logged when a user action redirects them to a URL set in the effective query pipeline on the search page.
+     */
+    triggerRedirect = 'redirect',
+}
+
+export const CustomEventsTypes: Partial<Record<SearchPageEvents, string>> = {
+    [SearchPageEvents.triggerNotify]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerExecute]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerQuery]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerRedirect]: 'queryPipelineTriggers'
 }
 
 export interface FacetMetadata {
@@ -97,6 +120,18 @@ export interface InterfaceChangeMetadata {
 
 export interface ResultsSortMetadata {
     resultsSortBy: string;
+}
+
+export interface TriggerNotifyMetadata {
+    notification: string;
+}
+
+export interface TriggerExecuteMetadata {
+    executed: string;
+}
+
+export interface TriggerRedirectMetadata {
+    redirectedTo: string;
 }
 
 export type PartialDocumentInformation = Omit<DocumentInformation, 'actionCause' | 'searchQueryUid'>


### PR DESCRIPTION
* For search events, the `queryText` being empty is a valid input, and should not be removed.
* Added supports for trigger(s) event in SearchPageClient
* Added support for logging custom events in general in SearchPageClient

