### PR TITLE
Request no response body on sendBeacon to prevent corb warning

### DIFF
--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -36,7 +36,7 @@ describe('AnalyticsBeaconClient', () => {
         });
 
         expect(sendBeaconMock).toHaveBeenCalledWith(
-            `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}`,
+            `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`,
             jasmine.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent(`{"wow":"ok"}`)}`);
@@ -59,7 +59,7 @@ describe('AnalyticsBeaconClient', () => {
         });
 
         expect(sendBeaconMock).toHaveBeenCalledWith(
-            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}`,
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
             jasmine.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
@@ -85,7 +85,7 @@ describe('AnalyticsBeaconClient', () => {
         });
 
         expect(sendBeaconMock).toHaveBeenCalledWith(
-            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}`,
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
             jasmine.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -47,6 +47,7 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         return [
             token && this.isEventTypeLegacy(eventType) ? `access_token=${token}` : '',
             visitorId ? `visitorId=${visitorId}` : '',
+            'discardVisitInfo=true',
         ]
             .filter((p) => !!p)
             .join('&');


### PR DESCRIPTION
[COM-665]
Add a GET parameter to `sendBeacon` that will request discarding of the response body and make the response status code a 204 No Content. 

This prevents the CORB warning by leaving no content for the browser to read and therefore to block.

Before:
![image](https://user-images.githubusercontent.com/8978908/96872164-4223bc00-1441-11eb-86c8-d807593fca09.png)

After:
![image](https://user-images.githubusercontent.com/8978908/96872566-cb3af300-1441-11eb-9dbb-d28818763154.png)


[COM-665]: https://coveord.atlassian.net/browse/COM-665