### PR TITLE
add preprocessRequest to client [KIT-405]

### DIFF
--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -373,7 +373,7 @@ describe('Analytics', () => {
     });
 
     it('should preprocess the request with the preprocessRequest', async () => {
-        let clientType: string;
+        let clientOrigin: string;
         let processedRequest: IAnalyticsRequestOptions = {
             url: 'https://www.myownanalytics.com/endpoint',
             headers: {
@@ -391,7 +391,7 @@ describe('Analytics', () => {
             endpoint: anEndpoint,
             version: A_VERSION,
             preprocessRequest: (request, type) => {
-                clientType = type;
+                clientOrigin = type;
                 processedRequest = {
                     ...request,
                     ...processedRequest,
@@ -405,7 +405,7 @@ describe('Analytics', () => {
         const options: RequestInit = call[1];
 
         const {url: expectedUrl, ...expectedOptions} = processedRequest;
-        expect(clientType).toBe('fetch');
+        expect(clientOrigin).toBe('analyticsFetch');
         expect(url).toBe(expectedUrl);
         expect(options).toEqual(expectedOptions);
     });

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -381,9 +381,9 @@ describe('Analytics', () => {
             },
             method: 'PUT',
             mode: 'same-origin',
-            payload: {
+            body: JSON.stringify({
                 test: 'custom',
-            },
+            }),
         };
         fetchMock.put(processedRequest.url, eventResponse);
         const searchEventPayload = {queryText: 'potato'};
@@ -399,14 +399,13 @@ describe('Analytics', () => {
         const call = fetchMock.calls()[0];
         const url = call[0];
         const options: RequestInit = call[1];
-        const body = getParsedBodyCalls()[0];
 
         expect(url).toBe(processedRequest.url);
         expect(options.credentials).toBe(processedRequest.credentials);
         expect(options.headers).toEqual(processedRequest.headers);
         expect(options.method).toBe(processedRequest.method);
         expect(options.mode).toBe(processedRequest.mode);
-        expect(body).toEqual(processedRequest.payload);
+        expect(options.body).toBe(processedRequest.body);
     });
 
     const getParsedBodyCalls = (): any[] => {

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -373,6 +373,7 @@ describe('Analytics', () => {
     });
 
     it('should preprocess the request with the preprocessRequest', async () => {
+        let clientType: string;
         let processedRequest: IAnalyticsRequestOptions = {
             url: 'https://www.myownanalytics.com/endpoint',
             headers: {
@@ -389,7 +390,8 @@ describe('Analytics', () => {
             token: aToken,
             endpoint: anEndpoint,
             version: A_VERSION,
-            preprocessRequest: (request) => {
+            preprocessRequest: (request, type) => {
+                clientType = type;
                 processedRequest = {
                     ...request,
                     ...processedRequest,
@@ -403,6 +405,7 @@ describe('Analytics', () => {
         const options: RequestInit = call[1];
 
         const {url: expectedUrl, ...expectedOptions} = processedRequest;
+        expect(clientType).toBe('fetch');
         expect(url).toBe(expectedUrl);
         expect(options).toEqual(expectedOptions);
     });

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -1,5 +1,9 @@
 import {IAnalyticsBeaconClientOptions} from './analyticsBeaconClient';
-import {AnalyticsFetchClient} from './analyticsFetchClient';
+import {
+    AnalyticsFetchClient,
+    IAnalyticsFetchClientOptions,
+    PreprocessAnalyticsRequestMiddleware,
+} from './analyticsFetchClient';
 import {
     AnyEventResponse,
     ClickEventRequest,
@@ -45,6 +49,7 @@ export interface ClientOptions {
     version: string;
     runtimeEnvironment?: IRuntimeEnvironment;
     beforeSendHooks: AnalyticsClientSendEventHook[];
+    preprocessRequestMiddleware?: PreprocessAnalyticsRequestMiddleware;
 }
 
 export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult | Promise<TResult>;
@@ -108,10 +113,11 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         this.beforeSendHooks = [enhanceViewEvent, addDefaultValues].concat(this.options.beforeSendHooks);
         this.eventTypeMapping = {};
 
-        const clientsOptions = {
+        const clientsOptions: IAnalyticsFetchClientOptions = {
             baseUrl: this.baseUrl,
             token: this.options.token,
             visitorIdProvider: this,
+            preprocessRequestMiddleware: this.options.preprocessRequestMiddleware,
         };
 
         this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -1,5 +1,5 @@
 import {IAnalyticsBeaconClientOptions} from './analyticsBeaconClient';
-import {AnalyticsFetchClient, IAnalyticsFetchClientOptions, PreprocessRequestMiddleware} from './analyticsFetchClient';
+import {AnalyticsFetchClient, IAnalyticsFetchClientOptions} from './analyticsFetchClient';
 import {
     AnyEventResponse,
     ClickEventRequest,
@@ -16,7 +16,7 @@ import {
     IRequestPayload,
     VariableArgumentsPayload,
 } from '../events';
-import {VisitorIdProvider} from './analyticsRequestClient';
+import {PreprocessRequest, VisitorIdProvider} from './analyticsRequestClient';
 import {hasWindow, hasDocument} from '../detector';
 import {addDefaultValues} from '../hook/addDefaultValues';
 import {enhanceViewEvent} from '../hook/enhanceViewEvent';
@@ -45,7 +45,7 @@ export interface ClientOptions {
     version: string;
     runtimeEnvironment?: IRuntimeEnvironment;
     beforeSendHooks: AnalyticsClientSendEventHook[];
-    preprocessRequestMiddleware?: PreprocessRequestMiddleware;
+    preprocessRequest?: PreprocessRequest;
 }
 
 export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult | Promise<TResult>;
@@ -113,7 +113,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             baseUrl: this.baseUrl,
             token: this.options.token,
             visitorIdProvider: this,
-            preprocessRequestMiddleware: this.options.preprocessRequestMiddleware,
+            preprocessRequest: this.options.preprocessRequest,
         };
 
         this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -16,7 +16,7 @@ import {
     IRequestPayload,
     VariableArgumentsPayload,
 } from '../events';
-import {PreprocessRequest, VisitorIdProvider} from './analyticsRequestClient';
+import {PreprocessAnalyticsRequest, VisitorIdProvider} from './analyticsRequestClient';
 import {hasWindow, hasDocument} from '../detector';
 import {addDefaultValues} from '../hook/addDefaultValues';
 import {enhanceViewEvent} from '../hook/enhanceViewEvent';
@@ -45,7 +45,7 @@ export interface ClientOptions {
     version: string;
     runtimeEnvironment?: IRuntimeEnvironment;
     beforeSendHooks: AnalyticsClientSendEventHook[];
-    preprocessRequest?: PreprocessRequest;
+    preprocessRequest?: PreprocessAnalyticsRequest;
 }
 
 export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult | Promise<TResult>;

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -1,9 +1,5 @@
 import {IAnalyticsBeaconClientOptions} from './analyticsBeaconClient';
-import {
-    AnalyticsFetchClient,
-    IAnalyticsFetchClientOptions,
-    PreprocessAnalyticsRequestMiddleware,
-} from './analyticsFetchClient';
+import {AnalyticsFetchClient, IAnalyticsFetchClientOptions, PreprocessRequestMiddleware} from './analyticsFetchClient';
 import {
     AnyEventResponse,
     ClickEventRequest,
@@ -49,7 +45,7 @@ export interface ClientOptions {
     version: string;
     runtimeEnvironment?: IRuntimeEnvironment;
     beforeSendHooks: AnalyticsClientSendEventHook[];
-    preprocessRequestMiddleware?: PreprocessAnalyticsRequestMiddleware;
+    preprocessRequestMiddleware?: PreprocessRequestMiddleware;
 }
 
 export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult | Promise<TResult>;

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -100,6 +100,7 @@ describe('AnalyticsBeaconClient', () => {
     });
 
     it('should preprocess the request with the preprocessRequest', async () => {
+        let clientType: string;
         const processedRequest: IAnalyticsRequestOptions = {
             url: 'https://www.myownanalytics.com/endpoint',
             body: JSON.stringify({
@@ -113,15 +114,17 @@ describe('AnalyticsBeaconClient', () => {
                 getCurrentVisitorId: () => {
                     return Promise.resolve(currentVisitorId);
                 },
-                setCurrentVisitorId: (visitorId) => {},
+                setCurrentVisitorId: () => {},
             },
-            preprocessRequest: () => {
+            preprocessRequest: (_request, type) => {
+                clientType = type;
                 return processedRequest;
             },
         });
 
         await client.sendEvent(EventType.collect, {});
 
+        expect(clientType).toBe('beacon');
         expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, processedRequest.body);
     });
 

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -1,6 +1,6 @@
 import {AnalyticsBeaconClient} from './analyticsBeaconClient';
 import {EventType} from '../events';
-import {IAnalyticsRequestOptions} from './analyticsRequestClient';
+import {AnalyticsClientOrigin, IAnalyticsRequestOptions} from './analyticsRequestClient';
 
 describe('AnalyticsBeaconClient', () => {
     const baseUrl = 'https://bloup.com';
@@ -100,7 +100,7 @@ describe('AnalyticsBeaconClient', () => {
     });
 
     it('should preprocess the request with the preprocessRequest', async () => {
-        let clientType: string;
+        let clientOrigin: AnalyticsClientOrigin;
         const processedRequest: IAnalyticsRequestOptions = {
             url: 'https://www.myownanalytics.com/endpoint',
             body: JSON.stringify({
@@ -117,14 +117,14 @@ describe('AnalyticsBeaconClient', () => {
                 setCurrentVisitorId: () => {},
             },
             preprocessRequest: (_request, type) => {
-                clientType = type;
+                clientOrigin = type;
                 return processedRequest;
             },
         });
 
         await client.sendEvent(EventType.collect, {});
 
-        expect(clientType).toBe('beacon');
+        expect(clientOrigin).toBe('analyticsBeacon');
         expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, processedRequest.body);
     });
 

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -1,5 +1,6 @@
 import {AnalyticsBeaconClient} from './analyticsBeaconClient';
 import {EventType} from '../events';
+import {IAnalyticsRequestOptions} from './analyticsRequestClient';
 
 describe('AnalyticsBeaconClient', () => {
     const baseUrl = 'https://bloup.com';
@@ -96,6 +97,32 @@ describe('AnalyticsBeaconClient', () => {
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
             `access_token=%F0%9F%91%9B&value=${encodeURIComponent(JSON.stringify({subvalue: 'ok'}))}`
         );
+    });
+
+    it('should preprocess the request with the preprocessRequest', async () => {
+        const processedRequest: IAnalyticsRequestOptions = {
+            url: 'https://www.myownanalytics.com/endpoint',
+            body: JSON.stringify({
+                test: 'custom',
+            }),
+        };
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                getCurrentVisitorId: () => {
+                    return Promise.resolve(currentVisitorId);
+                },
+                setCurrentVisitorId: (visitorId) => {},
+            },
+            preprocessRequest: () => {
+                return processedRequest;
+            },
+        });
+
+        await client.sendEvent(EventType.collect, {});
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, processedRequest.body);
     });
 
     const getSendBeaconFirstCallBlobArgument = async () => {

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -1,7 +1,7 @@
 import {
     AnalyticsRequestClient,
     VisitorIdProvider,
-    PreprocessRequest,
+    PreprocessAnalyticsRequest,
     IAnalyticsRequestOptions,
 } from './analyticsRequestClient';
 import {EventType, IRequestPayload} from '../events';
@@ -10,7 +10,7 @@ export interface IAnalyticsBeaconClientOptions {
     baseUrl: string;
     token?: string;
     visitorIdProvider: VisitorIdProvider;
-    preprocessRequest?: PreprocessRequest;
+    preprocessRequest?: PreprocessAnalyticsRequest;
 }
 
 export class AnalyticsBeaconClient implements AnalyticsRequestClient {

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -34,7 +34,7 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         };
         const {url, body}: IAnalyticsRequestOptions = {
             ...defaultOptions,
-            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'beacon') : {}),
+            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'analyticsBeacon') : {}),
         };
 
         // tslint:disable-next-line: no-console

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -34,7 +34,7 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         };
         const {url, body}: IAnalyticsRequestOptions = {
             ...defaultOptions,
-            ...(preprocessRequest ? await preprocessRequest(defaultOptions) : {}),
+            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'beacon') : {}),
         };
 
         // tslint:disable-next-line: no-console

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -30,7 +30,7 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
         };
         const {url, ...fetchData}: IAnalyticsRequestOptions = {
             ...defaultOptions,
-            ...(preprocessRequest ? await preprocessRequest(defaultOptions) : {}),
+            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'fetch') : {}),
         };
 
         const response = await fetch(url, fetchData);

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -2,7 +2,7 @@ import {
     AnalyticsRequestClient,
     VisitorIdProvider,
     IAnalyticsRequestOptions,
-    PreprocessRequest,
+    PreprocessAnalyticsRequest,
 } from './analyticsRequestClient';
 import {AnyEventResponse, EventType, IRequestPayload} from '../events';
 
@@ -10,7 +10,7 @@ export interface IAnalyticsFetchClientOptions {
     baseUrl: string;
     token?: string;
     visitorIdProvider: VisitorIdProvider;
-    preprocessRequest?: PreprocessRequest;
+    preprocessRequest?: PreprocessAnalyticsRequest;
 }
 
 export class AnalyticsFetchClient implements AnalyticsRequestClient {

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -12,7 +12,7 @@ export interface IAnalyticsFetchClientCallOptions {
     payload: Record<string, any>;
 }
 
-export type PreprocessAnalyticsRequestMiddleware = (
+export type PreprocessRequestMiddleware = (
     request: IAnalyticsFetchClientCallOptions
 ) => IAnalyticsFetchClientCallOptions | Promise<IAnalyticsFetchClientCallOptions>;
 
@@ -20,7 +20,7 @@ export interface IAnalyticsFetchClientOptions {
     baseUrl: string;
     token?: string;
     visitorIdProvider: VisitorIdProvider;
-    preprocessRequestMiddleware?: PreprocessAnalyticsRequestMiddleware;
+    preprocessRequestMiddleware?: PreprocessRequestMiddleware;
 }
 
 export class AnalyticsFetchClient implements AnalyticsRequestClient {

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -30,7 +30,7 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
         };
         const {url, ...fetchData}: IAnalyticsRequestOptions = {
             ...defaultOptions,
-            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'fetch') : {}),
+            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'analyticsFetch') : {}),
         };
 
         const response = await fetch(url, fetchData);

--- a/src/client/analyticsRequestClient.ts
+++ b/src/client/analyticsRequestClient.ts
@@ -8,3 +8,11 @@ export interface VisitorIdProvider {
 export interface AnalyticsRequestClient {
     sendEvent(eventType: string, payload: IRequestPayload): Promise<AnyEventResponse | void>;
 }
+
+export type PreprocessRequest = (
+    request: IAnalyticsRequestOptions
+) => IAnalyticsRequestOptions | Promise<IAnalyticsRequestOptions>;
+
+export interface IAnalyticsRequestOptions extends RequestInit {
+    url: string;
+}

--- a/src/client/analyticsRequestClient.ts
+++ b/src/client/analyticsRequestClient.ts
@@ -10,7 +10,8 @@ export interface AnalyticsRequestClient {
 }
 
 export type PreprocessRequest = (
-    request: IAnalyticsRequestOptions
+    request: IAnalyticsRequestOptions,
+    clientType: 'fetch' | 'beacon'
 ) => IAnalyticsRequestOptions | Promise<IAnalyticsRequestOptions>;
 
 export interface IAnalyticsRequestOptions extends RequestInit {

--- a/src/client/analyticsRequestClient.ts
+++ b/src/client/analyticsRequestClient.ts
@@ -11,7 +11,7 @@ export interface AnalyticsRequestClient {
 
 export type AnalyticsClientOrigin = 'analyticsFetch' | 'analyticsBeacon';
 
-export type PreprocessRequest = (
+export type PreprocessAnalyticsRequest = (
     request: IAnalyticsRequestOptions,
     clientOrigin: AnalyticsClientOrigin
 ) => IAnalyticsRequestOptions | Promise<IAnalyticsRequestOptions>;

--- a/src/client/analyticsRequestClient.ts
+++ b/src/client/analyticsRequestClient.ts
@@ -9,9 +9,11 @@ export interface AnalyticsRequestClient {
     sendEvent(eventType: string, payload: IRequestPayload): Promise<AnyEventResponse | void>;
 }
 
+export type AnalyticsClientOrigin = 'analyticsFetch' | 'analyticsBeacon';
+
 export type PreprocessRequest = (
     request: IAnalyticsRequestOptions,
-    clientType: 'fetch' | 'beacon'
+    clientOrigin: AnalyticsClientOrigin
 ) => IAnalyticsRequestOptions | Promise<IAnalyticsRequestOptions>;
 
 export interface IAnalyticsRequestOptions extends RequestInit {

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,4 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessAnalyticsRequest as PreprocessRequest} from '../client/analyticsRequestClient';
+export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export * as history from '../history';

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,4 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessRequest} from '../client/analyticsRequestClient';
+export {PreprocessAnalyticsRequest as PreprocessRequest} from '../client/analyticsRequestClient';
 export * as history from '../history';

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,4 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessRequestMiddleware} from '../client/analyticsFetchClient';
+export {PreprocessRequest} from '../client/analyticsRequestClient';
 export * as history from '../history';

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,3 +1,4 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
+export {PreprocessAnalyticsRequestMiddleware} from '../client/analyticsFetchClient';
 export * as history from '../history';

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,4 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessAnalyticsRequestMiddleware} from '../client/analyticsFetchClient';
+export {PreprocessRequestMiddleware} from '../client/analyticsFetchClient';
 export * as history from '../history';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -4,7 +4,7 @@ import * as history from '../history';
 import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessAnalyticsRequest as PreprocessRequest} from '../client/analyticsRequestClient';
+export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -4,7 +4,7 @@ import * as history from '../history';
 import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
-export {PreprocessRequest} from '../client/analyticsRequestClient';
+export {PreprocessAnalyticsRequest as PreprocessRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -4,6 +4,7 @@ import * as history from '../history';
 import * as SimpleAnalytics from './simpleanalytics';
 import * as storage from '../storage';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
+export {PreprocessRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-405 (used here https://github.com/coveo/ui-kit/pull/483)

We have this feature in the headless platform client, to allow to override request parameters such as headers, method, url, etc.

Currently coveo.analytics only allowed us to add hooks to change the events payload, but there was nothing to modify the request itself before sending it.

We currently have a customer who wants to remove an authorization header to proxy through their platform without hiccups.

