### PR TITLE
Allow non predefined custom event type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -97,6 +97,18 @@ describe('SearchPageClient', () => {
         });
     };
 
+    const expectMatchCustomEventWithTypePayload = (eventValue: string, eventType: string, meta = {}) => {
+        const [, {body}] = fetchMock.lastCall();
+        const customData = {foo: 'bar', ...meta};
+        expect(JSON.parse(body.toString())).toMatchObject({
+            eventValue,
+            eventType,
+            lastSearchQueryUid: 'my-uid',
+            customData,
+            ...expectOrigins(),
+        });
+    };
+
     it('should send proper payload for #interfaceLoad', async () => {
         await client.logInterfaceLoad();
         expectMatchPayload(SearchPageEvents.interfaceLoad);
@@ -377,6 +389,11 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #fetchMoreResults', async () => {
         await client.logFetchMoreResults();
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    });
+
+    it('should send proper payload for #logCustomEventWithType', async () => {
+        await client.logCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
+        expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
     });
 
     it('should enable analytics tracking by default', () => {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -235,6 +235,19 @@ export class CoveoSearchPageClient {
         return this.coveoAnalyticsClient.sendCustomEvent(payload);
     }
 
+    public logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+
+        const payload: CustomEventRequest = {
+            ...this.getOrigins(),
+            eventType,
+            eventValue,
+            lastSearchQueryUid: this.provider.getSearchUID(),
+            customData,
+        };
+        return this.coveoAnalyticsClient.sendCustomEvent(payload);
+    }
+
     public logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 


### PR DESCRIPTION
The current `logCustomEvent` function tries to find a custom event type from the predefined map in `searchPageEvents.ts`.

This is helpful for all events we want to log out of the box. 

But, if someone wanna create a new type of custom event, it needs to be possible to do so by creating your own event value and event type.