### PR TITLE
Add support for language in SearchPageClient

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -56,6 +56,7 @@ describe('SearchPageClient', () => {
         getOriginLevel1: () => 'origin-level-1',
         getOriginLevel2: () => 'origin-level-2',
         getOriginLevel3: () => 'origin-level-3',
+        getLanguage: () => 'en',
     };
 
     beforeEach(() => {
@@ -89,6 +90,7 @@ describe('SearchPageClient', () => {
             queryPipeline: 'my-pipeline',
             actionCause,
             customData,
+            language: 'en',
             ...expectOrigins(),
         });
     };
@@ -103,6 +105,7 @@ describe('SearchPageClient', () => {
             actionCause,
             customData,
             facetState,
+            language: 'en',
             ...expectOrigins(),
         });
     };
@@ -114,6 +117,7 @@ describe('SearchPageClient', () => {
             actionCause,
             customData,
             queryPipeline: 'my-pipeline',
+            language: 'en',
             ...doc,
             ...expectOrigins(),
         });
@@ -127,6 +131,7 @@ describe('SearchPageClient', () => {
             eventType: CustomEventsTypes[actionCause],
             lastSearchQueryUid: 'my-uid',
             customData,
+            language: 'en',
             ...expectOrigins(),
         });
     };
@@ -139,6 +144,7 @@ describe('SearchPageClient', () => {
             eventType,
             lastSearchQueryUid: 'my-uid',
             customData,
+            language: 'en',
             ...expectOrigins(),
         });
     };

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -262,7 +262,6 @@ export class CoveoSearchPageClient {
         const payload: ClickEventRequest = {
             ...info,
             ...this.getBaseEventRequest({...identifier, ...metadata}),
-            ...this.getOrigins(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -32,6 +32,7 @@ export interface SearchPageClientProvider {
     getOriginLevel1: () => string;
     getOriginLevel2: () => string;
     getOriginLevel3: () => string;
+    getLanguage: () => string;
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -229,11 +230,9 @@ export class CoveoSearchPageClient {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 
         const payload: CustomEventRequest = {
-            ...this.getOrigins(),
+            ...this.getBaseCustomEventRequest(customData),
             eventType: CustomEventsTypes[event]!,
             eventValue: event,
-            lastSearchQueryUid: this.provider.getSearchUID(),
-            customData,
         };
 
         return this.coveoAnalyticsClient.sendCustomEvent(payload);
@@ -243,11 +242,9 @@ export class CoveoSearchPageClient {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 
         const payload: CustomEventRequest = {
-            ...this.getOrigins(),
+            ...this.getBaseCustomEventRequest(customData),
             eventType,
             eventValue,
-            lastSearchQueryUid: this.provider.getSearchUID(),
-            customData,
         };
         return this.coveoAnalyticsClient.sendCustomEvent(payload);
     }
@@ -262,19 +259,13 @@ export class CoveoSearchPageClient {
         identifier: DocumentIdentifier,
         metadata?: Record<string, any>
     ) {
-        const customData = {
-            ...this.provider.getBaseMetadata(),
-            ...identifier,
-            ...metadata,
-        };
-
         const payload: ClickEventRequest = {
             ...info,
+            ...this.getBaseEventRequest({...identifier, ...metadata}),
             ...this.getOrigins(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,
-            customData,
         };
 
         return this.coveoAnalyticsClient.sendClickEvent(payload);
@@ -294,15 +285,28 @@ export class CoveoSearchPageClient {
     }
 
     private getBaseSearchEventRequest(event: SearchPageEvents, metadata?: Record<string, any>): SearchEventRequest {
-        const customData = {...this.provider.getBaseMetadata(), ...metadata};
-
         return {
+            ...this.getBaseEventRequest(metadata),
             ...this.provider.getSearchEventRequestPayload(),
-            ...this.getOrigins(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
-            customData,
             actionCause: event,
+        };
+    }
+
+    private getBaseCustomEventRequest(metadata?: Record<string, any>) {
+        return {
+            ...this.getBaseEventRequest(metadata),
+            lastSearchQueryUid: this.provider.getSearchUID(),
+        };
+    }
+
+    private getBaseEventRequest(metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        return {
+            ...this.getOrigins(),
+            customData,
+            language: this.provider.getLanguage(),
         };
     }
 


### PR DESCRIPTION
Need a way to specify the language if not available from the `addDefaultValues` function.

For example, when running in an environment different from a browser, `document.documentElement.lang` will never exists.

In a browser scenario, this will be null/undefined if the end users did not set `<html lang="foo">` in their markup.

Ref: https://coveord.atlassian.net/browse/KIT-447