### PR TITLE
SPAAS-647 Only minify browser bundle; remove sourcemaps from non-minifed bundles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
     "typescript.tsdk": "node_modules\\typescript\\lib",
     "files.exclude": {
         ".nyc_output": true,
-        "dist": true,
         "dist_test": true
     },
     "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -3003,12 +3003,6 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
-        "estree-walker": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-            "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-            "dev": true
-        },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7279,46 +7273,6 @@
                 }
             }
         },
-        "rollup-plugin-terser": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz",
-            "integrity": "sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "jest-worker": "^24.9.0",
-                "rollup-pluginutils": "^2.8.2",
-                "serialize-javascript": "^2.1.2",
-                "terser": "^4.6.2"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "jest-worker": {
-                    "version": "24.9.0",
-                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
-                    "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
-                    "dev": true,
-                    "requires": {
-                        "merge-stream": "^2.0.0",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "rollup-plugin-typescript2": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.27.0.tgz",
@@ -7458,15 +7412,6 @@
                         "has-flag": "^3.0.0"
                     }
                 }
-            }
-        },
-        "rollup-pluginutils": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-            "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-            "dev": true,
-            "requires": {
-                "estree-walker": "^0.6.1"
             }
         },
         "rsvp": {
@@ -8645,35 +8590,6 @@
             "requires": {
                 "ansi-escapes": "^4.2.1",
                 "supports-hyperlinks": "^2.0.0"
-            }
-        },
-        "terser": {
-            "version": "4.6.12",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.12.tgz",
-            "integrity": "sha512-fnIwuaKjFPANG6MAixC/k1TDtnl1YlPLUlLVIxxGZUn1gfUx2+l3/zGNB72wya+lgsb50QBi2tUV75RiODwnww==",
-            "dev": true,
-            "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "source-map-support": {
-                    "version": "0.5.19",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-                    "dev": true,
-                    "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
-                    }
-                }
             }
         },
         "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.7.3",
         "rollup-plugin-serve": "^1.0.1",
-        "rollup-plugin-terser": "^5.3.0",
         "rollup-plugin-typescript2": "^0.27.0",
         "rollup-plugin-uglify": "^6.0.4",
         "ts-jest": "^25.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,16 +8,20 @@ const tsPlugin = () =>
         useTsconfigDeclarationDir: true,
     });
 
-const umdConfig = (file) => ({
-    file,
+const umdConfig = {
     format: 'umd',
     name: 'coveoua',
-    sourcemap: true,
-});
+};
 
 const browser = {
     input: './src/coveoua/browser.ts',
-    output: [umdConfig('./dist/coveoua.js')],
+    output: [
+        {
+            ...umdConfig,
+            file: './dist/coveoua.js',
+            sourcemap: true,
+        },
+    ],
     plugins: [
         tsPlugin(),
         uglify(),
@@ -36,8 +40,13 @@ const browser = {
 
 const libUMD = {
     input: './src/coveoua/library.ts',
-    output: [umdConfig('./dist/library.js')],
-    plugins: [tsPlugin(), uglify()],
+    output: [
+        {
+            ...umdConfig,
+            file: './dist/library.js',
+        },
+    ],
+    plugins: [tsPlugin()],
 };
 
 const libESM = {
@@ -45,7 +54,6 @@ const libESM = {
     output: {
         file: './dist/library.es.js',
         format: 'es',
-        sourcemap: true,
     },
     plugins: [
         typescript({
@@ -60,7 +68,6 @@ const libRN = {
     output: {
         file: './dist/react-native.es.js',
         format: 'es',
-        sourcemap: true,
     },
     plugins: [
         typescript({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import typescript from 'rollup-plugin-typescript2';
 import {uglify} from 'rollup-plugin-uglify';
-import {terser} from 'rollup-plugin-terser';
 import serve from 'rollup-plugin-serve';
 
 const tsPlugin = () =>


### PR DESCRIPTION
**Background**

I am trying to bundle the coveo.analytics package inside IPX. However, I do not want Chrome to show this warning related to source maps:

![source-map_warning](https://user-images.githubusercontent.com/5565841/112197810-dc4f8200-8be2-11eb-9173-98f6f17d67bb.PNG)

**Problem**

By default, webpack tries to pull the file specified in the package.json `browser` field. This file should be minified and have a source map, since it is also served by CDN directly into browsers.

It is possible to configure webpack to use a different field such as `main` though. However, the file specified in the coveo.analytics `main` is also minified. This is not typical among open-source libs.

As far as I know, the best practice is to not minify non-browser files because they will be consumed by a bundler. This leaves it up to the consumer as to whether they want to minify the file and/or create source maps.

**Solution**

I adjusted rollup to no longer minify libUMD. I also removed source maps for this output, but also the `module` and `react-native` outputs for consistency.

Unrelated to the core issue, I adjusted the vscode configuration to show the `dist` folder, and removed a rollup plugin that was not being used.


