### PR TITLE
feat(build): expose a website-only script

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,12 +23,20 @@ const tsPlugin = () =>
 
 const browserUMD = {
     input: './src/coveoua/browser.ts',
-    output: {
-        file: './dist/coveoua.js',
-        format: 'umd',
-        name: 'coveoua',
-        sourcemap: true,
-    },
+    output: [
+        {
+            file: './dist/coveoua.js',
+            format: 'umd',
+            name: 'coveoua',
+            sourcemap: true,
+        },
+        {
+            file: './dist/coveoua.browser.js',
+            format: 'iife',
+            name: 'coveoua',
+            sourcemap: true,
+        },
+    ],
     plugins: [
         browserFetch(),
         tsPlugin(),


### PR DESCRIPTION
[COM-1158]

We had a client that tried to import the coveoua script through a script tag, but inadvertently had a module loader on the page (`dojotoolkit`, in this case, which uses the `amd` format).

This change now exposes a `coveoua.browser.js`  file, just in case a client wants to load the script in *browser-mode* even if there is a module loader on the page.

----

As a side node, I would *personally* rather expose a `coveoua.umd.js` file that support module loaders and make `coveoua.js` browser-only, but it would be a breaking change, so this is the next best thing

[COM-1158]: https://coveord.atlassian.net/browse/COM-1158