### PR TITLE
Add beforeSendHooks to AnalyticsClient option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.12.0",
+    "version": "2.13.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -341,6 +341,19 @@ describe('Analytics', () => {
         expect(historyStore.getMostRecentElement()).toBeUndefined();
     });
 
+    it('should execute before send hooks passed as option', async () => {
+        mockFetchRequestForEventType(EventType.search);
+        const spy = jest.fn((_, p) => p);
+        const searchEventPayload = {queryText: 'potato'};
+        await new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: anEndpoint,
+            version: A_VERSION,
+            beforeSendHooks: [spy],
+        }).sendEvent(EventType.search, searchEventPayload);
+        expect(spy).toHaveBeenLastCalledWith(EventType.search, expect.objectContaining(searchEventPayload));
+    });
+
     const getParsedBodyCalls = (): any[] => {
         return fetchMock.calls().map(([, {body}]) => {
             return JSON.parse(body.toString());

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -42,6 +42,7 @@ export interface ClientOptions {
     token?: string;
     endpoint: string;
     version: string;
+    beforeSendHooks: AnalyticsClientSendEventHook[];
 }
 
 export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult;
@@ -78,6 +79,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             endpoint: Endpoints.default,
             token: '',
             version: Version,
+            beforeSendHooks: [],
         };
     }
 
@@ -101,7 +103,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
         this.visitorId = '';
         this.bufferedRequests = [];
-        this.beforeSendHooks = [enhanceViewEvent, addDefaultValues];
+        this.beforeSendHooks = [enhanceViewEvent, addDefaultValues].concat(this.options.beforeSendHooks);
         this.eventTypeMapping = {};
 
         const clientsOptions = {

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,3 +1,3 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
-export {CoveoAnalyticsClient} from '../client/analytics';
+export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export * as history from '../history';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -3,7 +3,7 @@ import * as donottrack from '../donottrack';
 import * as history from '../history';
 import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
-export {CoveoAnalyticsClient} from '../client/analytics';
+export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 


### PR DESCRIPTION
For Headless, we want to expose the possibility for end users to augment analytics event with metadata that is unique to their setup.

For example, they might want to add a metadata that `userDepartment = admin/marketing/sales/r&d` to all events sent for their search page.

By exposing the before send hooks as an option on AnalyticsClient (and some plumbing done in headless), they should be able to modify the payload to add metadata if needed.