### PR TITLE
Extend mappings with coveo specific keys

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,10 @@
             "request": "launch",
             "name": "Launch Chrome against localhost",
             "url": "localhost:9001",
-            "webRoot": "${workspaceFolder}",
+            "webRoot": "${workspaceFolder}/src",
             "preLaunchTask": "dev",
             "sourceMapPathOverrides": {
-                "webpack:///./*": "${webRoot}/*",
-                "webpack:///src/*": "${webRoot}/*",
-                "webpack:///*": "*",
-                "webpack:///./~/*": "${webRoot}/node_modules/*",
-                "meteor://💻app/*": "${webRoot}/*"
+                "../src/*": "${webRoot}/*"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,10 +14,10 @@
                     "background": {
                         "activeOnStart": true,
                         "beginsPattern": {
-                            "regexp": "^.*Compiling....*$"
+                            "regexp": "^.*bundles./src/coveoua.*$"
                         },
                         "endsPattern": {
-                            "regexp": "^.*Compiled successfully.*$"
+                            "regexp": "^.*created dist/coveoua.*$"
                         }
                     }
                 },

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -510,8 +510,8 @@ describe('ec events', () => {
                 ...defaultContextValues,
                 pa: 'quote',
                 t: 'event',
-                id: 'something',
-                affiliation: 'my super store',
+                quoteId: 'something',
+                quoteAffiliation: 'my super store',
             });
         });
 
@@ -526,7 +526,7 @@ describe('ec events', () => {
                 ...defaultContextValues,
                 pa: 'quote',
                 t: 'event',
-                affiliation: 'super store',
+                quoteAffiliation: 'super store',
             });
         });
 
@@ -543,7 +543,7 @@ describe('ec events', () => {
                 ...defaultContextValues,
                 pa: 'review',
                 t: 'event',
-                id: 'something',
+                reviewId: 'something',
                 reviewRating: 5,
             });
         });

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -496,6 +496,76 @@ describe('ec events', () => {
         });
     });
 
+    describe('with the coveo extensions', () => {
+        it('can send a quote event with a specific id and affiliation', async () => {
+            await coveoua('ec:setAction', 'quote', {
+                id: 'something',
+                affiliation: 'my super store',
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'quote',
+                t: 'event',
+                id: 'something',
+                affiliation: 'my super store',
+            });
+        });
+
+        it('can send set an affiliation before defining the quote action', async () => {
+            coveoua('set', 'affiliation', 'super store');
+            await coveoua('ec:setAction', 'quote');
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'quote',
+                t: 'event',
+                affiliation: 'super store',
+            });
+        });
+
+        it('can send a review event with a specific id and reviewRating', async () => {
+            await coveoua('ec:setAction', 'review', {
+                id: 'something',
+                reviewRating: 5,
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'review',
+                t: 'event',
+                id: 'something',
+                reviewRating: 5,
+            });
+        });
+
+        it('can send a product with the group property', async () => {
+            await coveoua('ec:addProduct', {
+                id: 'something',
+                group: 'nsync',
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                t: 'event',
+                pr1id: 'something',
+                pr1group: 'nsync',
+            });
+        });
+    });
+
     const getParsedBody = (): any[] => {
         return fetchMock.calls().map(([, {body}]) => JSON.parse(body.toString()));
     };

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -496,6 +496,23 @@ describe('ec events', () => {
         });
     });
 
