### PR TITLE
SPAAS-716 Add SameSite=Lax when setting cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "build": "rollup -c",
         "start": "rollup -c -w --environment SERVE",
         "test": "jest --clearCache && jest --coverage",
+        "test:watch": "jest --watch",
         "prepare-deploy": "mkdir -p deploy && cp dist/coveoua.js dist/coveoua.js.map deploy",
         "clean": "rimraf -rf dist dist_test coverage"
     },

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -1,3 +1,10 @@
+interface ICookieDetails {
+    name: string;
+    value: string;
+    expires: string;
+    domain: string;
+}
+
 // Code originally taken from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
 export class Cookie {
     static set(name: string, value: string, expiration?: number) {
@@ -29,14 +36,14 @@ export class Cookie {
             domainParts.shift();
             domain = '.' + domainParts.join('.');
 
-            document.cookie = name + '=' + value + expires + '; path=/; domain=' + domain;
+            writeCookie({name, value, expires, domain});
 
             // check if cookie was successfuly set to the given domain
             // (otherwise it was a Top-Level Domain)
             if (Cookie.get(name) == null || Cookie.get(name) != value) {
                 // append "." to current domain
                 domain = '.' + host;
-                document.cookie = name + '=' + value + expires + '; path=/; domain=' + domain;
+                writeCookie({name, value, expires, domain});
             }
         }
     }
@@ -58,4 +65,9 @@ export class Cookie {
     static erase(name: string) {
         Cookie.set(name, '', -1);
     }
+}
+
+function writeCookie(details: ICookieDetails) {
+    const {name, value, expires, domain} = details;
+    document.cookie = `${name}=${value}${expires}; path=/; domain=${domain}; SameSite=None; Secure`;
 }

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -1,4 +1,4 @@
-interface ICookieDetails {
+interface CookieDetails {
     name: string;
     value: string;
     expires: string;
@@ -67,7 +67,7 @@ export class Cookie {
     }
 }
 
-function writeCookie(details: ICookieDetails) {
+function writeCookie(details: CookieDetails) {
     const {name, value, expires, domain} = details;
     document.cookie = `${name}=${value}${expires}; path=/; domain=${domain}; SameSite=Lax`;
 }

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -69,5 +69,5 @@ export class Cookie {
 
 function writeCookie(details: ICookieDetails) {
     const {name, value, expires, domain} = details;
-    document.cookie = `${name}=${value}${expires}; path=/; domain=${domain}; SameSite=None; Secure`;
+    document.cookie = `${name}=${value}${expires}; path=/; domain=${domain}; SameSite=Lax`;
 }

--- a/src/storage.spec.ts
+++ b/src/storage.spec.ts
@@ -10,7 +10,7 @@ describe('CookieStorage', () => {
         expect(storage.getItem(key)).toBe(someData);
     });
 
-    test('removeItem removes the cookie', () => {
+    it('removeItem removes the cookie', () => {
         const storage = new CookieStorage();
         storage.setItem(key, someData);
         storage.removeItem(key);
@@ -35,7 +35,7 @@ describe('CookieAndLocalStorage', () => {
         expect(localStorage.getItem(key)).toBe(someData);
     });
 
-    test('removeItem removes the cookie and local storage', () => {
+    it('removeItem removes the cookie and local storage', () => {
         storage.setItem(key, someData);
         storage.removeItem(key);
 


### PR DESCRIPTION
There was a change to the cookie spec in the past year, adding the [SameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) attribute to better protect cookies from being used maliciously.

When the attribute is not set, browsers such as Firefox show the following warning in the console:

![firefox_same-site_warning](https://user-images.githubusercontent.com/5565841/116736279-ab225880-a9bd-11eb-8633-e27bd0562db8.PNG)


It took me some time to figure out, but since the cookie is first-party (i.e associated with the customer's domain), I am 99% sure that `Lax` is the correct value, allowing scripts like IPX to read the value on first load.

