### PR TITLE
Fix for `window.coveoua` being revert to original function

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,11 @@ coveoua('init','YOUR-TOKEN');
 coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: { "verycustom": "value" }, unknown: "shouldberemoved"});
 coveoua('ec:setAction', 'detail', {storeid: "amazing"});
 coveoua('send', "pageview", "/firstpage");
-coveoua('ec:setAction', 'purchase', {storeid: "amazing"});
-coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue");
-coveoua('send', "pageview", "/secondpage");
-coveoua('send', "event");
+
+setTimeout(function() {
+    coveoua('ec:setAction', 'purchase', {storeid: "amazing"});
+    coveoua('send', "event", "eventCategory", "eventAction", "eventLabel", "eventValue");
+    coveoua('send', "pageview", "/secondpage");
+    coveoua('send', "event");
+}, 1000);
 </script>

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -41,4 +41,4 @@ if (coveoua.q) {
     [...initEvents, ...otherEvents].forEach((args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args));
 }
 
-export default coveoua;
+export default self.coveoua;


### PR DESCRIPTION
[COM-419]

Issue in prod with `2.1` where coveoua events logged *after* the initial run are completely ignored.

This is due to the way `rollup` exports the variable, the `export default coveoua` was overriding `window.coveoua` with **the initial implementation**, which pushed to `coveoua.q` instead of processing the events instantly.

I did a quick fix, let's figure out how to better handle this later

[COM-419]: https://coveord.atlassian.net/browse/COM-419