### PR TITLE
[COM-623] Lowercase custom properties

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -59,7 +59,7 @@ describe('ec events', () => {
         });
     });
 
-    it('should fix the cashing on custom objects', async () => {
+    it('should lowercase the properties of custom objects', async () => {
         await coveoua('set', 'custom', {
             camelCase: 'camel',
             snake_case: 'snake',

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -59,6 +59,27 @@ describe('ec events', () => {
         });
     });
 
+    it('should fix the cashing on custom objects', async () => {
+        await coveoua('set', 'custom', {
+            camelCase: 'camel',
+            snake_case: 'snake',
+            PascalCase: 'pascal',
+            UPPER_CASE_SNAKE: 'upper snake',
+        });
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            camelcase: 'camel',
+            snake_case: 'snake',
+            pascalcase: 'pascal',
+            upper_case_snake: 'upper snake',
+        });
+    });
+
     it('can send a product detail view event', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -330,7 +330,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private processCustomParameters(payload: IRequestPayload): IRequestPayload {
         const {custom, ...rest} = payload;
 
-        const lowercasedCustom = this.ensureLowercaseKeys(custom);
+        const lowercasedCustom = this.lowercaseKeys(custom);
 
         const newPayload = convertCustomMeasurementProtocolKeys(rest);
 
@@ -340,16 +340,16 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         };
     }
 
-    private ensureLowercaseKeys(custom: any) {
+    private lowercaseKeys(custom: any) {
         const keys = Object.keys(custom || {});
 
-        const lowercasedCustom = {} as {[key: string]: any};
-
-        keys.forEach((key) => {
-            lowercasedCustom[key.toLowerCase()] = custom[key];
-        });
-
-        return lowercasedCustom;
+        return keys.reduce(
+            (all, key) => ({
+                ...all,
+                [key.toLowerCase()]: custom[key],
+            }),
+            {}
+        );
     }
 
     private validateParams(payload: IRequestPayload): IRequestPayload {

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -330,12 +330,26 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private processCustomParameters(payload: IRequestPayload): IRequestPayload {
         const {custom, ...rest} = payload;
 
+        const lowercasedCustom = this.ensureLowercaseKeys(custom);
+
         const newPayload = convertCustomMeasurementProtocolKeys(rest);
 
         return {
-            ...(custom || {}),
+            ...lowercasedCustom,
             ...newPayload,
         };
+    }
+
+    private ensureLowercaseKeys(custom: any) {
+        const keys = Object.keys(custom || {});
+
+        const lowercasedCustom = {} as {[key: string]: any};
+
+        keys.forEach((key) => {
+            lowercasedCustom[key.toLowerCase()] = custom[key];
+        });
+
+        return lowercasedCustom;
     }
 
     private validateParams(payload: IRequestPayload): IRequestPayload {


### PR DESCRIPTION
Ensure that the custom objects passed from plugins (such as ec and svc) are consistent with the other properties from the measurement protocol which are all lowercased.

Still need to test side effects and see if typing in the `ensureLowercaseKeys` method could be improved.