### PR TITLE
chore(SFINT-3596): Refactor Plugins

### DIFF
--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -51,13 +51,13 @@ export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: stri
     }, {});
 };
 
-const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | null => {
-    let match = null;
+const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefined => {
+    let matchedKey: string | undefined = undefined;
     [...isCustomCommerceKey].every((regex) => {
-        match = regex.exec(key);
-        return !Boolean(match);
+        matchedKey = regex.exec(key)?.[1];
+        return !Boolean(matchedKey);
     });
-    return match;
+    return matchedKey;
 };
 
 const convertCustomObject = (prefix: string, customData: {[name: string]: string}) => {

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -1,5 +1,9 @@
 import {isServiceKey, serviceActionsKeysMapping} from './measurementProtocolMapping/serviceMeasurementProtocolMapper';
-import {commerceActionKeysMapping, isCommerceKey, isCustomCommerceKey} from './measurementProtocolMapping/commerceMeasurementProtocolMapper';
+import {
+    commerceActionKeysMapping,
+    isCommerceKey,
+    isCustomCommerceKey,
+} from './measurementProtocolMapping/commerceMeasurementProtocolMapper';
 import {keysOf} from './utils';
 import {baseMeasurementProtocolKeysMapping} from './measurementProtocolMapping/baseMeasurementProtocolMapper';
 

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -1,87 +1,12 @@
-import {EC, Product, ImpressionList, BaseImpression} from '../plugins/ec';
-import {isTicketKey, svcActionsKeysMapping} from './coveoServiceMeasurementProtocolMapper';
+import {isServiceKey, serviceActionsKeysMapping} from './measurementProtocolMapping/serviceMeasurementProtocolMapper';
+import {commerceActionKeysMapping, isCommerceKey, isCustomCommerceKey} from './measurementProtocolMapping/commerceMeasurementProtocolMapper';
 import {keysOf} from './utils';
-
-const globalParamKeysMapping: {[name: string]: string} = {
-    anonymizeIp: 'aip',
-};
-
-// Based off: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#enhanced-ecomm
-const productKeysMapping: {[key in keyof Product]: string} = {
-    id: 'id',
-    name: 'nm',
-    brand: 'br',
-    category: 'ca',
-    variant: 'va',
-    price: 'pr',
-    quantity: 'qt',
-    coupon: 'cc',
-    position: 'ps',
-};
-
-const impressionKeysMapping: {[key in keyof BaseImpression]: string} = {
-    id: 'id',
-    name: 'nm',
-    brand: 'br',
-    category: 'ca',
-    variant: 'va',
-    position: 'ps',
-    price: 'pr',
-};
-
-const eventKeysMapping: {[name: string]: string} = {
-    eventCategory: 'ec',
-    eventAction: 'ea',
-    eventLabel: 'el',
-    eventValue: 'ev',
-    page: 'dp',
-    visitorId: 'cid',
-    clientId: 'cid',
-    userId: 'uid',
-    currencyCode: 'cu',
-};
-
-const productActionsKeysMapping: {[name: string]: string} = {
-    action: 'pa',
-    list: 'pal',
-    listSource: 'pls',
-};
-
-const transactionActionsKeysMapping: {[name: string]: string} = {
-    id: 'ti',
-    revenue: 'tr',
-    tax: 'tt',
-    shipping: 'ts',
-    coupon: 'tcc',
-    affiliation: 'ta',
-    step: 'cos',
-    option: 'col',
-};
-
-type DefaultContextInformation = ReturnType<typeof EC.prototype.getDefaultContextInformation> &
-    ReturnType<typeof EC.prototype.getLocationInformation>;
-const contextInformationMapping: {[key in keyof DefaultContextInformation]: string} = {
-    hitType: 't',
-    pageViewId: 'pid',
-    encoding: 'de',
-    location: 'dl',
-    referrer: 'dr',
-    screenColor: 'sd',
-    screenResolution: 'sr',
-    title: 'dt',
-    userAgent: 'ua',
-    language: 'ul',
-    eventId: 'z',
-    time: 'tm',
-};
+import {baseMeasurementProtocolKeysMapping} from './measurementProtocolMapping/baseMeasurementProtocolMapper';
 
 const measurementProtocolKeysMapping: {[name: string]: string} = {
-    ...eventKeysMapping,
-    ...productActionsKeysMapping,
-    ...transactionActionsKeysMapping,
-    ...contextInformationMapping,
-    ...globalParamKeysMapping,
-    ...svcActionsKeysMapping,
+    ...baseMeasurementProtocolKeysMapping,
+    ...commerceActionKeysMapping,
+    ...serviceActionsKeysMapping,
 };
 
 export const convertKeysToMeasurementProtocol = (params: any) => {
@@ -94,87 +19,24 @@ export const convertKeysToMeasurementProtocol = (params: any) => {
     }, {});
 };
 
-export const convertProductToMeasurementProtocol = (product: Product, index: number) => {
-    return keysOf(product).reduce((mappedProduct, key) => {
-        const newKey = `pr${index + 1}${productKeysMapping[key] || key}`;
-        return {
-            ...mappedProduct,
-            [newKey]: product[key],
-        };
-    }, {});
-};
-
-export const convertImpressionListToMeasurementProtocol = (
-    impressionList: ImpressionList,
-    listIndex: number,
-    prefix: string
-) => {
-    const payload: {[name: string]: any} = impressionList.impressions.reduce(
-        (mappedImpressions, impression, productIndex) => {
-            return {
-                ...mappedImpressions,
-                ...convertImpressionToMeasurementProtocol(impression, listIndex, productIndex, prefix),
-            };
-        },
-        {}
-    );
-
-    if (impressionList.listName) {
-        const listNameKey = `il${listIndex + 1}nm`;
-        payload[listNameKey] = impressionList.listName;
-    }
-    return payload;
-};
-
-const convertImpressionToMeasurementProtocol = (
-    impression: BaseImpression,
-    listIndex: number,
-    productIndex: number,
-    prefix: string
-) => {
-    return keysOf(impression).reduce((mappedImpression, key) => {
-        const newKey = `il${listIndex + 1}${prefix}${productIndex + 1}${impressionKeysMapping[key] || key}`;
-        return {
-            ...mappedImpression,
-            [newKey]: impression[key],
-        };
-    }, {});
-};
-
 const measurementProtocolKeysMappingValues = keysOf(measurementProtocolKeysMapping).map(
     (key) => measurementProtocolKeysMapping[key]
 );
-const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
-const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
 
-const productSubKeysMatchGroup = [...productKeysMappingValues, 'custom'].join('|');
-const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, 'custom'].join('|');
-const productPrefixMatchGroup = '(pr[0-9]+)';
-const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
-const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
-const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
-const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
-const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
-
-const isProductKey = (key: string) => productKeyRegex.test(key);
-const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
 const isKnownMeasurementProtocolKey = (key: string) => measurementProtocolKeysMappingValues.indexOf(key) !== -1;
 const isCustomKey = (key: string) => key === 'custom';
 
 export const isMeasurementProtocolKey = (key: string): boolean => {
-    return [isProductKey, isTicketKey, isImpressionKey, isKnownMeasurementProtocolKey, isCustomKey].some((test) =>
-        test(key)
-    );
+    return [...isCommerceKey, ...isServiceKey, isKnownMeasurementProtocolKey, isCustomKey].some((test) => test(key));
 };
 
 export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: string | {[name: string]: string}}) => {
     return keysOf(data).reduce((all, current) => {
-        const match = customProductKeyRegex.exec(current) || customImpressionKeyRegex.exec(current);
+        const match = getFirstCustomMeasurementProtocolKeyMatch(current);
         if (match) {
-            const originalKey = match[1];
             return {
                 ...all,
-                ...convertCustomObject(originalKey, data[current] as {[name: string]: string}),
+                ...convertCustomObject(match, data[current] as {[name: string]: string}),
             };
         } else {
             return {
@@ -183,6 +45,16 @@ export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: stri
             };
         }
     }, {});
+};
+
+const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefined => {
+    const customKeyRegExps: RegExp[] = [...isCustomCommerceKey];
+    for (let index = 0; index < customKeyRegExps.length; index++) {
+        const match = customKeyRegExps[index].exec(key);
+        if (match) {
+            return match[1];
+        }
+    }
 };
 
 const convertCustomObject = (prefix: string, customData: {[name: string]: string}) => {

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -51,14 +51,13 @@ export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: stri
     }, {});
 };
 
