### PR TITLE
Add support for originLevel in search page client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -33,6 +33,9 @@ describe('SearchPageClient', () => {
         }),
         getSearchUID: () => 'my-uid',
         getPipeline: () => 'my-pipeline',
+        getOriginLevel1: () => 'origin-level-1',
+        getOriginLevel2: () => 'origin-level-2',
+        getOriginLevel3: () => 'origin-level-3',
     };
 
     beforeEach(() => {
@@ -51,6 +54,12 @@ describe('SearchPageClient', () => {
         return new CoveoSearchPageClient({}, provider);
     };
 
+    const expectOrigins = () => ({
+        originLevel1: 'origin-level-1',
+        originLevel2: 'origin-level-2',
+        originLevel3: 'origin-level-3',
+    });
+
     const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
         const [, {body}] = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
@@ -60,6 +69,7 @@ describe('SearchPageClient', () => {
             queryPipeline: 'my-pipeline',
             actionCause,
             customData,
+            ...expectOrigins(),
         });
     };
 
@@ -71,6 +81,7 @@ describe('SearchPageClient', () => {
             customData,
             queryPipeline: 'my-pipeline',
             ...doc,
+            ...expectOrigins(),
         });
     };
 
@@ -82,6 +93,7 @@ describe('SearchPageClient', () => {
             eventType: CustomEventsTypes[actionCause],
             lastSearchQueryUid: 'my-uid',
             customData,
+            ...expectOrigins(),
         });
     };
 

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -27,6 +27,9 @@ export interface SearchPageClientProvider {
     getSearchEventRequestPayload: () => Omit<SearchEventRequest, 'actionCause' | 'searchQueryUid'>;
     getSearchUID: () => string;
     getPipeline: () => string;
+    getOriginLevel1: () => string;
+    getOriginLevel2: () => string;
+    getOriginLevel3: () => string;
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -209,6 +212,7 @@ export class CoveoSearchPageClient {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 
         const payload: CustomEventRequest = {
+            ...this.getOrigins(),
             eventType: CustomEventsTypes[event]!,
             eventValue: event,
             lastSearchQueryUid: this.provider.getSearchUID(),
@@ -223,6 +227,7 @@ export class CoveoSearchPageClient {
 
         const payload: SearchEventRequest = {
             ...this.provider.getSearchEventRequestPayload(),
+            ...this.getOrigins(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             customData,
@@ -246,6 +251,7 @@ export class CoveoSearchPageClient {
 
         const payload: ClickEventRequest = {
             ...info,
+            ...this.getOrigins(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,
@@ -253,5 +259,13 @@ export class CoveoSearchPageClient {
         };
 
         return this.coveoAnalyticsClient.sendClickEvent(payload);
+    }
+
+    private getOrigins() {
+        return {
+            originLevel1: this.provider.getOriginLevel1(),
+            originLevel2: this.provider.getOriginLevel2(),
+            originLevel3: this.provider.getOriginLevel3(),
+        };
     }
 }


### PR DESCRIPTION
originLevel1/2/3 support.

Also, I made them mandatory, even though they are in theory not required by the API.

In practice though, you'd want to always set all parameters for proper support in Coveo/being able to support all types of advanced ML models/build all types of reports etc.

More data > less data.