### PR TITLE
COM-965 - Found the right TF structure this time

### DIFF
--- a/.terragrunt.hcl
+++ b/.terragrunt.hcl
@@ -1,0 +1,3 @@
+inputs = {
+    project = "coveo.analytics.js"
+}

--- a/terraform/.terragrunt.hcl
+++ b/terraform/.terragrunt.hcl
@@ -1,3 +1,3 @@
-inputs = {
-    project = "coveo.analytics.js"
+include {
+  path = find_in_parent_folders()
 }


### PR DESCRIPTION
[COM-965]

OK I noticed I had the same "no plan" locally, so there was something wrong with my terraform again.

The main thing that was missing is the `include` command. Now I get a "proper" plan on `tgf plan-all --var package_json_major_version=1.2.3` at the root:

```
Terraform will perform the following actions:

  # null_resource.invalidate-cloudfront will be created
  + resource "null_resource" "invalidate-cloudfront" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + terraform_version = "0.14.7"
  + tgf_version       = "3.13"
...
```

so I'm pretty confident the terraform will be properly executed now :smile: 

I'm just not sure it will succeed, but we'll see in due time

[COM-965]: https://coveord.atlassian.net/browse/COM-965