### PR TITLE
add support for anonymous events

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -59,6 +59,7 @@ describe('SearchPageClient', () => {
         getOriginLevel3: () => 'origin-level-3',
         getLanguage: () => 'en',
         getFacetState: () => fakeFacetState,
+        getIsAnonymous: () => false,
     };
 
     beforeEach(() => {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -35,6 +35,7 @@ export interface SearchPageClientProvider {
     getOriginLevel2: () => string;
     getOriginLevel3: () => string;
     getLanguage: () => string;
+    getIsAnonymous: () => boolean;
     getFacetState?: () => FacetStateMetadata[];
 }
 
@@ -338,6 +339,7 @@ export class CoveoSearchPageClient {
             customData,
             language: this.provider.getLanguage(),
             facetState: this.provider.getFacetState ? this.provider.getFacetState() : [],
+            anonymous: this.provider.getIsAnonymous(),
         };
     }
 


### PR DESCRIPTION
This tells Usage Analytics service to anonymize search/click/custom events.
From swagger:

> Whether the interaction that caused the search interface to log the event was triggered by an anonymous user. If set to true, the Usage Analytics Write API will not extract the name and userDisplayName, if present, from the search token

Need to add support for the parameter in headless

https://coveord.atlassian.net/browse/KIT-856