### PR TITLE
feat: add static filter analytics events

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -5,6 +5,7 @@ import {
     CustomEventsTypes,
     SmartSnippetFeedbackReason,
     OmniboxSuggestionsMetadata,
+    StaticFilterToggleValueMetadata,
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
@@ -290,6 +291,39 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
     });
 
+    it('should send the proper payload for #logStaticFilterClearAll', async () => {
+        const staticFilterId = 'filetypes';
+        await client.logStaticFilterClearAll({staticFilterId});
+
+        expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
+    });
+
+    it('should send the proper payload for #logStaticFilterSelect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        await client.logStaticFilterSelect(meta);
+
+        expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
+    });
+
+    it('should send the proper payload for #logStaticFilterDeselect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        await client.logStaticFilterDeselect(meta);
+
+        expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
+    });
+
     it('should send proper payload for #logFacetSearch', async () => {
         const meta = {
             facetField: '@foo',
@@ -312,7 +346,7 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.facetSelect, meta);
     });
 
-    it('should send proper payload for #logFacetSelect', async () => {
+    it('should send proper payload for #logFacetDeselect', async () => {
         const meta = {
             facetField: '@foo',
             facetId: 'bar',

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -22,6 +22,8 @@ import {
     FacetStateMetadata,
     SmartSnippetFeedbackReason,
     SmartSnippetSuggestionMeta,
+    StaticFilterMetadata,
+    StaticFilterToggleValueMetadata,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -76,6 +78,18 @@ export class CoveoSearchPageClient {
 
     public logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.logClickEvent(SearchPageEvents.recommendationOpen, info, identifier);
+    }
+
+    public logStaticFilterClearAll(meta: StaticFilterMetadata) {
+        return this.logSearchEvent(SearchPageEvents.staticFilterClearAll, meta);
+    }
+
+    public logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
+        return this.logSearchEvent(SearchPageEvents.staticFilterSelect, meta);
+    }
+
+    public logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
+        return this.logSearchEvent(SearchPageEvents.staticFilterDeselect, meta);
     }
 
     public logFetchMoreResults() {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -98,6 +98,18 @@ export enum SearchPageEvents {
      */
     pagerScrolling = 'pagerScrolling',
     /**
+     * Identifies the search event that gets logged when the clearing all selected values of a static filter.
+     */
+    staticFilterClearAll = 'staticFilterClearAll',
+    /**
+     * Identifies the search event that gets logged when a static filter check box is selected and the query is updated.
+     */
+    staticFilterSelect = 'staticFilterSelect',
+    /**
+     * Identifies the search event that gets logged when a static filter check box is deselected and the query is updated.
+     */
+    staticFilterDeselect = 'staticFilterDeselect',
+    /**
      * Identifies the search event that gets logged when the Clear Facet button is selected.
      */
     facetClearAll = 'facetClearAll',
@@ -254,6 +266,19 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents, string>> = {
     [SearchPageEvents.recentResultClick]: 'recentlyClickedDocuments',
     [SearchPageEvents.clearRecentResults]: 'recentlyClickedDocuments',
 };
+
+export interface StaticFilterMetadata {
+    staticFilterId: string;
+}
+
+export interface StaticFilterToggleValueMetadata extends StaticFilterMetadata {
+    staticFilterValue: StaticFilterValueMetadata;
+}
+
+interface StaticFilterValueMetadata {
+    caption: string;
+    expression: string;
+}
 
 export interface FacetMetadata {
     facetId: string;


### PR DESCRIPTION
The Static Filter is a new [headless controller](https://github.com/coveo/ui-kit/pull/1322) that makes it easier to build a facet-like UI component, where the values are query expressions.

This PR adds dedicated events for this new component.