### PR TITLE
COM-965 - Add missing `.value` for ssm parameter in terraform

### DIFF
--- a/terraform/coveo-analytics-js/invalidate-cloudfront.tf
+++ b/terraform/coveo-analytics-js/invalidate-cloudfront.tf
@@ -13,7 +13,7 @@ resource "null_resource" "invalidate-cloudfront" {
     environment = {
       CLOUDFRONT_DISTRIBUTION_ID="E2VWLFSCSD1GLA"
       AWS_ACCESS_KEY_ID="AKIAYKDJLZITZZKEN7WY"
-      AWS_SECRET_ACCESS_KEY=data.aws_ssm_parameter.svc_coveoanalyticsjs_secret
+      AWS_SECRET_ACCESS_KEY=data.aws_ssm_parameter.svc_coveoanalyticsjs_secret.value
     }
   }
 }


### PR DESCRIPTION
[COM-965]

One step closer!

> Error: Incorrect attribute value type: Inappropriate value for attribute "environment": element "AWS_SECRET_ACCESS_KEY": string required.

[COM-965]: https://coveord.atlassian.net/browse/COM-965