### PR TITLE
Use proper jenkins team name [COM-814]

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -8,7 +8,7 @@
         "notifications": {
             "slack_channels": ["commerceteambuilds"]
         },
-        "team_jenkins": "commerceteambuilds"
+        "team_jenkins": "commercebuilds"
     },
     "package_rollout": {
         "only_consider_changesets_after": "688b6873442721d61e2a0ac492b9da808ddb0ef0"


### PR DESCRIPTION
`team_jenkins` refers to our jenkins instance. `commercebuilds` is the name of our jenkins instance, not `commerceteambuilds`. 

I _think_ the deployment pipeline didn't fail before because we never triggered a jobs on our jenkins instance.