### PR TITLE
Use npm_corp_token and bump the version for real

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   }
 
   environment {
-    NPM_TOKEN = credentials("npmjs_com_token")
+    NPM_TOKEN = credentials("npm_corp_token")
     GIT = credentials('github-coveobot')
     GH_TOKEN = credentials('github-coveobot_token')
     SNYK_TOKEN = credentials("snyk_token")
@@ -66,7 +66,7 @@ pipeline {
         script {
           gitUtils.withCredentialHelper() {
             sh "git checkout master"
-            sh "npm version -m \"Bump version to %s [version bump]\""
+            sh "npm version patch -m \"Bump version to %s [version bump]\""
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.16.1",
+    "version": "2.16.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.16.1",
+    "version": "2.16.2",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",


### PR DESCRIPTION
[COM-765]

The token was based off `react-vapor`, but it is the `npmcoveord` user. What we need for `coveo.analytics` is the `coveo-organization` token, so here it is.

I also forgot to add `patch` after `npm version`, so it was not creating the commit :facepalm: 

I also bumped to `2.16.2` since I had already published this version by hand earlier

[COM-765]: https://coveord.atlassian.net/browse/COM-765