### PR TITLE
JSUI-3107 Prevent chrome from detecting cookie use

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -1,5 +1,4 @@
-import * as detector from './detector';
-import {CookieStorage, getAvailableStorage, WebStorage} from './storage';
+import {getAvailableStorage, WebStorage} from './storage';
 
 export const STORE_KEY: string = '__coveo.analytics.history';
 export const MAX_NUMBER_OF_HISTORY_ELEMENTS: number = 20;
@@ -10,11 +9,6 @@ export class HistoryStore {
     private store: WebStorage;
     constructor(store?: WebStorage) {
         this.store = store || getAvailableStorage();
-        // cleanup any old cookie that we might have added
-        // eg : we used cookies before, but switched to local storage
-        if (!(this.store instanceof CookieStorage) && detector.hasCookieStorage()) {
-            new CookieStorage().removeItem(STORE_KEY);
-        }
     }
 
     addElement(elem: HistoryElement) {


### PR DESCRIPTION
When we remove the action history in the constructor, Chrome still warns users that the JSUI site is using a `__coveo.analytics.history`. This warning appears even when analytics is disabled, when we are initializing History with NullStorage.

This PR removes the Cookie clearing step.