### PR TITLE
Support analytics disabling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.3.1",
+    "version": "2.4.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -1,0 +1,38 @@
+import {AnalyticsClient} from './analytics';
+import {
+    AnyEventResponse,
+    SearchEventResponse,
+    ClickEventResponse,
+    CustomEventResponse,
+    VisitResponse,
+    HealthResponse,
+    ViewEventResponse,
+} from '../events';
+import {NoopRuntime} from './runtimeEnvironment';
+
+export class NoopAnalytics implements AnalyticsClient {
+    sendEvent(): Promise<AnyEventResponse | void> {
+        return Promise.resolve();
+    }
+    sendSearchEvent(): Promise<SearchEventResponse | void> {
+        return Promise.resolve();
+    }
+    sendClickEvent(): Promise<ClickEventResponse | void> {
+        return Promise.resolve();
+    }
+    sendCustomEvent(): Promise<CustomEventResponse | void> {
+        return Promise.resolve();
+    }
+    sendViewEvent(): Promise<ViewEventResponse | void> {
+        return Promise.resolve();
+    }
+    getVisit(): Promise<VisitResponse> {
+        return Promise.resolve({id: '', visitorId: ''});
+    }
+    getHealth(): Promise<HealthResponse> {
+        return Promise.resolve({status: ''});
+    }
+    registerBeforeSendEventHook(): void {}
+    addEventTypeMapping(): void {}
+    runtime = new NoopRuntime();
+}

--- a/src/client/runtimeEnvironment.ts
+++ b/src/client/runtimeEnvironment.ts
@@ -1,10 +1,10 @@
-import {WebStorage, CookieStorage, NullStorage, CookieAndLocalStorage} from "../storage";
-import {AnalyticsBeaconClient, IAnalyticsBeaconClientOptions, NoopAnalyticsBeaconClient} from "./analyticsBeaconClient";
-import {hasLocalStorage, hasCookieStorage} from "../detector";
-import {AnalyticsRequestClient} from "./analyticsRequestClient";
+import {WebStorage, NullStorage, CookieAndLocalStorage} from '../storage';
+import {AnalyticsBeaconClient, IAnalyticsBeaconClientOptions, NoopAnalyticsBeaconClient} from './analyticsBeaconClient';
+import {hasLocalStorage, hasCookieStorage} from '../detector';
+import {AnalyticsRequestClient} from './analyticsRequestClient';
 
 export interface IRuntimeEnvironment {
-    storage: WebStorage
+    storage: WebStorage;
     beaconClient: AnalyticsRequestClient;
 }
 
@@ -13,24 +13,26 @@ export class BrowserRuntime implements IRuntimeEnvironment {
     public beaconClient: AnalyticsBeaconClient;
 
     constructor(beaconOptions: IAnalyticsBeaconClientOptions, beforeUnload: () => void) {
-
         if (hasLocalStorage() && hasCookieStorage()) {
-            this.storage = new CookieAndLocalStorage()
+            this.storage = new CookieAndLocalStorage();
         } else if (hasLocalStorage()) {
-            this.storage = localStorage
+            this.storage = localStorage;
         } else {
-            console.warn("BrowserRuntime detected no valid storage available.", this)
-            this.storage = new NullStorage()
+            console.warn('BrowserRuntime detected no valid storage available.', this);
+            this.storage = new NullStorage();
         }
 
-
-        this.beaconClient = new AnalyticsBeaconClient(beaconOptions)
-        window.addEventListener('beforeunload', () => beforeUnload())
+        this.beaconClient = new AnalyticsBeaconClient(beaconOptions);
+        window.addEventListener('beforeunload', () => beforeUnload());
     }
-
 }
 
 export class NodeJSRuntime implements IRuntimeEnvironment {
-    public storage = new NullStorage()
-    public beaconClient = new NoopAnalyticsBeaconClient()
+    public storage = new NullStorage();
+    public beaconClient = new NoopAnalyticsBeaconClient();
+}
+
+export class NoopRuntime implements IRuntimeEnvironment {
+    public storage = new NullStorage();
+    public beaconClient = new NoopAnalyticsBeaconClient();
 }

--- a/src/hook/enhanceViewEvent.ts
+++ b/src/hook/enhanceViewEvent.ts
@@ -1,6 +1,6 @@
 import {AnalyticsClientSendEventHook} from '../client/analytics';
 import {ViewEventRequest, EventType} from '../events';
-import {HistoryStore} from '../history';
+import {HistoryStore, STORE_KEY} from '../history';
 
 export const enhanceViewEvent: AnalyticsClientSendEventHook = (eventType, payload) => {
     if (eventType === EventType.view) {


### PR DESCRIPTION
For headless, we need to be able to specify if analytics tracking is enabled or not. By default, we will be tracking all analytics event, but we need to be able to opt out if need be.

As far as Headless is concerned, the code won't be impacted too much since we will always be calling "logThis(), logThat()", which is the reason I've decided to add the "Noop" logic in coveo.analytics instead of Headless itself.

We also need a way to be able to clear any analytics cookies after initialization.