### PR TITLE
Remove deploy of major and major.minor while integrating deployment pipeline

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -49,46 +49,6 @@
                     }
                 }
             }
-        },
-        {
-            "id": "deploy-major-minor",
-            "s3": {
-                "bucket": "coveo-ndev-coveoanalytics",
-                "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_MINOR_VERSION]",
-                "parameters": {
-                    "include": ".*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
-                },
-                "source": "deploy",
-                "prd": {
-                    "bucket": "coveo-public-content",
-                    "parameters": {
-                        "include": ".*",
-                        "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                        "acl": "public-read"
-                    }
-                }
-            }
-        },
-        {
-            "id": "deploy-major",
-            "s3": {
-                "bucket": "coveo-ndev-coveoanalytics",
-                "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_VERSION]",
-                "parameters": {
-                    "include": ".*",
-                    "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff"
-                },
-                "source": "deploy",
-                "prd": {
-                    "bucket": "coveo-public-content",
-                    "parameters": {
-                        "include": ".*",
-                        "metadata": "X-Frame-Options=deny,X-Content-Type-Options=nosniff",
-                        "acl": "public-read"
-                    }
-                }
-            }
         }
     ],
     "deployment_config_version": 1


### PR DESCRIPTION
So with the incident today, I decided to just try deploying to `major.minor.patch` while we figure things out.

We should put `major.minor` back once we are 100% certain it won't break prod, _then_ bring back `major` while keeping Travis on backup. 

[COM-765]

[COM-765]: https://coveord.atlassian.net/browse/COM-765