### PR TITLE
add getFacetState method to the SearchPageClientProvider

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1,6 +1,6 @@
 import * as fetchMock from 'fetch-mock';
 import {CoveoSearchPageClient, SearchPageClientProvider} from './searchPageClient';
-import {SearchPageEvents, PartialDocumentInformation, CustomEventsTypes, FacetStateMetadata} from './searchPageEvents';
+import {SearchPageEvents, PartialDocumentInformation, CustomEventsTypes} from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 
@@ -85,21 +85,7 @@ describe('SearchPageClient', () => {
             queryPipeline: 'my-pipeline',
             actionCause,
             customData,
-            language: 'en',
-            ...expectOrigins(),
-        });
-    };
-
-    const expectMatchFacetPayload = (actionCause: SearchPageEvents, meta = {}, facetState: FacetStateMetadata[]) => {
-        const [, {body}] = fetchMock.lastCall();
-        const customData = {foo: 'bar', ...meta};
-        expect(JSON.parse(body.toString())).toMatchObject({
-            queryText: 'queryText',
-            responseTime: 123,
-            queryPipeline: 'my-pipeline',
-            actionCause,
-            customData,
-            facetState,
+            facetState: fakeFacetState,
             language: 'en',
             ...expectOrigins(),
         });
@@ -293,7 +279,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         await client.logFacetSearch(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetSearch, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetSearch, meta);
     });
 
     it('should send proper payload for #logFacetSelect', async () => {
@@ -305,7 +291,7 @@ describe('SearchPageClient', () => {
         };
 
         await client.logFacetSelect(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetSelect, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetSelect, meta);
     });
 
     it('should send proper payload for #logFacetSelect', async () => {
@@ -317,7 +303,7 @@ describe('SearchPageClient', () => {
         };
 
         await client.logFacetDeselect(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetDeselect, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetDeselect, meta);
     });
 
     it('should send proper payload for #logFacetExclude', async () => {
@@ -328,7 +314,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         await client.logFacetExclude(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetExclude, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetExclude, meta);
     });
 
     it('should send proper payload for #logFacetUnexclude', async () => {
@@ -339,7 +325,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         await client.logFacetUnexclude(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetUnexclude, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
     });
 
     it('should send proper payload for #logFacetSelectAll', async () => {
@@ -349,7 +335,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         await client.logFacetSelectAll(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetSelectAll, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
     });
 
     it('should send proper payload for #logFacetUpdateSort', async () => {
@@ -360,7 +346,7 @@ describe('SearchPageClient', () => {
             criteria: 'bazz',
         };
         await client.logFacetUpdateSort(meta);
-        expectMatchFacetPayload(SearchPageEvents.facetUpdateSort, meta, fakeFacetState);
+        expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
     });
 
     it('should send proper payload for #logFacetShowMore', async () => {

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1,12 +1,6 @@
 import * as fetchMock from 'fetch-mock';
-import {CoveoSearchPageClient} from './searchPageClient';
-import {
-    SearchPageEvents,
-    PartialDocumentInformation,
-    DocumentIdentifier,
-    CustomEventsTypes,
-    FacetStateMetadata,
-} from './searchPageEvents';
+import {CoveoSearchPageClient, SearchPageClientProvider} from './searchPageClient';
+import {SearchPageEvents, PartialDocumentInformation, CustomEventsTypes, FacetStateMetadata} from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 
@@ -45,7 +39,7 @@ describe('SearchPageClient', () => {
 
     let client: CoveoSearchPageClient;
 
-    const provider = {
+    const provider: SearchPageClientProvider = {
         getBaseMetadata: () => ({foo: 'bar'}),
         getSearchEventRequestPayload: () => ({
             queryText: 'queryText',
@@ -57,6 +51,7 @@ describe('SearchPageClient', () => {
         getOriginLevel2: () => 'origin-level-2',
         getOriginLevel3: () => 'origin-level-3',
         getLanguage: () => 'en',
+        getFacetState: () => fakeFacetState,
     };
 
     beforeEach(() => {
@@ -297,7 +292,7 @@ describe('SearchPageClient', () => {
             facetId: 'bar',
             facetTitle: 'title',
         };
-        await client.logFacetSearch(meta, fakeFacetState);
+        await client.logFacetSearch(meta);
         expectMatchFacetPayload(SearchPageEvents.facetSearch, meta, fakeFacetState);
     });
 
@@ -309,7 +304,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
 
-        await client.logFacetSelect(meta, fakeFacetState);
+        await client.logFacetSelect(meta);
         expectMatchFacetPayload(SearchPageEvents.facetSelect, meta, fakeFacetState);
     });
 
@@ -321,7 +316,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
 
-        await client.logFacetDeselect(meta, fakeFacetState);
+        await client.logFacetDeselect(meta);
         expectMatchFacetPayload(SearchPageEvents.facetDeselect, meta, fakeFacetState);
     });
 
@@ -332,7 +327,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
             facetValue: 'qwerty',
         };
-        await client.logFacetExclude(meta, fakeFacetState);
+        await client.logFacetExclude(meta);
         expectMatchFacetPayload(SearchPageEvents.facetExclude, meta, fakeFacetState);
     });
 
@@ -343,7 +338,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
             facetValue: 'qwerty',
         };
-        await client.logFacetUnexclude(meta, fakeFacetState);
+        await client.logFacetUnexclude(meta);
         expectMatchFacetPayload(SearchPageEvents.facetUnexclude, meta, fakeFacetState);
     });
 
@@ -353,7 +348,7 @@ describe('SearchPageClient', () => {
             facetId: 'bar',
             facetTitle: 'title',
         };
-        await client.logFacetSelectAll(meta, fakeFacetState);
+        await client.logFacetSelectAll(meta);
         expectMatchFacetPayload(SearchPageEvents.facetSelectAll, meta, fakeFacetState);
     });
 
@@ -364,7 +359,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
             criteria: 'bazz',
         };
-        await client.logFacetUpdateSort(meta, fakeFacetState);
+        await client.logFacetUpdateSort(meta);
         expectMatchFacetPayload(SearchPageEvents.facetUpdateSort, meta, fakeFacetState);
     });
 

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -104,7 +104,7 @@ export class CoveoSearchPageClient {
     }
 
     public logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
-        return this.logFacetSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
+        return this.logSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
     }
 
     public logBreadcrumbResetAll() {
@@ -166,35 +166,35 @@ export class CoveoSearchPageClient {
     }
 
     public logFacetClearAll(meta: FacetBaseMeta) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetClearAll, meta);
