### PR TITLE
Remove content-encoding for non-minified files

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -37,14 +37,14 @@
                 "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION]",
                 "parameters": {
                     "include": ".*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                    "content-encoding": "gzip"
+                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "deploy",
                 "prd": {
                     "bucket": "coveo-public-content",
                     "parameters": {
                         "include": ".*",
+                        "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "acl": "public-read"
                     }
                 }
@@ -57,14 +57,14 @@
                 "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_MINOR_VERSION]",
                 "parameters": {
                     "include": ".*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                    "content-encoding": "gzip"
+                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "deploy",
                 "prd": {
                     "bucket": "coveo-public-content",
                     "parameters": {
                         "include": ".*",
+                        "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "acl": "public-read"
                     }
                 }
@@ -77,14 +77,14 @@
                 "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_VERSION]",
                 "parameters": {
                     "include": ".*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                    "content-encoding": "gzip"
+                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
                 },
                 "source": "deploy",
                 "prd": {
                     "bucket": "coveo-public-content",
                     "parameters": {
                         "include": ".*",
+                        "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
                         "acl": "public-read"
                     }
                 }


### PR DESCRIPTION
[COM-765]

I deployed this one locally and I now have access to those files with: https://static.cloud.coveo.com/coveo.analytics.js/2.16.2/coveoua.js ! :confetti_ball: 

[COM-765]: https://coveord.atlassian.net/browse/COM-765