### PR TITLE
Add contentId, contentIdKey and contentType to extension keys

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -842,6 +842,25 @@ describe('ec events', () => {
                 pr1group: 'nsync',
             });
         });
+
+        it('can send an event with base extension keys', async () => {
+            await coveoua('send', 'event', {
+                contentId: 123,
+                contentIdKey: 'bloup',
+                contentType: 'fish',
+                invalidOne: 'nope',
+            });
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                t: 'event',
+                contentId: 123,
+                contentIdKey: 'bloup',
+                contentType: 'fish',
+            });
+        });
     });
 
     const getParsedBody = (): any[] => {

--- a/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
@@ -34,8 +34,18 @@ const contextInformationMapping: {[key in keyof DefaultContextInformation]: stri
     time: 'tm',
 };
 
+/* Those are extension keys that are supported by the collect protocol. They will be forwarded as-is. */
+const coveoExtensionsKeys = ['contentId', 'contentIdKey', 'contentType'];
+
 export const baseMeasurementProtocolKeysMapping: {[name: string]: string} = {
     ...globalParamKeysMapping,
     ...eventKeysMapping,
     ...contextInformationMapping,
+    ...coveoExtensionsKeys.reduce(
+        (all, key) => ({
+            ...all,
+            [key]: key,
+        }),
+        {}
+    ),
 };


### PR DESCRIPTION
[COM-1304]

We need to support those three values so that we are able to send some analytics events with the legacy format.

@SLangevin waiting for your explicit approval on this one :P 

(I renamed the branch to use the right ticket)

[COM-1304]: https://coveord.atlassian.net/browse/COM-1304