-const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefined => {
-    const customKeyRegExps: RegExp[] = [...isCustomCommerceKey];
-    for (let index = 0; index < customKeyRegExps.length; index++) {
-        const match = customKeyRegExps[index].exec(key);
-        if (match) {
-            return match[1];
-        }
-    }
+const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | null => {
+    let match = null;
+    [...isCustomCommerceKey].every((regex) => {
+        match = regex.exec(key);
+        return !Boolean(match);
+    });
+    return match;
 };
 
 const convertCustomObject = (prefix: string, customData: {[name: string]: string}) => {

--- a/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
@@ -1,0 +1,41 @@
+import {BasePlugin} from '../../plugins/BasePlugin';
+
+type DefaultContextInformation = ReturnType<typeof BasePlugin.prototype.getDefaultContextInformation> &
+    ReturnType<typeof BasePlugin.prototype.getLocationInformation>;
+
+const globalParamKeysMapping: {[name: string]: string} = {
+    anonymizeIp: 'aip',
+};
+
+const eventKeysMapping: {[name: string]: string} = {
+    eventCategory: 'ec',
+    eventAction: 'ea',
+    eventLabel: 'el',
+    eventValue: 'ev',
+    page: 'dp',
+    visitorId: 'cid',
+    clientId: 'cid',
+    userId: 'uid',
+    currencyCode: 'cu',
+};
+
+const contextInformationMapping: {[key in keyof DefaultContextInformation]: string} = {
+    hitType: 't',
+    pageViewId: 'pid',
+    encoding: 'de',
+    location: 'dl',
+    referrer: 'dr',
+    screenColor: 'sd',
+    screenResolution: 'sr',
+    title: 'dt',
+    userAgent: 'ua',
+    language: 'ul',
+    eventId: 'z',
+    time: 'tm',
+};
+
+export const baseMeasurementProtocolKeysMapping: {[name: string]: string} = {
+    ...globalParamKeysMapping,
+    ...eventKeysMapping,
+    ...contextInformationMapping,
+};

--- a/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -1,0 +1,112 @@
+import {Product, ImpressionList, BaseImpression} from '../../plugins/ec';
+import {keysOf} from '../utils';
+
+// Based off: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#enhanced-ecomm
+const productKeysMapping: {[key in keyof Product]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    price: 'pr',
+    quantity: 'qt',
+    coupon: 'cc',
+    position: 'ps',
+};
+
+const impressionKeysMapping: {[key in keyof BaseImpression]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    position: 'ps',
+    price: 'pr',
+};
+
+const productActionsKeysMapping: {[name: string]: string} = {
+    action: 'pa',
+    list: 'pal',
+    listSource: 'pls',
+};
+
+const transactionActionsKeysMapping: {[name: string]: string} = {
+    id: 'ti',
+    revenue: 'tr',
+    tax: 'tt',
+    shipping: 'ts',
+    coupon: 'tcc',
+    affiliation: 'ta',
+    step: 'cos',
+    option: 'col',
+};
+
+export const commerceActionKeysMapping: {[name: string]: string} = {
+    ...productActionsKeysMapping,
+    ...transactionActionsKeysMapping,
+};
+
+export const convertProductToMeasurementProtocol = (product: Product, index: number) => {
+    return keysOf(product).reduce((mappedProduct, key) => {
+        const newKey = `pr${index + 1}${productKeysMapping[key] || key}`;
+        return {
+            ...mappedProduct,
+            [newKey]: product[key],
+        };
+    }, {});
+};
+
+export const convertImpressionListToMeasurementProtocol = (
+    impressionList: ImpressionList,
+    listIndex: number,
+    prefix: string
+) => {
+    const payload: {[name: string]: any} = impressionList.impressions.reduce(
+        (mappedImpressions, impression, productIndex) => {
+            return {
+                ...mappedImpressions,
+                ...convertImpressionToMeasurementProtocol(impression, listIndex, productIndex, prefix),
+            };
+        },
+        {}
+    );
+
+    if (impressionList.listName) {
+        const listNameKey = `il${listIndex + 1}nm`;
+        payload[listNameKey] = impressionList.listName;
+    }
+    return payload;
+};
+
+const convertImpressionToMeasurementProtocol = (
+    impression: BaseImpression,
+    listIndex: number,
+    productIndex: number,
+    prefix: string
+) => {
+    return keysOf(impression).reduce((mappedImpression, key) => {
+        const newKey = `il${listIndex + 1}${prefix}${productIndex + 1}${impressionKeysMapping[key] || key}`;
+        return {
+            ...mappedImpression,
+            [newKey]: impression[key],
+        };
+    }, {});
+};
+
+const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
+const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
+
+const productSubKeysMatchGroup = [...productKeysMappingValues, 'custom'].join('|');
+const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, 'custom'].join('|');
+const productPrefixMatchGroup = '(pr[0-9]+)';
+const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
+const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
+const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
+const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
+const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
+
+const isProductKey = (key: string) => productKeyRegex.test(key);
+const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
+
+export const isCommerceKey = [isImpressionKey, isProductKey];
+export const isCustomCommerceKey = [customProductKeyRegex, customImpressionKeyRegex];

--- a/src/client/measurementProtocolMapping/serviceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/serviceMeasurementProtocolMapper.ts
@@ -1,5 +1,5 @@
-import {Ticket} from '../plugins/svc';
-import {keysOf} from './utils';
+import {Ticket} from '../../plugins/svc';
+import {keysOf} from '../utils';
 
 const ticketKeysMapping: {[key in keyof Ticket]: string} = {
     id: 'svc_ticket_id',
@@ -13,7 +13,7 @@ const ticketKeysMappingValues = keysOf(ticketKeysMapping).map((key) => ticketKey
 const ticketSubKeysMatchGroup = [...ticketKeysMappingValues].join('|');
 const ticketKeyRegex = new RegExp(`^(${ticketSubKeysMatchGroup}$)`);
 
-export const svcActionsKeysMapping: {[name: string]: string} = {
+export const serviceActionsKeysMapping: {[name: string]: string} = {
     svcAction: 'svc_action',
     svcActionData: 'svc_action_data',
 };
@@ -30,4 +30,6 @@ export const convertTicketToMeasurementProtocol = (ticket: Ticket) => {
         }, {});
 };
 
-export const isTicketKey = (key: string) => ticketKeyRegex.test(key);
+const isTicketKey = (key: string) => ticketKeyRegex.test(key);
+
+export const isServiceKey = [isTicketKey];

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -1,0 +1,96 @@
+import {AnalyticsClient} from '../client/analytics';
+import {uuidv4} from '../client/crypto';
+import {getFormattedLocation} from '../client/location';
+
+export const BasePluginEventTypes = {
+    pageview: 'pageview',
+    event: 'event',
+};
+
+export abstract class BasePlugin {
+    protected client: AnalyticsClient;
+    protected uuidGenerator: typeof uuidv4;
+    protected action?: string;
+    protected actionData: {[name: string]: string} = {};
+    private pageViewId: string;
+    private hasSentFirstPageView?: boolean;
+    private lastLocation: string;
+    private lastReferrer: string;
+
+    constructor({client, uuidGenerator = uuidv4}: {client: AnalyticsClient; uuidGenerator?: typeof uuidv4}) {
+        this.client = client;
+        this.uuidGenerator = uuidGenerator;
+        this.pageViewId = uuidGenerator();
+        this.lastLocation = getFormattedLocation(window.location);
+        this.lastReferrer = document.referrer;
+
+        this.addHooks();
+    }
+
+    protected abstract addHooks(): void;
+
+    public setAction(action: string, options?: any) {
+        this.action = action;
+        this.actionData = options;
+    }
+
+    public clearData() {
+        this.action = undefined;
+        this.actionData = {};
+    }
+
+    public getLocationInformation(eventType: string, payload: any) {
+        eventType === BasePluginEventTypes.pageview && this.updateStateForNewPageView(payload);
+        return {
+            referrer: this.lastReferrer,
+            location: this.lastLocation,
+        };
+    }
+
+    public getDefaultContextInformation(eventType: string) {
+        const pageContext = {
+            hitType: eventType,
+            pageViewId: this.pageViewId,
+        };
+        const documentContext = {
+            title: document.title,
+            encoding: document.characterSet,
+        };
+        const screenContext = {
+            screenResolution: `${screen.width}x${screen.height}`,
+            screenColor: `${screen.colorDepth}-bit`,
+        };
+        const navigatorContext = {
+            language: navigator.language,
+            userAgent: navigator.userAgent,
+        };
+        const eventContext = {
+            time: Date.now().toString(),
+            eventId: this.uuidGenerator(),
+        };
+        return {
+            ...pageContext,
+            ...eventContext,
+            ...screenContext,
+            ...navigatorContext,
+            ...documentContext,
+        };
+    }
+
+    private updateStateForNewPageView(payload: any) {
+        if (this.hasSentFirstPageView) {
+            this.pageViewId = this.uuidGenerator();
+            this.lastReferrer = this.lastLocation;
+        }
+
+        if (!!payload.page) {
+            const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
+            const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
+            this.lastLocation = `${extractHostnamePart(this.lastLocation)}${removeStartingSlash(payload.page)}`;
+        } else {
+            this.lastLocation = getFormattedLocation(window.location);
+        }
+
+        this.hasSentFirstPageView = true;
+    }
+}

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -28,6 +28,7 @@ export abstract class BasePlugin {
     }
 
     protected abstract addHooks(): void;
+    protected abstract clearPluginData(): void;
 
     public setAction(action: string, options?: any) {
         this.action = action;
@@ -35,6 +36,7 @@ export abstract class BasePlugin {
     }
 
     public clearData() {
+        this.clearPluginData();
         this.action = undefined;
         this.actionData = {};
     }

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -81,8 +81,7 @@ export class EC extends BasePlugin {
         this.impressions.push(impression);
     }
 
-    clearData() {
-        super.clearData();
+    protected clearPluginData() {
         this.products = [];
         this.impressions = [];
     }

--- a/src/plugins/svc.spec.ts
+++ b/src/plugins/svc.spec.ts
@@ -137,7 +137,6 @@ describe('SVC plugin', () => {
 
     it('should be able to clear all the data', () => {
         svc.setTicket({subject: '🍨', description: 'Some desc'});
-        svc.addImpression({id: '🍦', name: 'impression'});
         svc.clearData();
 
         const result = executeRegisteredHook(SVCPluginEventTypes.event, {});

--- a/src/plugins/svc.ts
+++ b/src/plugins/svc.ts
@@ -44,8 +44,7 @@ export class SVC extends BasePlugin {
         this.ticket = ticket;
     }
 
-    clearData() {
-        super.clearData();
+    protected clearPluginData() {
         this.ticket = {};
     }
 

--- a/src/plugins/svc.ts
+++ b/src/plugins/svc.ts
@@ -1,12 +1,11 @@
 import {AnalyticsClient} from '../client/analytics';
 import {EventType} from '../events';
 import {uuidv4} from '../client/crypto';
-import {getFormattedLocation} from '../client/location';
-import {convertTicketToMeasurementProtocol} from '../client/coveoServiceMeasurementProtocolMapper';
+import {convertTicketToMeasurementProtocol} from '../client/measurementProtocolMapping/serviceMeasurementProtocolMapper';
+import {BasePlugin, BasePluginEventTypes} from './BasePlugin';
 
 export const SVCPluginEventTypes = {
-    pageview: 'pageview',
-    event: 'event',
+    ...BasePluginEventTypes,
 };
 
 const allSVCEventTypes = Object.keys(SVCPluginEventTypes).map(
@@ -28,42 +27,16 @@ export interface TicketProperties {
 
 export type Ticket = TicketProperties;
 
-export interface ImpressionProperties {
-    id?: string;
-    name?: string;
-    position?: number;
-    list?: string;
-    custom?: CustomValues;
-}
-
-export type Impression = ImpressionProperties;
-export type BaseImpression = Omit<Impression, 'list'>;
-export interface ImpressionList {
-    listName?: string;
-    impressions: BaseImpression[];
-}
-
-export class SVC {
-    private client: AnalyticsClient;
-    private uuidGenerator: typeof uuidv4;
+export class SVC extends BasePlugin {
     private ticket: Ticket = {};
-    private impressions: Impression[] = [];
-    private action?: string;
-    private actionData: {[name: string]: string} = {};
-    private pageViewId: string;
-    private hasSentFirstPageView?: boolean;
-    private lastLocation: string;
-    private lastReferrer: string;
 
     constructor({client, uuidGenerator = uuidv4}: {client: AnalyticsClient; uuidGenerator?: typeof uuidv4}) {
-        this.client = client;
-        this.uuidGenerator = uuidGenerator;
-        this.pageViewId = uuidGenerator();
-        this.lastLocation = getFormattedLocation(window.location);
-        this.lastReferrer = document.referrer;
+        super({client, uuidGenerator});
+    }
 
-        this.addHooksForPageView();
+    protected addHooks(): void {
         this.addHooksForEvent();
+        this.addHooksForPageView();
         this.addHooksForSVCEvents();
     }
 
@@ -71,20 +44,9 @@ export class SVC {
         this.ticket = ticket;
     }
 
-    addImpression(impression: Impression) {
-        this.impressions.push(impression);
-    }
-
-    setAction(action: string, options?: any) {
-        this.action = action;
-        this.actionData = options;
-    }
-
     clearData() {
+        super.clearData();
         this.ticket = {};
-        this.impressions = [];
-        this.action = undefined;
-        this.actionData = {};
     }
 
     private addHooksForSVCEvents() {
@@ -131,60 +93,5 @@ export class SVC {
 
     private getTicketPayload() {
         return convertTicketToMeasurementProtocol(this.ticket);
-    }
-
-    private updateStateForNewPageView(payload: any) {
-        if (this.hasSentFirstPageView) {
-            this.pageViewId = this.uuidGenerator();
-            this.lastReferrer = this.lastLocation;
-        }
-
-        if (!!payload.page) {
-            const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
-            const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
-            this.lastLocation = `${extractHostnamePart(this.lastLocation)}${removeStartingSlash(payload.page)}`;
-        } else {
-            this.lastLocation = getFormattedLocation(window.location);
-        }
-
-        this.hasSentFirstPageView = true;
-    }
-
-    getLocationInformation(eventType: string, payload: any) {
-        eventType === SVCPluginEventTypes.pageview && this.updateStateForNewPageView(payload);
-        return {
-            referrer: this.lastReferrer,
-            location: this.lastLocation,
-        };
-    }
-
-    getDefaultContextInformation(eventType: string) {
-        const pageContext = {
-            hitType: eventType,
-            pageViewId: this.pageViewId,
-        };
-        const documentContext = {
-            title: document.title,
-            encoding: document.characterSet,
-        };
-        const screenContext = {
-            screenResolution: `${screen.width}x${screen.height}`,
-            screenColor: `${screen.colorDepth}-bit`,
-        };
-        const navigatorContext = {
-            language: navigator.language,
-            userAgent: navigator.userAgent,
-        };
-        const eventContext = {
-            time: Date.now().toString(),
-            eventId: this.uuidGenerator(),
-        };
-        return {
-            ...pageContext,
-            ...eventContext,
-            ...screenContext,
-            ...navigatorContext,
-            ...documentContext,
-        };
     }
 }


### PR DESCRIPTION
I refactored the plugins and measurement protocol mapping.

 I created a 'base' plugin that is in charge of logging the minimal data required by the Measurement Protocol.
 The other plugins extend upon it, this ensures that every plugin does log the minimal data required (and also simplify the job of a plugin implementer, because he just has to focus on the data relevant to his plugin)
 
 The measurement protocol is divided similarly, with three mapping files: one for the 'base', one for service, one for commerce, and finally, a mapper that consume the three mapping files into single functions, later used by analytics.ts
 
 And ride-along come the deletion of the impression in the service plugin. We did not implement client-side impressions yet and the type definition and the method could lead to confusion.
 
 