### PR TITLE
[COM-400] set userId to anonymous for API keys

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -45,9 +45,9 @@ describe('ec events', () => {
     });
 
     it('can set custom data at the root level and send a page view event', async () => {
-        await coveoua("set", "custom", {
-            "verycustom": "value"
-        })
+        await coveoua('set', 'custom', {
+            verycustom: 'value',
+        });
         await coveoua('send', 'pageview');
 
         const [body] = getParsedBody();
@@ -78,7 +78,7 @@ describe('ec events', () => {
 
     it('can send a product detail view event with custom values', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand'});
-        coveoua('ec:setAction', 'detail', {storeid: 'amazing', custom: { verycustom: "value"}});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing', custom: {verycustom: 'value'}});
         await coveoua('send', 'pageview');
 
         const [body] = getParsedBody();
@@ -90,7 +90,7 @@ describe('ec events', () => {
             pr1id: 'something',
             pr1br: 'brand',
             pa: 'detail',
-            verycustom: "value",
+            verycustom: 'value',
         });
     });
 
@@ -116,8 +116,8 @@ describe('ec events', () => {
             title: 'wow',
             location: 'http://right.here',
             custom: {
-                verycustom: "value"
-            }
+                verycustom: 'value',
+            },
         });
 
         const [body] = getParsedBody();
@@ -128,7 +128,7 @@ describe('ec events', () => {
             dp: 'page',
             dt: 'wow',
             dl: 'http://right.here',
-            verycustom: "value"
+            verycustom: 'value',
         });
     });
 
@@ -207,6 +207,71 @@ describe('ec events', () => {
         });
     });
 
