### PR TITLE
Add support for facet-state in search event request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.13.0",
+    "version": "2.15.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.14.0",
+    "version": "2.15.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/events.ts
+++ b/src/events.ts
@@ -37,6 +37,18 @@ export interface EventBaseRequest {
     originLevel3?: string;
 }
 
+export interface FacetStateRequest {
+    field: string;
+    id: string;
+    value: string;
+    valuePosition: number;
+    displayValue: string;
+    facetType: 'specific' | 'dateRange' | 'numericalRange' | 'hierarchical';
+    state: 'idle' | 'selected';
+    facetPosition: number;
+    title: string;
+}
+
 export interface SearchEventRequest extends EventBaseRequest {
     searchQueryUid: string;
     queryText: string;
@@ -48,6 +60,7 @@ export interface SearchEventRequest extends EventBaseRequest {
     results?: SearchDocument[];
     queryPipeline?: string;
     userGroups?: string[];
+    facetState?: FacetStateRequest[];
 }
 
 export interface DocumentInformation {

--- a/src/events.ts
+++ b/src/events.ts
@@ -44,9 +44,12 @@ export interface FacetStateRequest {
     valuePosition: number;
     displayValue: string;
     facetType: 'specific' | 'dateRange' | 'numericalRange' | 'hierarchical';
-    state: 'selected';
+    state: 'selected' | 'idle';
     facetPosition: number;
     title: string;
+    start?: string;
+    end?: string;
+    endInclusive?: boolean;
 }
 
 export interface SearchEventRequest extends EventBaseRequest {

--- a/src/events.ts
+++ b/src/events.ts
@@ -44,7 +44,7 @@ export interface FacetStateRequest {
     valuePosition: number;
     displayValue: string;
     facetType: 'specific' | 'dateRange' | 'numericalRange' | 'hierarchical';
-    state: 'idle' | 'selected';
+    state: 'selected';
     facetPosition: number;
     title: string;
 }

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -293,7 +293,7 @@ export class CoveoSearchPageClient {
         return this.coveoAnalyticsClient.sendSearchEvent(payload);
     }
 
-    private getBaseSearchEventRequest(event: SearchPageEvents, metadata?: Record<string, any>) {
+    private getBaseSearchEventRequest(event: SearchPageEvents, metadata?: Record<string, any>): SearchEventRequest {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 
         return {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -1,4 +1,4 @@
-import {DocumentInformation} from '../events';
+import {DocumentInformation, FacetStateRequest} from '../events';
 
 export enum SearchPageEvents {
     /**
@@ -186,6 +186,7 @@ export interface FacetMetadata {
     facetTitle: string;
 }
 
+export type FacetStateMetadata = FacetStateRequest;
 export interface FacetRangeMetadata extends Omit<FacetMetadata, 'facetValue'> {
     facetRangeStart: string;
     facetRangeEnd: string;


### PR DESCRIPTION
For DynamicFacet experience, UA (and ML) need to have access to the full "facet state" when a facet value is selected/deselected.

This adds the new definition expected by UA 

https://platformdev.cloud.coveo.com/docs?urls.primaryName=Usage%20Analytics%20Write#/Analytics%20API%20-%20Version%2015/post__v15_analytics_search


Also modifies the different "logFacet" function in SearchPageClient to request that new information.