### PR TITLE
Added getVisitorId() to AnalyticsClient interface

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -63,7 +63,7 @@ export interface AnalyticsClient {
     registerBeforeSendEventHook(hook: AnalyticsClientSendEventHook): void;
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void;
     runtime: IRuntimeEnvironment;
-    getVisitorId(): string;
+    readonly currentVisitorId: string;
 }
 
 interface BufferedRequest {
@@ -267,9 +267,9 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         this.eventTypeMapping[eventType] = eventConfig;
     } 
     
-    getVisitorId(){
-        return this.currentVisitorId;
-    }
+    // getVisitorId(){
+    //     return this.currentVisitorId;
+    // }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {
         const parsedArguments: {[name: string]: any} = {};

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -63,6 +63,7 @@ export interface AnalyticsClient {
     registerBeforeSendEventHook(hook: AnalyticsClientSendEventHook): void;
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void;
     runtime: IRuntimeEnvironment;
+    getVisitorId(): string;
 }
 
 interface BufferedRequest {
@@ -264,6 +265,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void {
         this.eventTypeMapping[eventType] = eventConfig;
+    } 
+    
+    getVisitorId(){
+        return this.currentVisitorId;
     }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -266,10 +266,6 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void {
         this.eventTypeMapping[eventType] = eventConfig;
     } 
-    
-    // getVisitorId(){
-    //     return this.currentVisitorId;
-    // }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {
         const parsedArguments: {[name: string]: any} = {};

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -34,6 +34,6 @@ export class NoopAnalytics implements AnalyticsClient {
     }
     registerBeforeSendEventHook(): void {}
     addEventTypeMapping(): void {}
-    getVisitorId():string {return ''}
     runtime = new NoopRuntime();
+    currentVisitorId='';
 }

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -34,5 +34,6 @@ export class NoopAnalytics implements AnalyticsClient {
     }
     registerBeforeSendEventHook(): void {}
     addEventTypeMapping(): void {}
+    getVisitorId():string {return ''}
     runtime = new NoopRuntime();
 }

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -12,5 +12,5 @@ export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     addEventTypeMapping: jest.fn(),
     registerBeforeSendEventHook: jest.fn(),
     runtime: new NodeJSRuntime(),
-    getVisitorId: jest.fn(() => 'mockVisitorId'),
+    currentVisitorId:'',
 });

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -12,4 +12,5 @@ export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     addEventTypeMapping: jest.fn(),
     registerBeforeSendEventHook: jest.fn(),
     runtime: new NodeJSRuntime(),
+    getVisitorId: jest.fn(() => 'mockVisitorId'),
 });


### PR DESCRIPTION
Adding this getter function to the interface in order to use it in headless to send the `visitorId` to the searchAPI. 