+    describe('with auto-detection of userId', () => {
+        describe('with API key', () => {
+            beforeEach(() => {
+                coveoua('init', 'xxapikey', anEndpoint);
+            });
+
+            it('should set userId to anonymous', async () => {
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: 'anonymous',
+                });
+            });
+            it('should not overwrite existing userId', async () => {
+                const aUser = '👴';
+                await coveoua('set', 'userId', aUser);
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: aUser,
+                });
+            });
+        });
+        describe('with Search Token', () => {
+            beforeEach(() => {
+                const searchToken =
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+                    'eyJ1cmwiOiJodHRwczovL3d3dy55b3V0dWJlLmNvb' +
+                    'S93YXRjaD92PW9IZzVTSllSSEEwIiwidXNlcklkIj' +
+                    'oiUmljayBBc3RsZXkiLCJleHAiOjE1MTYyMzkwMjJ9.' +
+                    'gOxUfMZuwMFw-QK-q0xOKJ-23YgGwFJbncCIHgIxjcc';
+                coveoua('init', searchToken, anEndpoint);
+            });
+
+            it('should not set the user id', async () => {
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(Object.keys(event)).not.toContain('uid');
+            });
+            it('should not overwrite existing userId', async () => {
+                const steveJobs = 'steve@apple.com';
+                await coveoua('set', 'userId', steveJobs);
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: steveJobs,
+                });
+            });
+        });
+    });
+
     it('should be able to set the anonymizeIp', async () => {
         await coveoua('set', 'anonymizeIp', true);
         await coveoua('send', 'pageview');
@@ -276,7 +341,7 @@ describe('ec events', () => {
 
         const [body] = getParsedBody();
 
-        expect(Object.keys(body)).not.toContain("unknownParam");
+        expect(Object.keys(body)).not.toContain('unknownParam');
     });
 
     it('should remove unknown measurement protocol product keys', async () => {
@@ -285,11 +350,11 @@ describe('ec events', () => {
 
         const [body] = getParsedBody();
 
-        expect(Object.keys(body)).not.toContain("pr1unknown");
+        expect(Object.keys(body)).not.toContain('pr1unknown');
     });
 
-    it('should append custom values to product', async () =>{
-        var partialProduct = {name: 'wow', custom: { verycustom: "value" }};
+    it('should append custom values to product', async () => {
+        var partialProduct = {name: 'wow', custom: {verycustom: 'value'}};
         await coveoua('ec:addProduct', partialProduct);
         await coveoua('send', 'pageview');
 
@@ -299,8 +364,8 @@ describe('ec events', () => {
             ...defaultContextValues,
             t: 'pageview',
             pr1nm: partialProduct.name,
-            pr1verycustom: partialProduct.custom.verycustom
-        })
+            pr1verycustom: partialProduct.custom.verycustom,
+        });
     });
 
     it('should be able to follow the complete addToCart flow', async () => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "browser": "dist/coveoua.js",
     "types": "dist/definitions/coveoua/library.d.ts",
     "scripts": {
-        "lint": "prettier **/*.* --write",
+        "lint": "prettier */**/*.* --write",
         "build": "rollup -c",
         "start": "rollup -c -w --environment SERVE",
         "test": "jest --clearCache && jest --coverage",

--- a/src/client/crypto.ts
+++ b/src/client/crypto.ts
@@ -1,4 +1,4 @@
-import {hasCryptoRandomValues} from "../detector";
+import {hasCryptoRandomValues} from '../detector';
 
 export const uuidv4 = (a?: number | string): string => {
     if (!!a) {

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -143,10 +143,10 @@ const measurementProtocolKeysMappingValues = keysOf(measurementProtocolKeysMappi
 const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
 const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
 
-const productSubKeysMatchGroup = [...productKeysMappingValues, "custom"].join('|');
-const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, "custom"].join('|');
-const productPrefixMatchGroup = "(pr[0-9]+)";
-const impressionPrefixMatchGroup = "(il[0-9]+pi[0-9]+)";
+const productSubKeysMatchGroup = [...productKeysMappingValues, 'custom'].join('|');
+const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, 'custom'].join('|');
+const productPrefixMatchGroup = '(pr[0-9]+)';
+const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
 const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
 const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
 const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
@@ -154,39 +154,37 @@ const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custo
 
 const isProductKey = (key: string) => productKeyRegex.test(key);
 const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
-const isKnownMeasurementProtocolKey = (key: string) => measurementProtocolKeysMappingValues.indexOf(key) !== -1
-const isCustomKey = (key: string) => key === "custom";
+const isKnownMeasurementProtocolKey = (key: string) => measurementProtocolKeysMappingValues.indexOf(key) !== -1;
+const isCustomKey = (key: string) => key === 'custom';
 
 export const isMeasurementProtocolKey = (key: string): boolean => {
-    return [
-        isProductKey,
-        isImpressionKey,
-        isKnownMeasurementProtocolKey,
-        isCustomKey
-    ].some(test => test(key));
+    return [isProductKey, isImpressionKey, isKnownMeasurementProtocolKey, isCustomKey].some((test) => test(key));
 };
 
-export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: string | {[name:string] :string}}) => {
+export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: string | {[name: string]: string}}) => {
     return keysOf(data).reduce((all, current) => {
         const match = customProductKeyRegex.exec(current) || customImpressionKeyRegex.exec(current);
         if (match) {
             const originalKey = match[1];
             return {
                 ...all,
-                ...convertCustomObject(originalKey, data[current] as {[name: string]: string})
-            }
+                ...convertCustomObject(originalKey, data[current] as {[name: string]: string}),
+            };
         } else {
             return {
                 ...all,
-                [current]: data[current]
-            }
+                [current]: data[current],
+            };
         }
     }, {});
-}
+};
 
 const convertCustomObject = (prefix: string, customData: {[name: string]: string}) => {
-    return keysOf(customData).reduce((allCustom, currentCustomKey) => ({
-        ...allCustom,
-        [`${prefix}${currentCustomKey}`]: customData[currentCustomKey]
-    }), {});
-}
+    return keysOf(customData).reduce(
+        (allCustom, currentCustomKey) => ({
+            ...allCustom,
+            [`${prefix}${currentCustomKey}`]: customData[currentCustomKey],
+        }),
+        {}
+    );
+};

--- a/src/client/token.ts
+++ b/src/client/token.ts
@@ -1,0 +1,3 @@
+const API_KEY_PREFIX = 'xx';
+
+export const isApiKey = (token?: string) => token?.startsWith(API_KEY_PREFIX);

--- a/src/client/token.ts
+++ b/src/client/token.ts
@@ -1,3 +1,3 @@
 const API_KEY_PREFIX = 'xx';
 
-export const isApiKey = (token?: string) => token?.startsWith(API_KEY_PREFIX);
+export const isApiKey = (token?: string) => token?.startsWith(API_KEY_PREFIX) || false;

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,2 +1,2 @@
-export {CoveoSearchPageClient,SearchPageClientProvider} from '../searchPage/searchPageClient'
+export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient} from '../client/analytics';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -5,6 +5,6 @@ import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
 export {CoveoAnalyticsClient} from '../client/analytics';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
-export {CoveoSearchPageClient,SearchPageClientProvider} from '../searchPage/searchPageClient'
+export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -232,7 +232,7 @@ export interface FacetRangeMetadata extends FacetBaseMeta {
 
 export interface FacetSortMeta extends FacetBaseMeta {
     criteria: string;
-  }
+}
 
 export interface QueryErrorMeta {
     query: string;


### PR DESCRIPTION
When UA receives events without a userId, it adds one based on the token UNLESS the event is anonymous. However, the measurement protocol does not include a field for UA to identify if the event is supposed to be anonymous or not. Therefore, to prevent adding an 'API Key' user, we explicitly set the userId to `anonymous` which gets picked up properly from UA