### PR TITLE
Fix acl attribute and remove start_environment_automatically

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -8,8 +8,7 @@
         "notifications": {
             "slack_channels": ["commerceteambuilds"]
         },
-        "team_jenkins": "commerceteambuilds",
-        "start_environment_automatically": true
+        "team_jenkins": "commerceteambuilds"
     },
     "package_rollout": {
         "only_consider_changesets_after": "688b6873442721d61e2a0ac492b9da808ddb0ef0"
@@ -48,7 +47,7 @@
                         "include": ".*",
                         "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "content-encoding": "gzip",
-                        "acl": "public_read"
+                        "acl": "public-read"
                     }
                 }
             }
@@ -70,7 +69,7 @@
                         "include": ".*",
                         "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "content-encoding": "gzip",
-                        "acl": "public_read"
+                        "acl": "public-read"
                     }
                 }
             }
@@ -92,7 +91,7 @@
                         "include": ".*",
                         "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "content-encoding": "gzip",
-                        "acl": "public_read"
+                        "acl": "public-read"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.16.0",
+    "version": "2.16.1",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",


### PR DESCRIPTION
[COM-765]

A quick one, there was a typo for the `acl` attribute, and I noticed `start_environment_automatically` would automatically trigger `prd`, which I don't think is what we want :sweat_smile: 

I am also bumping to `2.16.1` mostly to 100% test a new deployment

[COM-765]: https://coveord.atlassian.net/browse/COM-765