### PR TITLE
fix(ec): ensure that unknown actions work properly

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -115,6 +115,23 @@ describe('ec events', () => {
         });
     });
 
+    it('can send a product impression event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'impression');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'impression',
+        });
+    });
+
     it('can send a pageview event with options', async () => {
         await coveoua('send', 'pageview', 'page', {
             title: 'wow',
@@ -150,6 +167,22 @@ describe('ec events', () => {
             dt: 'wow',
             dl: 'http://right.here',
             verycustom: 'value',
+        });
+    });
+
+    it("doesn't crash when sending an unknown action", async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'bloup');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
         });
     });
 

--- a/src/client/measurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapper.ts
@@ -13,7 +13,7 @@ const measurementProtocolKeysMapping: {[name: string]: string} = {
 };
 
 export const convertKeysToMeasurementProtocol = (params: any) => {
-    const keysMappingForAction = !!params.action ? commerceActionKeysMappingPerAction[params.action] : {};
+    const keysMappingForAction = (!!params.action && commerceActionKeysMappingPerAction[params.action]) || {};
     return keysOf(params).reduce((mappedKeys, key) => {
         const newKey = keysMappingForAction[key] || measurementProtocolKeysMapping[key] || key;
         return {

--- a/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -74,6 +74,7 @@ export const commerceActionKeysMappingPerAction: Record<string, {[name: string]:
     checkout: productActionsKeysMapping,
     checkout_option: productActionsKeysMapping,
     detail: productActionsKeysMapping,
+    impression: productActionsKeysMapping,
     remove: productActionsKeysMapping,
     refund: {
         ...productActionsKeysMapping,


### PR DESCRIPTION
+ add impression as first-class action

[COM-986]

The `measurementProtocolMapper` was the actual issue, if the action was not supported, it would throw at `const newKey = keysMappingForAction[key] || measurementProtocolKeysMapping[key] || key;`. It is now tested with `doesn't crash when sending an unknown action`.

The `impression` line is to properly map the `impression` action. Without that, the `can send a product impression event` was failing because it didn't set the `pa` attribute

