### PR TITLE
feat(deploy): invalidate the cloudfront cache when deploying to prod

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -82,6 +82,18 @@
                     "directory": "coveo.analytics.js/$[PACKAGE_JSON_MAJOR_VERSION]"
                 }
             }
+        },
+        {
+            "id": "invalidate-cloudfront",
+            "terraform": {
+                "disabled": true,
+                "source": "terraform",
+                "prd": {
+                    "auto_approve": true,
+                    "auto_approve_in_production": true,
+                    "disabled": false
+                }
+            }
         }
     ],
     "deployment_config_version": 1,

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,6 @@ Jenkinsfile
 Jenkinsfile_FT
 Dockerfile
 *.sh
+
+# Deploy files
+terraform

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,8 @@ pipeline {
           def tgfResolveParameter = [
             "PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION=${env.PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION}",
             "PACKAGE_JSON_MAJOR_MINOR_VERSION=${env.PACKAGE_JSON_MAJOR_MINOR_VERSION}",
-            "PACKAGE_JSON_MAJOR_VERSION=${env.PACKAGE_JSON_MAJOR_VERSION}"
+            "PACKAGE_JSON_MAJOR_VERSION=${env.PACKAGE_JSON_MAJOR_VERSION}",
+            "TF_VAR_package_json_major_version=${env.PACKAGE_JSON_MAJOR_VERSION}"
           ]
           deploymentPackage.command(command: 'package create', parameters: [
             resolve: tgfResolveParameter,

--- a/terraform/.tgf.config
+++ b/terraform/.tgf.config
@@ -1,0 +1,1 @@
+docker-image-version: "3.13"

--- a/terraform/invalidate-cloudfront.tf
+++ b/terraform/invalidate-cloudfront.tf
@@ -1,0 +1,19 @@
+variable "package_json_major_version" {
+  description = "Defines the major version that has just been deployed"
+}
+
+data "aws_ssm_parameter" "svc_coveoanalyticsjs_secret" {
+  name = "/${var.env}/coveoanalyticsjs/svcAccountSecret"
+}
+
+resource "null_resource" "invalidate-cloudfront" {
+  provisioner "local-exec" {
+    command = "aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths \"/coveo.analytics.js/${var.package_json_major_version}/*\""
+
+    environment = {
+      CLOUDFRONT_DISTRIBUTION_ID="E2VWLFSCSD1GLA"
+      AWS_ACCESS_KEY_ID="AKIAYKDJLZITZZKEN7WY"
+      AWS_SECRET_ACCESS_KEY=data.aws_ssm_parameter.svc_coveoanalyticsjs_secret
+    }
+  }
+}


### PR DESCRIPTION
[COM-956]

Alright so I consider this pretty experimental :sweat_smile: I have no idea if this will _really_ work

There is no terraform for CloudFront invalidation because they are mostly "one-shot" things, you never need to create or destroy them, really, they have no real state to keep track of.

Things that I am really not sure:

* Running the `aws` command like that.
* Whether the `TF_VAR_package_json_major_version` will be properly injected in the phase
* Whether the environment variables are properly defined for the was command

So huh... feedback is appreciated :sweat: 

[COM-956]: https://coveord.atlassian.net/browse/COM-956