### PR TITLE
Quote env vars properly [COM-814]

### DIFF
--- a/Jenkinsfile_FT
+++ b/Jenkinsfile_FT
@@ -26,7 +26,7 @@ pipeline {
   environment {
     CYPRESS_version = "${env.VERSION}"
     CYPRESS_endpoint = "${env.ENDPOINT}"
-    CYPRESS_targetEnv = targetEnv
+    CYPRESS_targetEnv = "${targetEnv}"
     BUILD_NODE_VERSION = 'NodeJS Latest'
     HOME = "${env.WORKSPACE}"
   }


### PR DESCRIPTION
Fixes:
```
WorkflowScript: 29: Environment variable values must either be single quoted, double quoted, or function calls. @ line 29, column 25.
       CYPRESS_targetEnv = targetEnv
                           ^
```