+        return this.logSearchEvent(SearchPageEvents.facetClearAll, meta);
     }
 
     public logFacetSearch(meta: FacetBaseMeta) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSearch, meta);
+        return this.logSearchEvent(SearchPageEvents.facetSearch, meta);
     }
 
     public logFacetSelect(meta: FacetMetadata) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSelect, meta);
+        return this.logSearchEvent(SearchPageEvents.facetSelect, meta);
     }
 
     public logFacetDeselect(meta: FacetMetadata) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetDeselect, meta);
+        return this.logSearchEvent(SearchPageEvents.facetDeselect, meta);
     }
 
     public logFacetExclude(meta: FacetMetadata) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetExclude, meta);
+        return this.logSearchEvent(SearchPageEvents.facetExclude, meta);
     }
 
     public logFacetUnexclude(meta: FacetMetadata) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetUnexclude, meta);
+        return this.logSearchEvent(SearchPageEvents.facetUnexclude, meta);
     }
 
     public logFacetSelectAll(meta: FacetBaseMeta) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSelectAll, meta);
+        return this.logSearchEvent(SearchPageEvents.facetSelectAll, meta);
     }
 
     public logFacetUpdateSort(meta: FacetSortMeta) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetUpdateSort, meta);
+        return this.logSearchEvent(SearchPageEvents.facetUpdateSort, meta);
     }
 
     public logFacetShowMore(meta: FacetBaseMeta) {
@@ -266,10 +266,6 @@ export class CoveoSearchPageClient {
         };
 
         return this.coveoAnalyticsClient.sendClickEvent(payload);
-    }
-
-    public logFacetSearchEvent(event: SearchPageEvents, metadata: Record<string, any>) {
-        return this.coveoAnalyticsClient.sendSearchEvent(this.getBaseSearchEventRequest(event, metadata));
     }
 
     private getBaseSearchEventRequest(event: SearchPageEvents, metadata?: Record<string, any>): SearchEventRequest {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -33,6 +33,7 @@ export interface SearchPageClientProvider {
     getOriginLevel2: () => string;
     getOriginLevel3: () => string;
     getLanguage: () => string;
+    getFacetState?: () => FacetStateMetadata[];
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -102,11 +103,8 @@ export class CoveoSearchPageClient {
         return this.logSearchEvent(SearchPageEvents.searchboxAsYouType);
     }
 
-    public logBreadcrumbFacet(
-        metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata,
-        facetState: FacetStateMetadata[]
-    ) {
-        return this.logFacetSearchEvent(SearchPageEvents.breadcrumbFacet, metadata, facetState);
+    public logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
+        return this.logFacetSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
     }
 
     public logBreadcrumbResetAll() {
@@ -167,36 +165,36 @@ export class CoveoSearchPageClient {
         return this.logCustomEvent(SearchPageEvents.pagerScrolling);
     }
 
-    public logFacetClearAll(meta: FacetBaseMeta, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetClearAll, meta, facetState);
+    public logFacetClearAll(meta: FacetBaseMeta) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetClearAll, meta);
     }
 
-    public logFacetSearch(meta: FacetBaseMeta, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSearch, meta, facetState);
+    public logFacetSearch(meta: FacetBaseMeta) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetSearch, meta);
     }
 
