### PR TITLE
Add ssm parameter type and default region

### DIFF
--- a/terraform/coveo-analytics-js/invalidate-cloudfront.tf
+++ b/terraform/coveo-analytics-js/invalidate-cloudfront.tf
@@ -4,6 +4,7 @@ variable "package_version" {
 
 data "aws_ssm_parameter" "svc_coveoanalyticsjs_secret" {
   name = "/${var.env}/coveoanalyticsjs/svcAccountSecret"
+  type = "SecureString"
 }
 
 resource "null_resource" "invalidate-cloudfront" {
@@ -14,6 +15,7 @@ resource "null_resource" "invalidate-cloudfront" {
       CLOUDFRONT_DISTRIBUTION_ID="E2VWLFSCSD1GLA"
       AWS_ACCESS_KEY_ID="AKIAYKDJLZITZZKEN7WY"
       AWS_SECRET_ACCESS_KEY=data.aws_ssm_parameter.svc_coveoanalyticsjs_secret.value
+      AWS_DEFAULT_REGION=var.region
     }
   }
 }


### PR DESCRIPTION
[COM-965]

I am still getting an error, but it's pretty close now:

> An error occurred (InvalidClientTokenId) when calling the CreateInvalidation operation: The security token included in the request is invalid

I reviewed every value and every string, so I am guessing the secret is not properly passed (or simply doesn't work), but it used to work in Travis with the same access key ID and Secret... 

So I am testing this thing, hope it will work, otherwise I have no clue :( 

[COM-965]: https://coveord.atlassian.net/browse/COM-965