### PR TITLE
Fix formatting issue when sending beacon with collect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,3 +1,4 @@
+<html>
 <script>
 (function(c,o,v,e,O,u,a){
 a='coveoua';c[a]=c[a]||function(){(c[a].q=c[a].q|| []).push(arguments)};
@@ -18,4 +19,16 @@ setTimeout(function() {
     coveoua('send', "pageview", "/secondpage");
     coveoua('send', "event");
 }, 1000);
+
+function testBeacon() {
+    coveoua('ec:addProduct', {name: "wow", id: 'something', brand: 'brand', custom: { "verycustom": "value" }, unknown: "shouldberemoved"});
+    coveoua('ec:setAction', 'addToCart');
+    coveoua('send', 'event')
+    window.location = "index.html?added=" + new Date().valueOf();
+}
 </script>
+
+<body>
+    <button onclick="testBeacon()">Test beacon</button>
+</body>
+</html>

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -2,11 +2,26 @@ import {AnalyticsBeaconClient} from './analyticsBeaconClient';
 import {EventType} from '../events';
 
 describe('AnalyticsBeaconClient', () => {
+    const baseUrl = 'https://bloup.com';
+    const token = '👛';
+    const currentVisitorId = 'hereiam';
+
+    const originalSendBeacon = navigator.sendBeacon;
+    const sendBeaconMock = jest.fn();
+    beforeAll(() => {
+        navigator.sendBeacon = sendBeaconMock;
+    });
+
+    afterAll(() => {
+        navigator.sendBeacon = originalSendBeacon;
+    })
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    })
+
+
     it('can send an event', async () => {
-        navigator.sendBeacon = jest.fn();
-        const baseUrl = 'https://bloup.com';
-        const token = '👛';
-        const currentVisitorId = 'hereiam';
         const eventType: EventType = EventType.custom;
 
         const client = new AnalyticsBeaconClient({
@@ -21,6 +36,60 @@ describe('AnalyticsBeaconClient', () => {
             wow: 'ok',
         });
 
-        expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent(`{"wow":"ok"}`)}`);
     });
+
+    it('can send a collect event with the proper payload', async () => {
+        const eventType: EventType = EventType.collect;
+
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                currentVisitorId,
+            },
+        });
+
+        await client.sendEvent(eventType, {
+            pr1a: 'value',
+            "to encode": "to encode"
+        });
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/collect?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe("pr1a=value&to%20encode=to%20encode");
+    });
+
+    it('can send a collect event with a more complex payload', async () => {
+        const eventType: EventType = EventType.collect;
+
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                currentVisitorId,
+            },
+        });
+
+        await client.sendEvent(eventType, {
+            value: {
+                subvalue: 'ok'
+            }
+        });
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/collect?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`value=${encodeURIComponent(JSON.stringify({subvalue: 'ok'}))}`);
+    });
+
+    const getSendBeaconFirstCallBlobArgument = async () => {
+        const blobArgument: Blob = sendBeaconMock.mock.calls[0][1];
+        expect(blobArgument.size).toBeGreaterThan(0);
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.addEventListener('loadend', () => {
+                resolve(reader.result);
+            });
+            reader.readAsText(blobArgument);
+        });
+    }
 });

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -14,12 +14,11 @@ describe('AnalyticsBeaconClient', () => {
 
     afterAll(() => {
         navigator.sendBeacon = originalSendBeacon;
-    })
+    });
 
     beforeEach(() => {
         jest.clearAllMocks();
-    })
-
+    });
 
     it('can send an event', async () => {
         const eventType: EventType = EventType.custom;
@@ -36,7 +35,10 @@ describe('AnalyticsBeaconClient', () => {
             wow: 'ok',
         });
 
-        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}`,
+            jasmine.anything()
+        );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent(`{"wow":"ok"}`)}`);
     });
 
@@ -53,11 +55,16 @@ describe('AnalyticsBeaconClient', () => {
 
         await client.sendEvent(eventType, {
             pr1a: 'value',
-            "to encode": "to encode"
+            'to encode': 'to encode',
         });
 
-        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/collect?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
-        expect(await getSendBeaconFirstCallBlobArgument()).toBe("pr1a=value&to%20encode=to%20encode");
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}`,
+            jasmine.anything()
+        );
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+            'access_token=%F0%9F%91%9B&pr1a=value&to%20encode=to%20encode'
+        );
     });
 
     it('can send a collect event with a more complex payload', async () => {
@@ -73,12 +80,17 @@ describe('AnalyticsBeaconClient', () => {
 
         await client.sendEvent(eventType, {
             value: {
-                subvalue: 'ok'
-            }
+                subvalue: 'ok',
+            },
         });
 
-        expect(sendBeaconMock).toHaveBeenCalledWith(`${baseUrl}/analytics/collect?access_token=👛&visitorId=${currentVisitorId}`, jasmine.anything());
-        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`value=${encodeURIComponent(JSON.stringify({subvalue: 'ok'}))}`);
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}`,
+            jasmine.anything()
+        );
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+            `access_token=%F0%9F%91%9B&value=${encodeURIComponent(JSON.stringify({subvalue: 'ok'}))}`
+        );
     });
 
     const getSendBeaconFirstCallBlobArgument = async () => {
@@ -91,5 +103,5 @@ describe('AnalyticsBeaconClient', () => {
             });
             reader.readAsText(blobArgument);
         });
-    }
+    };
 });


### PR DESCRIPTION
[COM-495]

The beacon format was correct for legacy events (all the payload under a `customEvent` key), but with the measurement protocol, each key-value should be sent directly in the payload.

It fixes that, plus introduces tests to properly validate that

[COM-495]: https://coveord.atlassian.net/browse/COM-495