### PR TITLE
feat: expose handleOneAnalyticsEvent to headless

### DIFF
--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,5 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
+export {handleOneAnalyticsEvent} from './simpleanalytics';
 export * as history from '../history';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-3742

In order to log the Usage Analytics events for Service from headless, we need to get access to the `handleOneAnalyticsEvent` function.

This PR, makes the function accessible.