### PR TITLE
KIT-893 add querySuggestResponseId prop to metadata interface

### DIFF
--- a/src/formatting/format-omnibox-metadata.ts
+++ b/src/formatting/format-omnibox-metadata.ts
@@ -1,7 +1,7 @@
 import {OmniboxSuggestionsMetadata} from '../searchPage/searchPageEvents';
 import {formatArrayForCoveoCustomData} from './format-array-for-coveo-custom-data';
 
-export function formatOmniboxMetadata(meta: OmniboxSuggestionsMetadata) {
+export function formatOmniboxMetadata(meta: OmniboxSuggestionsMetadata): OmniboxSuggestionsMetadata {
     const partialQueries =
         typeof meta.partialQueries === 'string'
             ? meta.partialQueries

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -4,6 +4,7 @@ import {
     PartialDocumentInformation,
     CustomEventsTypes,
     SmartSnippetFeedbackReason,
+    OmniboxSuggestionsMetadata,
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
@@ -198,22 +199,24 @@ describe('SearchPageClient', () => {
     });
 
     it('should send proper payload for #omniboxAnalytics', async () => {
-        const meta = {
+        const meta: OmniboxSuggestionsMetadata = {
             partialQueries: 'a;b;c',
             partialQuery: 'abcd',
             suggestionRanking: 1,
             suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
         };
         await client.logOmniboxAnalytics(meta);
         expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
     });
 
     it('should send proper payload for #logOmniboxFromLink', async () => {
-        const meta = {
+        const meta: OmniboxSuggestionsMetadata = {
             partialQueries: 'a;b;c',
             partialQuery: 'abcd',
             suggestionRanking: 1,
             suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
         };
         await client.logOmniboxFromLink(meta);
         expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -258,6 +258,7 @@ export interface OmniboxSuggestionsMetadata {
     partialQueries: string | string[];
     suggestions: string | string[];
     partialQuery: string;
+    querySuggestResponseId: string;
 }
 
 export interface DocumentIdentifier {


### PR DESCRIPTION
After exploring the possibilities, I think adding a property to the existing metadata interface is the simplest solution.
When moving to collect, we will explore how to translate all existing UA events.

https://coveord.atlassian.net/browse/KIT-893