### PR TITLE
Support some legacy UA attributes in collect

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -848,6 +848,11 @@ describe('ec events', () => {
                 contentId: 123,
                 contentIdKey: 'bloup',
                 contentType: 'fish',
+                searchHub: 'searchhub',
+                tab: 'tab',
+                searchUid: 'searchuid',
+                permanentId: 'somethingsomething',
+                contentLocale: 'en-us',
                 invalidOne: 'nope',
             });
 
@@ -859,6 +864,11 @@ describe('ec events', () => {
                 contentId: 123,
                 contentIdKey: 'bloup',
                 contentType: 'fish',
+                searchHub: 'searchhub',
+                tab: 'tab',
+                searchUid: 'searchuid',
+                permanentId: 'somethingsomething',
+                contentLocale: 'en-us',
             });
         });
     });

--- a/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
@@ -34,8 +34,17 @@ const contextInformationMapping: {[key in keyof DefaultContextInformation]: stri
     time: 'tm',
 };
 
-/* Those are extension keys that are supported by the collect protocol. They will be forwarded as-is. */
-const coveoExtensionsKeys = ['contentId', 'contentIdKey', 'contentType'];
+/* Those are extension keys that are supported by the Coveo collect protocol (but not Google's protocol). They will be forwarded as-is. */
+const coveoExtensionsKeys = [
+    'contentId',
+    'contentIdKey',
+    'contentType',
+    'searchHub',
+    'tab',
+    'searchUid',
+    'permanentId',
+    'contentLocale',
+];
 
 export const baseMeasurementProtocolKeysMapping: {[name: string]: string} = {
     ...globalParamKeysMapping,


### PR DESCRIPTION
[COM-1208]

PMs took the decision to support those in the product, otherwise they are not able to use the Collect protocol. 

So yeah... they are legacy keys, but this will help adopt (at least partially) the new protocol.

[COM-1208]: https://coveord.atlassian.net/browse/COM-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