-    public logFacetSelect(meta: FacetMetadata, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSelect, meta, facetState);
+    public logFacetSelect(meta: FacetMetadata) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetSelect, meta);
     }
 
-    public logFacetDeselect(meta: FacetMetadata, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetDeselect, meta, facetState);
+    public logFacetDeselect(meta: FacetMetadata) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetDeselect, meta);
     }
 
-    public logFacetExclude(meta: FacetMetadata, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetExclude, meta, facetState);
+    public logFacetExclude(meta: FacetMetadata) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetExclude, meta);
     }
 
-    public logFacetUnexclude(meta: FacetMetadata, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetUnexclude, meta, facetState);
+    public logFacetUnexclude(meta: FacetMetadata) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetUnexclude, meta);
     }
 
-    public logFacetSelectAll(meta: FacetBaseMeta, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetSelectAll, meta, facetState);
+    public logFacetSelectAll(meta: FacetBaseMeta) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetSelectAll, meta);
     }
 
-    public logFacetUpdateSort(meta: FacetSortMeta, facetState: FacetStateMetadata[]) {
-        return this.logFacetSearchEvent(SearchPageEvents.facetUpdateSort, meta, facetState);
+    public logFacetUpdateSort(meta: FacetSortMeta) {
+        return this.logFacetSearchEvent(SearchPageEvents.facetUpdateSort, meta);
     }
 
     public logFacetShowMore(meta: FacetBaseMeta) {
@@ -270,17 +268,8 @@ export class CoveoSearchPageClient {
         return this.coveoAnalyticsClient.sendClickEvent(payload);
     }
 
-    public logFacetSearchEvent(
-        event: SearchPageEvents,
-        metadata: Record<string, any>,
-        facetState: FacetStateMetadata[]
-    ) {
-        const payload = {
-            ...this.getBaseSearchEventRequest(event, metadata),
-            facetState,
-        };
-
-        return this.coveoAnalyticsClient.sendSearchEvent(payload);
+    public logFacetSearchEvent(event: SearchPageEvents, metadata: Record<string, any>) {
+        return this.coveoAnalyticsClient.sendSearchEvent(this.getBaseSearchEventRequest(event, metadata));
     }
 
     private getBaseSearchEventRequest(event: SearchPageEvents, metadata?: Record<string, any>): SearchEventRequest {
@@ -306,6 +295,7 @@ export class CoveoSearchPageClient {
             ...this.getOrigins(),
             customData,
             language: this.provider.getLanguage(),
+            facetState: this.provider.getFacetState ? this.provider.getFacetState() : [],
         };
     }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-589

Facet state should be sent all the time and not just on the facet specific events.
This was previously added here https://github.com/coveo/coveo.analytics.js/pull/235 and is still only used by headless as far as we know. I could make the parameters optional and deprecate them, if we worry about potentially breaking other implementations.