### PR TITLE
Add query pipeline support for search pages events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.4.2",
+    "version": "2.5.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -13,7 +13,7 @@ describe('SearchPageClient', () => {
         documentUri: 'uri',
         documentUriHash: 'hash',
         documentUrl: 'url',
-        queryPipeline: 'pipeline',
+        queryPipeline: 'my-pipeline',
         rankingModifier: 'modifier',
         sourceName: 'source',
     };
@@ -32,6 +32,7 @@ describe('SearchPageClient', () => {
             responseTime: 123,
         }),
         getSearchUID: () => 'my-uid',
+        getPipeline: () => 'my-pipeline',
     };
 
     beforeEach(() => {
@@ -56,6 +57,7 @@ describe('SearchPageClient', () => {
         expect(JSON.parse(body.toString())).toMatchObject({
             queryText: 'queryText',
             responseTime: 123,
+            queryPipeline: 'my-pipeline',
             actionCause,
             customData,
         });
@@ -67,6 +69,7 @@ describe('SearchPageClient', () => {
         expect(JSON.parse(body.toString())).toMatchObject({
             actionCause,
             customData,
+            queryPipeline: 'my-pipeline',
             ...doc,
         });
     };

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -26,6 +26,7 @@ export interface SearchPageClientProvider {
     getBaseMetadata: () => Record<string, any>;
     getSearchEventRequestPayload: () => Omit<SearchEventRequest, 'actionCause' | 'searchQueryUid'>;
     getSearchUID: () => string;
+    getPipeline: () => string;
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -223,6 +224,7 @@ export class CoveoSearchPageClient {
         const payload: SearchEventRequest = {
             ...this.provider.getSearchEventRequestPayload(),
             searchQueryUid: this.provider.getSearchUID(),
+            queryPipeline: this.provider.getPipeline(),
             customData,
             actionCause: event,
         };
@@ -245,6 +247,7 @@ export class CoveoSearchPageClient {
         const payload: ClickEventRequest = {
             ...info,
             searchQueryUid: this.provider.getSearchUID(),
+            queryPipeline: this.provider.getPipeline(),
             actionCause: event,
             customData,
         };


### PR DESCRIPTION
Adds a new `getPipeline` method the the search page provider interface, that is added to all click and search events