+    it('ignores properties that are specific to another action', async () => {
+        await coveoua('ec:setAction', 'purchase', {
+            id: 'something',
+            rating: '5/7',
+        });
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            pa: 'purchase',
+            t: 'event',
+            ti: 'something',
+        });
+    });
+
     describe('with the coveo extensions', () => {
         it('can send a quote event with a specific id and affiliation', async () => {
             await coveoua('ec:setAction', 'quote', {
@@ -515,7 +532,7 @@ describe('ec events', () => {
             });
         });
 
-        it('can send set an affiliation before defining the quote action', async () => {
+        it('can set an affiliation before defining the quote action', async () => {
             coveoua('set', 'affiliation', 'super store');
             await coveoua('ec:setAction', 'quote');
             await coveoua('send', 'event');

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -1,6 +1,7 @@
 import {isServiceKey, serviceActionsKeysMapping} from './measurementProtocolMapping/serviceMeasurementProtocolMapper';
 import {
-    commerceActionKeysMapping,
+    allCommerceActionKeysMapping,
+    commerceActionKeysMappingPerAction,
     isCommerceKey,
     isCustomCommerceKey,
 } from './measurementProtocolMapping/commerceMeasurementProtocolMapper';
@@ -9,13 +10,14 @@ import {baseMeasurementProtocolKeysMapping} from './measurementProtocolMapping/b
 
 const measurementProtocolKeysMapping: {[name: string]: string} = {
     ...baseMeasurementProtocolKeysMapping,
-    ...commerceActionKeysMapping,
+    ...allCommerceActionKeysMapping,
     ...serviceActionsKeysMapping,
 };
 
 export const convertKeysToMeasurementProtocol = (params: any) => {
     return keysOf(params).reduce((mappedKeys, key) => {
-        const newKey = measurementProtocolKeysMapping[key] || key;
+        const actionKey = !!params.action ? commerceActionKeysMappingPerAction[params.action]?.[key] : '';
+        const newKey = actionKey || measurementProtocolKeysMapping[key] || key;
         return {
             ...mappedKeys,
             [newKey]: params[key],

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -1,6 +1,5 @@
 import {isServiceKey, serviceActionsKeysMapping} from './measurementProtocolMapping/serviceMeasurementProtocolMapper';
 import {
-    allCommerceActionKeysMapping,
     commerceActionKeysMappingPerAction,
     isCommerceKey,
     isCustomCommerceKey,
@@ -10,14 +9,13 @@ import {baseMeasurementProtocolKeysMapping} from './measurementProtocolMapping/b
 
 const measurementProtocolKeysMapping: {[name: string]: string} = {
     ...baseMeasurementProtocolKeysMapping,
-    ...allCommerceActionKeysMapping,
     ...serviceActionsKeysMapping,
 };
 
 export const convertKeysToMeasurementProtocol = (params: any) => {
+    const keysMappingForAction = !!params.action ? commerceActionKeysMappingPerAction[params.action] : {};
     return keysOf(params).reduce((mappedKeys, key) => {
-        const actionKey = !!params.action ? commerceActionKeysMappingPerAction[params.action]?.[key] : '';
-        const newKey = actionKey || measurementProtocolKeysMapping[key] || key;
+        const newKey = keysMappingForAction[key] || measurementProtocolKeysMapping[key] || key;
         return {
             ...mappedKeys,
             [newKey]: params[key],

--- a/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -12,6 +12,8 @@ const productKeysMapping: {[key in keyof Product]: string} = {
     quantity: 'qt',
     coupon: 'cc',
     position: 'ps',
+    // Below are keys that were extended for Coveo
+    group: 'group',
 };
 
 const impressionKeysMapping: {[key in keyof BaseImpression]: string} = {
@@ -41,9 +43,58 @@ const transactionActionsKeysMapping: {[name: string]: string} = {
     option: 'col',
 };
 
-export const commerceActionKeysMapping: {[name: string]: string} = {
+const coveoCommerceExtensionKeys: string[] = [
+    'loyaltyCardNumber',
+    'loyaltyTier',
+    'thirdPartyPersona',
+    'companyName',
+    'favoriteStore',
+    'storeName',
+    'userIndustry',
+    'userRole',
+    'userDepartment',
+    'businessUnit',
+];
+
+const quoteActionsKeysMapping: {[name: string]: string} = {
+    id: 'id',
+    affiliation: 'affiliation',
+};
+
+const reviewActionsKeysMapping: {[name: string]: string} = {
+    id: 'id',
+    reviewRating: 'reviewRating',
+    reviewComment: 'reviewComment',
+};
+
+export const allCommerceActionKeysMapping: {[name: string]: string} = {
     ...productActionsKeysMapping,
     ...transactionActionsKeysMapping,
+};
+
+export const commerceActionKeysMappingPerAction: Record<string, {[name: string]: string}> = {
+    add: productActionsKeysMapping,
+    click: productActionsKeysMapping,
+    checkout: productActionsKeysMapping,
+    checkout_option: productActionsKeysMapping,
+    detail: productActionsKeysMapping,
+    remove: productActionsKeysMapping,
+    refund: {
+        ...productActionsKeysMapping,
+        ...transactionActionsKeysMapping,
+    },
+    purchase: {
+        ...productActionsKeysMapping,
+        ...transactionActionsKeysMapping,
+    },
+    quote: {
+        ...productActionsKeysMapping,
+        ...quoteActionsKeysMapping,
+    },
+    review: {
+        ...productActionsKeysMapping,
+        ...reviewActionsKeysMapping,
+    },
 };
 
 export const convertProductToMeasurementProtocol = (product: Product, index: number) => {
@@ -95,6 +146,8 @@ const convertImpressionToMeasurementProtocol = (
 
 const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
 const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
+const reviewKeysMappingValues = keysOf(reviewActionsKeysMapping).map((key) => reviewActionsKeysMapping[key]);
+const quoteKeysMappingValues = keysOf(quoteActionsKeysMapping).map((key) => quoteActionsKeysMapping[key]);
 
 const productSubKeysMatchGroup = [...productKeysMappingValues, 'custom'].join('|');
 const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, 'custom'].join('|');
@@ -104,9 +157,13 @@ const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeys
 const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
 const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
 const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
+const coveoCommerceExtensionKeysRegex = new RegExp(
+    `^(${[...coveoCommerceExtensionKeys, ...reviewKeysMappingValues, ...quoteKeysMappingValues].join('|')})$`
+);
 
 const isProductKey = (key: string) => productKeyRegex.test(key);
 const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
+const isCoveoCommerceExtensionKey = (key: string) => coveoCommerceExtensionKeysRegex.test(key);
 
-export const isCommerceKey = [isImpressionKey, isProductKey];
+export const isCommerceKey = [isImpressionKey, isProductKey, isCoveoCommerceExtensionKey];
 export const isCustomCommerceKey = [customProductKeyRegex, customImpressionKeyRegex];

--- a/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -43,6 +43,7 @@ const transactionActionsKeysMapping: {[name: string]: string} = {
     option: 'col',
 };
 
+// These extension keys do not have direct mappings, we are sending them as-is, thus only requiring an array.
 const coveoCommerceExtensionKeys: string[] = [
     'loyaltyCardNumber',
     'loyaltyTier',
@@ -57,19 +58,14 @@ const coveoCommerceExtensionKeys: string[] = [
 ];
 
 const quoteActionsKeysMapping: {[name: string]: string} = {
-    id: 'id',
-    affiliation: 'affiliation',
+    id: 'quoteId',
+    affiliation: 'quoteAffiliation',
 };
 
 const reviewActionsKeysMapping: {[name: string]: string} = {
-    id: 'id',
+    id: 'reviewId',
     reviewRating: 'reviewRating',
     reviewComment: 'reviewComment',
-};
-
-export const allCommerceActionKeysMapping: {[name: string]: string} = {
-    ...productActionsKeysMapping,
-    ...transactionActionsKeysMapping,
 };
 
 export const commerceActionKeysMappingPerAction: Record<string, {[name: string]: string}> = {
@@ -146,6 +142,7 @@ const convertImpressionToMeasurementProtocol = (
 
 const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
 const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
+const productActionsKeysMappingValues = keysOf(productActionsKeysMapping).map((key) => productActionsKeysMapping[key]);
 const reviewKeysMappingValues = keysOf(reviewActionsKeysMapping).map((key) => reviewActionsKeysMapping[key]);
 const quoteKeysMappingValues = keysOf(quoteActionsKeysMapping).map((key) => quoteActionsKeysMapping[key]);
 
@@ -155,6 +152,7 @@ const productPrefixMatchGroup = '(pr[0-9]+)';
 const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
 const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
 const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
+const productActionsKeyRegex = new RegExp(`^(${productActionsKeysMappingValues.join('|')})$`);
 const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
 const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
 const coveoCommerceExtensionKeysRegex = new RegExp(
@@ -163,7 +161,8 @@ const coveoCommerceExtensionKeysRegex = new RegExp(
 
 const isProductKey = (key: string) => productKeyRegex.test(key);
 const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
+const isProductActionsKey = (key: string) => productActionsKeyRegex.test(key);
 const isCoveoCommerceExtensionKey = (key: string) => coveoCommerceExtensionKeysRegex.test(key);
 
-export const isCommerceKey = [isImpressionKey, isProductKey, isCoveoCommerceExtensionKey];
+export const isCommerceKey = [isImpressionKey, isProductKey, isProductActionsKey, isCoveoCommerceExtensionKey];
 export const isCustomCommerceKey = [customProductKeyRegex, customImpressionKeyRegex];

--- a/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -45,7 +45,7 @@ const transactionActionsKeysMapping: {[name: string]: string} = {
 
 // These extension keys do not have direct mappings, we are sending them as-is, thus only requiring an array.
 const coveoCommerceExtensionKeys: string[] = [
-    'loyaltyCardNumber',
+    'loyaltyCardId',
     'loyaltyTier',
     'thirdPartyPersona',
     'companyName',
@@ -64,8 +64,8 @@ const quoteActionsKeysMapping: {[name: string]: string} = {
 
 const reviewActionsKeysMapping: {[name: string]: string} = {
     id: 'reviewId',
-    reviewRating: 'reviewRating',
-    reviewComment: 'reviewComment',
+    rating: 'reviewRating',
+    comment: 'reviewComment',
 };
 
 export const commerceActionKeysMappingPerAction: Record<string, {[name: string]: string}> = {
@@ -143,6 +143,9 @@ const convertImpressionToMeasurementProtocol = (
 const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
 const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
 const productActionsKeysMappingValues = keysOf(productActionsKeysMapping).map((key) => productActionsKeysMapping[key]);
+const transactionActionsKeysMappingValues = keysOf(transactionActionsKeysMapping).map(
+    (key) => transactionActionsKeysMapping[key]
+);
 const reviewKeysMappingValues = keysOf(reviewActionsKeysMapping).map((key) => reviewActionsKeysMapping[key]);
 const quoteKeysMappingValues = keysOf(quoteActionsKeysMapping).map((key) => quoteActionsKeysMapping[key]);
 
@@ -153,6 +156,7 @@ const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
 const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
 const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
 const productActionsKeyRegex = new RegExp(`^(${productActionsKeysMappingValues.join('|')})$`);
+const transactionActionsKeyRegex = new RegExp(`^(${transactionActionsKeysMappingValues.join('|')})$`);
 const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
 const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
 const coveoCommerceExtensionKeysRegex = new RegExp(
@@ -162,7 +166,14 @@ const coveoCommerceExtensionKeysRegex = new RegExp(
 const isProductKey = (key: string) => productKeyRegex.test(key);
 const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
 const isProductActionsKey = (key: string) => productActionsKeyRegex.test(key);
+const isTransactionActionsKeyRegex = (key: string) => transactionActionsKeyRegex.test(key);
 const isCoveoCommerceExtensionKey = (key: string) => coveoCommerceExtensionKeysRegex.test(key);
 
-export const isCommerceKey = [isImpressionKey, isProductKey, isProductActionsKey, isCoveoCommerceExtensionKey];
+export const isCommerceKey = [
+    isImpressionKey,
+    isProductKey,
+    isProductActionsKey,
+    isTransactionActionsKeyRegex,
+    isCoveoCommerceExtensionKey,
+];
 export const isCustomCommerceKey = [customProductKeyRegex, customImpressionKeyRegex];

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -24,7 +24,11 @@ export type CustomValues = {
     [key: string]: string | number | boolean;
 };
 
-export interface ProductProperties {
+export interface ProductCoveoExtensionProperties {
+    group?: string;
+}
+
+export interface ProductProperties extends ProductCoveoExtensionProperties {
     id?: string;
     name?: string;
     brand?: string;


### PR DESCRIPTION
This adds the new keys that should be accepted by our protocol.

I also noticed a small thing in our implementation.

The following code:

```
coveoua("ec:setAction", "detail", {
  affiliation: 'x'
});
```

would map `affiliation` to `ta` (transaction affiliation) because we were using a somewhat global key translation.

So with our new "review" and "quote", it would need to be translated to *another key* than `ta`. We had the same issue with `id`, which shares its key with many actions, but not their mapping.

So I went into the [Measurement Protocol doc](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#(product_action)_affiliation) and noticed the following for the `Affiliation` attribute:

> The store or affiliation from which this transaction occurred. This is an additional parameter that can be sent when Product Action is set to 'purchase' or 'refund'.

This means that some attributes are *not* global. They should only be set when a specific action is set. 

So I implemented this logic with the `commerceActionKeysMappingPerAction`.