### PR TITLE
fix(cypress): prevent health-check flakiness with retries

### DIFF
--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -11,5 +11,8 @@
         "mochaFile": "reports/junit-[hash].xml"
     },
     "viewportWidth": 1366,
-    "viewportHeight": 768
+    "viewportHeight": 768,
+    "retries": {
+        "runMode": 2
+    }
 }

--- a/cypress/package-lock.json
+++ b/cypress/package-lock.json
@@ -620,9 +620,9 @@
             }
         },
         "cypress": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.5.0.tgz",
-            "integrity": "sha512-ol/yTAqHrQQpYBjxLlRSvZf4DOb9AhaQNVlwdOZgJcBHZOOa52/p/6/p3PPcvzjWGOMG6Yq0z4G+jrbWyk/9Dg==",
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
+            "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
             "dev": true,
             "requires": {
                 "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -658,7 +658,7 @@
                 "moment": "^2.29.1",
                 "ospath": "^1.2.2",
                 "pretty-bytes": "^5.4.1",
-                "ramda": "~0.26.1",
+                "ramda": "~0.27.1",
                 "request-progress": "^3.0.0",
                 "supports-color": "^7.2.0",
                 "tmp": "~0.2.1",
@@ -785,9 +785,9 @@
             }
         },
         "eventemitter2": {
-            "version": "6.4.3",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
-            "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
+            "version": "6.4.4",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+            "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
             "dev": true
         },
         "eventemitter3": {
@@ -1211,9 +1211,9 @@
             }
         },
         "is-path-inside": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-            "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "dev": true
         },
         "is-promise": {
@@ -1232,6 +1232,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true
         },
         "isarray": {
@@ -1517,12 +1523,13 @@
             "dev": true
         },
         "log-symbols": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
             "requires": {
-                "chalk": "^4.0.0"
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
             }
         },
         "log-update": {
@@ -1585,18 +1592,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.45.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-            "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.28",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-            "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+            "version": "2.1.29",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.45.0"
+                "mime-db": "1.46.0"
             }
         },
         "mimic-fn": {
@@ -1821,9 +1828,9 @@
             }
         },
         "pretty-bytes": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
-            "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
             "dev": true
         },
         "process-nextick-args": {
@@ -1867,9 +1874,9 @@
             "dev": true
         },
         "ramda": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+            "version": "0.27.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+            "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
             "dev": true
         },
         "read-pkg": {
@@ -2092,9 +2099,9 @@
             }
         },
         "string-width": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-            "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
             "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "devDependencies": {
         "concurrently": "^5.3.0",
-        "cypress": "^6.5.0",
+        "cypress": "^6.8.0",
         "eslint-plugin-cypress": "^2.11.2",
         "http-server": "^0.12.3",
         "typescript": "^4.1.5"


### PR DESCRIPTION
[COM-953]

This simple config will *individually* retry all tests that fail. `2` means there will be 2 retries, so 3 total runs.

Each failure logs a screenshot.

I bumped the version, because why not

[COM-953]: https://coveord.atlassian.net/browse/COM-953