### PR TITLE
[COM-971] add getParameters and getPayload to analyticsClient

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -1,7 +1,11 @@
 import 'isomorphic-fetch';
 import * as fetchMock from 'fetch-mock';
 import {DefaultEventResponse} from '../src/events';
+import type {getCurrentClient} from "../src/coveoua/library";
 import coveoua from '../src/coveoua/browser';
+
+declare const self: any;
+const getClient: typeof getCurrentClient = (self.coveoanalytics as any).getCurrentClient;
 
 describe('ec events', () => {
     const initialLocation = `${window.location}`;
@@ -28,6 +32,8 @@ describe('ec events', () => {
         z: expect.stringMatching(guidFormat),
     };
 
+    let client: ReturnType<typeof getClient>;
+
     beforeEach(() => {
         changeDocumentLocation(initialLocation);
         const address = `${anEndpoint}/rest/v15/analytics/collect`;
@@ -42,6 +48,7 @@ describe('ec events', () => {
         });
         coveoua('reset');
         coveoua('init', aToken, anEndpoint);
+        client = getClient();
     });
 
     it('can set custom data at the root level and send a page view event', async () => {
@@ -194,6 +201,174 @@ describe('ec events', () => {
         expect(secondPageView.dr).toBe(initialLocation);
         expect(afterSecond.dl).toBe(secondLocation);
         expect(afterSecond.dr).toBe(initialLocation);
+    });
+
+    it('should return the same payload', async () => {
+        const secondLocation = 'http://very.new/';
+
+        const firstPayload = await client.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondPayload = await client.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        const firstAfterPayload = await client.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondAfterPayload = await client.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+
+        const firstPayloadToCompare = returnCommonAttributes(firstPayload, ["tm", "z"]);
+        const secondPayloadToCompare = returnCommonAttributes(secondPayload, ["tm", "z"]);
+        const firstAfterPayloadToCompare = returnCommonAttributes(firstAfterPayload, ["tm", "z"]);
+        const secondAfterPayloadToCompare = returnCommonAttributes(secondAfterPayload, ["tm", "z"]);
+
+        expect(firstPayloadToCompare).toEqual(secondPayloadToCompare);
+        expect(firstPayloadToCompare.dl).toBe(initialLocation);
+        expect(firstPayloadToCompare.dr).toBe(document.referrer);
+
+        expect(firstAfterPayloadToCompare).toEqual(secondAfterPayloadToCompare);
+        expect(firstAfterPayloadToCompare.dl).toBe(secondLocation);
+        expect(firstAfterPayloadToCompare.dr).toBe(initialLocation);
+    });
+
+    it('should return the same parameters', async () => {
+        const secondLocation = 'http://very.new/';
+
+        const firstParameters = await client.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondParameters = await client.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        const firstAfterParameters = await client.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondAfterParameters = await client.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+
+        const firstParametersToCompare = returnCommonAttributes(firstParameters, ["time", "eventId"]);
+        const secondParametersToCompare = returnCommonAttributes(secondParameters, ["time", "eventId"]);
+        const firstAfterParametersToCompare = returnCommonAttributes(firstAfterParameters, ["time", "eventId"]);
+        const secondAfterParametersToCompare = returnCommonAttributes(secondAfterParameters, ["time", "eventId"]);
+
+        expect(firstParametersToCompare).toEqual(secondParametersToCompare);
+        expect(firstParametersToCompare.location).toBe(initialLocation);
+        expect(firstParametersToCompare.referrer).toBe(document.referrer);
+
+        expect(firstAfterParametersToCompare).toEqual(secondAfterParametersToCompare);
+        expect(firstAfterParametersToCompare.location).toBe(secondLocation);
+        expect(firstAfterParametersToCompare.referrer).toBe(initialLocation);
+    });
+
+    it('should return similar parameters and payload', async () => {
+        const parameters = await client.getParameters('pageview', {});
+        const payload = await client.getPayload('pageview', {});
+
+        const firstParametersToCompare = returnCommonAttributes(parameters, ["time", "eventId"]);
+
+        expect(firstParametersToCompare).toEqual({
+            hitType: payload.t,
+            pageViewId: payload.pid,
+            encoding: payload.de,
+            location: payload.dl,
+            referrer: payload.dr,
+            screenColor: payload.sd,
+            screenResolution: payload.sr,
+            title: payload.dt,
+            userAgent: payload.ua,
+            language: payload.ul,
+            visitorId: payload.cid
+        });
+    });
+
+    it('should return similar parameters and send', async () => {
+        const firstParameters = await client.getParameters('pageview', {});
+        await coveoua('send', 'pageview');
+        const secondParameters = await client.getParameters('pageview', {});
+        await coveoua('send', 'pageview');
+
+        const [pageView, secondPageView] = getParsedBody();
+
+        const firstParametersToCompare = returnCommonAttributes(firstParameters, ["time", "eventId"]);
+        const secondParametersToCompare = returnCommonAttributes(secondParameters, ["time", "eventId"]);
+
+        expect(firstParametersToCompare).toEqual({
+            hitType: pageView.t,
+            pageViewId: pageView.pid,
+            encoding: pageView.de,
+            location: pageView.dl,
+            referrer: pageView.dr,
+            screenColor: pageView.sd,
+            screenResolution: pageView.sr,
+            title: pageView.dt,
+            userAgent: pageView.ua,
+            language: pageView.ul,
+            visitorId: pageView.cid
+        });
+
+        expect(secondParametersToCompare).toEqual({
+            hitType: secondPageView.t,
+            pageViewId: secondPageView.pid,
+            encoding: secondPageView.de,
+            location: secondPageView.dl,
+            referrer: secondPageView.dr,
+            screenColor: secondPageView.sd,
+            screenResolution: secondPageView.sr,
+            title: secondPageView.dt,
+            userAgent: secondPageView.ua,
+            language: secondPageView.ul,
+            visitorId: secondPageView.cid
+        });
+    });
+
+    it('should return similar payload and send', async () => {
+        const firstPayload = await client.getPayload('pageview', {});
+        await coveoua('send', 'pageview');
+        const secondPayload = await client.getPayload('pageview', {});
+        await coveoua('send', 'pageview');
+
+        const [pageView, secondPageView] = getParsedBody();
+
+        const firstPayloadToCompare = returnCommonAttributes(firstPayload, ["tm", "z"]);
+        const secondPayloadToCompare = returnCommonAttributes(secondPayload, ["tm", "z"]);
+
+        const pageViewToCompare = returnCommonAttributes(pageView, ["tm", "z"]);
+
+        const secondPageViewToCompare = returnCommonAttributes(secondPageView, ["tm", "z"]);
+
+        expect(firstPayloadToCompare).toEqual(pageViewToCompare);
+        expect(secondPayloadToCompare).toEqual(secondPageViewToCompare);
     });
 
     it('should update the current location when a pageview is sent with the page parameter and keep it', async () => {
@@ -593,4 +768,9 @@ describe('ec events', () => {
         // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.
         window.location = new URL(url);
     };
+
+    const returnCommonAttributes = <T>(payload: T, attributesToRemove: Array<keyof T>) => {
+        attributesToRemove.forEach(attribute => delete payload[attribute]);
+        return payload;
+    }
 });

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -11,6 +11,12 @@ import {
 import {NoopRuntime} from './runtimeEnvironment';
 
 export class NoopAnalytics implements AnalyticsClient {
+    getPayload(): Promise<any> {
+        return Promise.resolve();
+    }
+    getParameters(): Promise<any> {
+        return Promise.resolve();
+    }
     sendEvent(): Promise<AnyEventResponse | void> {
         return Promise.resolve();
     }
@@ -33,6 +39,7 @@ export class NoopAnalytics implements AnalyticsClient {
         return Promise.resolve({status: ''});
     }
     registerBeforeSendEventHook(): void {}
+    registerAfterSendEventHook(): void {}
     addEventTypeMapping(): void {}
     runtime = new NoopRuntime();
     currentVisitorId = '';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -6,7 +6,7 @@ import * as storage from '../storage';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
-export {CoveoUA, handleOneAnalyticsEvent} from './simpleanalytics';
+export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -13,7 +13,7 @@ export interface CoveoUAOptions {
 
 // CoveoUA mimics the GoogleAnalytics API.
 export class CoveoUA {
-    private client?: AnalyticsClient;
+    public client?: AnalyticsClient;
     private plugins: Plugins = new Plugins();
     private params: {[name: string]: string} = {};
 
@@ -139,6 +139,7 @@ export class CoveoUA {
 }
 
 export const coveoua = new CoveoUA();
+export const getCurrentClient = () => coveoua.client;
 
 export const handleOneAnalyticsEvent = (command: string, ...params: any[]) => {
     const [, trackerName, pluginName, fn] = /^(?:(\w+)\.)?(?:(\w+):)?(\w+)$/.exec(command)!;

--- a/src/events.ts
+++ b/src/events.ts
@@ -14,6 +14,7 @@ export interface SearchDocument {
 }
 
 export type SendEventArguments = [EventType, ...any[]];
+
 export type VariableArgumentsPayload =
     | []
     | [any]

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -22,15 +22,17 @@ export abstract class BasePlugin {
     protected action?: string;
     protected actionData: {[name: string]: string} = {};
     private pageViewId: string;
+    private nextPageViewId: string;
     private hasSentFirstPageView?: boolean;
-    private lastLocation: string;
+    private currentLocation: string;
     private lastReferrer: string;
 
     constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
         this.client = client;
         this.uuidGenerator = uuidGenerator;
         this.pageViewId = uuidGenerator();
-        this.lastLocation = getFormattedLocation(window.location);
+        this.nextPageViewId = this.pageViewId;
+        this.currentLocation = getFormattedLocation(window.location);
         this.lastReferrer = document.referrer;
 
         this.addHooks();
@@ -51,18 +53,17 @@ export abstract class BasePlugin {
     }
 
     public getLocationInformation(eventType: string, payload: any) {
-        eventType === BasePluginEventTypes.pageview && this.updateStateForNewPageView(payload);
         return {
-            referrer: this.lastReferrer,
-            location: this.lastLocation,
+            hitType: eventType,
+            ...this.getNextValues(eventType, payload),
         };
     }
 
+    public updateLocationInformation(eventType: string, payload: any) {
+        this.updateLocationForNextPageView(eventType, payload);
+    }
+
     public getDefaultContextInformation(eventType: string) {
-        const pageContext = {
-            hitType: eventType,
-            pageViewId: this.pageViewId,
-        };
         const documentContext = {
             title: document.title,
             encoding: document.characterSet,
@@ -80,7 +81,6 @@ export abstract class BasePlugin {
             eventId: this.uuidGenerator(),
         };
         return {
-            ...pageContext,
             ...eventContext,
             ...screenContext,
             ...navigatorContext,
@@ -88,20 +88,45 @@ export abstract class BasePlugin {
         };
     }
 
-    private updateStateForNewPageView(payload: any) {
-        if (this.hasSentFirstPageView) {
-            this.pageViewId = this.uuidGenerator();
-            this.lastReferrer = this.lastLocation;
-        }
+    private updateLocationForNextPageView(eventType: string, payload: any) {
+        const {pageViewId, referrer, location} = this.getNextValues(eventType, payload);
 
-        if (!!payload.page) {
-            const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
-            const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
-            this.lastLocation = `${extractHostnamePart(this.lastLocation)}${removeStartingSlash(payload.page)}`;
-        } else {
-            this.lastLocation = getFormattedLocation(window.location);
+        this.lastReferrer = referrer;
+        this.pageViewId = pageViewId;
+        this.currentLocation = location;
+
+        if (eventType === BasePluginEventTypes.pageview) {
+            this.nextPageViewId = this.uuidGenerator();
         }
 
         this.hasSentFirstPageView = true;
+    }
+
+    /* 
+        When calling getPayload or getParameters, we need to return what would be sent by the API without updating our internal reference. 
+        For instance, if you getPayload("pageview"), we want to return the same payload as if you did coveoua("send", "pageview").
+    */
+    private getNextValues(eventType: string, payload: any) {
+        /*
+            When sending a pageview, we need to generate a new pageview ID.
+            For instance, with the following sequence: 1. pageview, 2. event, 3. pageview, 4. event, 1 and 2 will have the pageviewid, whereas 3 and 4 will have a different pageviewid.
+            We pre-generate the "nextPageViewId" in case you send the following sequence: 1. pageview, 2. event, 3. getPayload, 4. pageview. This ensures that 3 and 4 have the same pageviewid.
+            We applied the same logic to the referrer and the location.
+        */
+        return {
+            pageViewId: eventType === BasePluginEventTypes.pageview ? this.nextPageViewId : this.pageViewId,
+            referrer: eventType === BasePluginEventTypes.pageview && this.hasSentFirstPageView ? this.currentLocation : this.lastReferrer,
+            location: eventType === BasePluginEventTypes.pageview ? this.getCurrentLocationFromPayload(payload) : this.currentLocation,
+        }
+    }
+
+    private getCurrentLocationFromPayload(payload: any) {
+        if (!!payload.page) {
+            const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
+            const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
+            return `${extractHostnamePart(this.currentLocation)}${removeStartingSlash(payload.page)}`;
+        } else {
+            return getFormattedLocation(window.location);
+        }
     }
 }

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -11,7 +11,7 @@ describe('EC plugin', () => {
         pageViewId: someUUID,
         encoding: document.characterSet,
         location: 'http://localhost/',
-        referrer: 'http://somewhere.over/therainbow',
+        referrer: 'http://somewhere.over/thereferrer',
         title: 'MAH PAGE',
         screenColor: '24-bit',
         screenResolution: '0x0',
@@ -474,13 +474,13 @@ describe('EC plugin', () => {
         expect(someUUIDGenerator).toHaveBeenCalledTimes(1 + 3);
     });
 
-    it('should update the location when sending a pageview with the page parameter', async () => {
+    it('should update the location when sending a pageview with the page parameter', () => {
         const payload = {
             page: '/somepage',
         };
 
-        const pageview = await executeRegisteredHook(ECPluginEventTypes.pageview, payload);
-        const event = await executeRegisteredHook(ECPluginEventTypes.event, {});
+        const pageview = executeRegisteredHook(ECPluginEventTypes.pageview, payload);
+        const event = executeRegisteredHook(ECPluginEventTypes.event, {});
 
         expect(pageview).toEqual({
             ...defaultResult,
@@ -496,7 +496,10 @@ describe('EC plugin', () => {
     });
 
     const executeRegisteredHook = (eventType: string, payload: any) => {
-        const [hook] = client.registerBeforeSendEventHook.mock.calls[0];
-        return hook(eventType, payload);
+        const [beforeHook] = client.registerBeforeSendEventHook.mock.calls[0];
+        const [afterHook] = client.registerAfterSendEventHook.mock.calls[0];
+        const result = beforeHook(eventType, payload);
+        afterHook(eventType, result);
+        return result;
     };
 });

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -94,6 +94,12 @@ export class ECPlugin extends BasePlugin {
         this.client.registerBeforeSendEventHook((eventType, ...[payload]) => {
             return allECEventTypes.indexOf(eventType) !== -1 ? this.addECDataToPayload(eventType, payload) : payload;
         });
+        this.client.registerAfterSendEventHook((eventType, ...[payload]) => {
+            if (allECEventTypes.indexOf(eventType) !== -1) {
+                this.updateLocationInformation(eventType, payload);
+            };
+            return payload;
+        });
     }
 
     private addHooksForPageView() {

--- a/src/plugins/svc.spec.ts
+++ b/src/plugins/svc.spec.ts
@@ -11,7 +11,7 @@ describe('SVC plugin', () => {
         pageViewId: someUUID,
         encoding: document.characterSet,
         location: 'http://localhost/',
-        referrer: 'http://somewhere.over/therainbow',
+        referrer: 'http://somewhere.over/thereferrer',
         title: 'MAH PAGE',
         screenColor: '24-bit',
         screenResolution: '0x0',
@@ -175,7 +175,10 @@ describe('SVC plugin', () => {
     });
 
     const executeRegisteredHook = (eventType: string, payload: any) => {
-        const [hook] = client.registerBeforeSendEventHook.mock.calls[0];
-        return hook(eventType, payload);
+        const [beforeHook] = client.registerBeforeSendEventHook.mock.calls[0];
+        const [afterHook] = client.registerAfterSendEventHook.mock.calls[0];
+        const result = beforeHook(eventType, payload);
+        afterHook(eventType, result);
+        return result;
     };
 });

--- a/src/plugins/svc.ts
+++ b/src/plugins/svc.ts
@@ -52,6 +52,12 @@ export class SVCPlugin extends BasePlugin {
         this.client.registerBeforeSendEventHook((eventType, ...[payload]) => {
             return allSVCEventTypes.indexOf(eventType) !== -1 ? this.addSVCDataToPayload(eventType, payload) : payload;
         });
+        this.client.registerAfterSendEventHook((eventType, ...[payload]) => {
+            if (allSVCEventTypes.indexOf(eventType) !== -1) {
+                this.updateLocationInformation(eventType, payload);
+            };
+            return payload;
+        });
     }
 
     private addHooksForPageView() {

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -2,6 +2,8 @@ import {AnalyticsClient} from '../src/client/analytics';
 import {NoopRuntime} from '../src/client/runtimeEnvironment';
 
 export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
+    getPayload: jest.fn((eventType, ...payload) => Promise.resolve()),
+    getParameters: jest.fn((eventType, ...payload) => Promise.resolve()),
     sendEvent: jest.fn((eventType, payload) => Promise.resolve()),
     sendClickEvent: jest.fn((request) => Promise.resolve()),
     sendCustomEvent: jest.fn((request) => Promise.resolve()),
@@ -11,6 +13,7 @@ export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),
     addEventTypeMapping: jest.fn(),
     registerBeforeSendEventHook: jest.fn(),
+    registerAfterSendEventHook: jest.fn(),
     runtime: new NoopRuntime(),
     currentVisitorId: '',
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -4,7 +4,7 @@ global.crypto = {
 };
 
 const documentMock = {
-    referrer: 'http://somewhere.over/therainbow',
+    referrer: 'http://somewhere.over/thereferrer',
     title: 'MAH PAGE',
     characterSet: 'UTF-8',
 };


### PR DESCRIPTION
Big shoutout to **Frank** for all the help! 

Split the `sendEvent()` to be able to get both parameters (non altered info) and payload.
From the browser, if you run `window.coveoanalytics.getCurrentClient().getParameters('event', {});` you should get an output.

<img width="750" alt="Screen Shot 2021-04-22 at 4 12 44 PM" src="https://user-images.githubusercontent.com/61028694/115779131-945c8000-a385-11eb-90c2-369276a5f16c.png">

<img width="750" alt="Screen Shot 2021-04-22 at 4 13 21 PM" src="https://user-images.githubusercontent.com/61028694/115779196-aa6a4080-a385-11eb-9bb1-6cf1f8166365.png">
