### PR TITLE
feat(case-assist): add Case Assist client

### DIFF
--- a/src/caseAssist/caseAssistActions.ts
+++ b/src/caseAssist/caseAssistActions.ts
@@ -1,5 +1,10 @@
 import {TicketProperties} from '../plugins/svc';
 
+export enum CaseAssistEvents {
+    click = 'click',
+    flowStart = 'flowStart',
+}
+
 export enum CaseAssistActions {
     enterInterface = 'ticket_create_start',
     fieldUpdate = 'ticket_field_update',
@@ -10,6 +15,11 @@ export enum CaseAssistActions {
     caseCancelled = 'ticket_cancel',
     caseSolved = 'ticket_cancel',
     caseCreated = 'ticket_create',
+}
+
+export enum CaseCancelledReasons {
+    quit = 'Quit',
+    solved = 'Solved',
 }
 
 export interface EnterInterfaceMetadata {

--- a/src/caseAssist/caseAssistActions.ts
+++ b/src/caseAssist/caseAssistActions.ts
@@ -1,0 +1,76 @@
+import {TicketProperties} from '../plugins/svc';
+
+export enum CaseAssistActions {
+    enterInterface = 'ticket_create_start',
+    fieldUpdate = 'ticket_field_update',
+    fieldSuggestionClick = 'ticket_classification_click',
+    suggestionClick = 'suggestion_click',
+    suggestionRate = 'suggestion_rate',
+    nextCaseStep = 'ticket_next_stage',
+    caseCancelled = 'ticket_cancel',
+    caseSolved = 'ticket_cancel',
+    caseCreated = 'ticket_create',
+}
+
+export interface EnterInterfaceMetadata {
+    ticket: TicketProperties;
+}
+
+export interface UpdateCaseFieldMetadata {
+    fieldName: string;
+    ticket: TicketProperties;
+}
+
+export interface SelectFieldSuggestionMetadata {
+    suggestion: FieldSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface SelectDocumentSuggestionMetadata {
+    suggestion: DocumentSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface RateDocumentSuggestionMetadata {
+    rating: number;
+    suggestion: DocumentSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface MoveToNextCaseStepMetadata {
+    ticket: TicketProperties;
+}
+
+export interface CaseCancelledMetadata {
+    ticket: TicketProperties;
+}
+
+export interface CaseSolvedMetadata {
+    ticket: TicketProperties;
+}
+
+export interface CaseCreatedMetadata {
+    ticket: TicketProperties;
+}
+
+export interface FieldSuggestion {
+    classificationId: string;
+    responseId: string;
+    fieldName: string;
+    classification: {
+        value: string;
+        confidence: number;
+    };
+}
+
+export interface DocumentSuggestion {
+    suggestionId: string;
+    responseId: string;
+    suggestion: {
+        documentUri: string;
+        documentUriHash: string;
+        documentTitle: string;
+        documentUrl: string;
+        documentPosition: number;
+    };
+}

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -116,6 +116,16 @@ describe('CaseAssistClient', () => {
         }
     };
 
+    it('should have #enableAnalytics default to #true', async () => {
+        client = new CaseAssistClient({});
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(true);
+    });
+
     it('should not send events when #enableAnalytics option is #false', async () => {
         client = new CaseAssistClient({
             enableAnalytics: false,

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -1,0 +1,245 @@
+import {CaseAssistClient} from './caseAssistClient';
+import {CaseAssistActions, DocumentSuggestion, FieldSuggestion} from './caseAssistActions';
+
+import {mockFetch} from '../../tests/fetchMock';
+import {TicketProperties} from '../plugins/svc';
+
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+describe('CaseAssistClient', () => {
+    let client: CaseAssistClient;
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        client = initClient();
+        fetchMock.mock(/.*/, {
+            visitorId: 'visitor-id',
+        });
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+    });
+
+    const initClient = () => {
+        return new CaseAssistClient({
+            enableAnalytics: true,
+        });
+    };
+
+    const noTicket: Record<string, unknown> = undefined;
+    const noActionData: Record<string, unknown> = undefined;
+    const emptyTicket: TicketProperties = {};
+
+    const fakeTicket: TicketProperties = {
+        id: 'the-ticket-id',
+        subject: 'the ticket subject',
+        description: 'the ticket description',
+        category: 'ticket-category',
+        productId: 'some-product-id',
+        custom: {
+            customA: 'custom-a-value',
+            customB: 'custom-b-value',
+        },
+    };
+
+    const fakeFieldSuggestion: FieldSuggestion = {
+        classification: {
+            value: 'some-field-value',
+            confidence: 0.5,
+        },
+        classificationId: 'field-suggestion-id',
+        fieldName: 'some-field',
+        responseId: 'field-suggestion-response-id',
+    };
+
+    const fakeDocumentSuggestion: DocumentSuggestion = {
+        responseId: 'document-suggestion-response-id',
+        suggestionId: 'document-suggestion-id',
+        suggestion: {
+            documentPosition: 0,
+            documentTitle: 'the document title',
+            documentUri: 'some-document-uri',
+            documentUriHash: 'documenturihash',
+            documentUrl: 'some-document-url',
+        },
+    };
+
+    const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
+        const [, {body}] = fetchMock.lastCall();
+        const content = JSON.parse(body.toString());
+
+        expectMatchActionPayload(content, actionName, actionData);
+        expectMatchTicketPayload(content, ticket);
+    };
+
+    const expectMatchActionPayload = (
+        content: Record<string, unknown>,
+        actionName: CaseAssistActions,
+        actionData: Object
+    ) => {
+        expectMatchProperty(content, 'ec', 'svc');
+        expectMatchProperty(content, 'svc_action', actionName);
+        expectMatchProperty(content, 'svc_action_data', actionData);
+
+        const expectedEvent = actionName === CaseAssistActions.enterInterface ? 'flowStart' : 'click';
+        expectMatchProperty(content, 'ea', expectedEvent);
+    };
+
+    const expectMatchTicketPayload = (content: Record<string, unknown>, ticket?: TicketProperties) => {
+        expectMatchProperty(content, 'svc_ticket_id', ticket?.id);
+        expectMatchProperty(content, 'svc_ticket_subject', ticket?.subject);
+        expectMatchProperty(content, 'svc_ticket_description', ticket?.description);
+        expectMatchProperty(content, 'svc_ticket_category', ticket?.category);
+        expectMatchProperty(content, 'svc_ticket_product_id', ticket?.productId);
+        expectMatchProperty(content, 'svc_ticket_custom', ticket?.custom);
+    };
+
+    const expectMatchProperty = (content: Record<string, unknown>, propName: string, propValue: unknown) => {
+        if (typeof propValue !== 'undefined') {
+            if (typeof propValue === 'object') {
+                expect(content).toHaveProperty(propName);
+                expect(content[propName]).toMatchObject(propValue);
+            } else {
+                expect(content).toHaveProperty(propName, propValue);
+            }
+        } else {
+            expect(content).not.toHaveProperty(propName);
+        }
+    };
+
+    it('should not send events when #enabled option is #false', async () => {
+        client = new CaseAssistClient({
+            enableAnalytics: false,
+        });
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('should not send events after #disable function is called', async () => {
+        client.disable();
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('should send events after #enable function is called', async () => {
+        client = new CaseAssistClient({
+            enableAnalytics: false,
+        });
+
+        client.enable();
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(true);
+    });
+
+    it('should send proper payload for #logEnterInterface', async () => {
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.enterInterface, noActionData, noTicket);
+    });
+
+    it('should send proper payload for #logUpdateCaseField', async () => {
+        await client.logUpdateCaseField({
+            fieldName: 'subject',
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldUpdate, {fieldName: 'subject'}, fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectFieldSuggestion', async () => {
+        await client.logSelectFieldSuggestion({
+            suggestion: fakeFieldSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion, fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion', async () => {
+        await client.logSelectDocumentSuggestion({
+            suggestion: fakeDocumentSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion, fakeTicket);
+    });
+
+    it('should send proper payload for #logRateDocumentSuggestion', async () => {
+        const rating = 0.8;
+
+        await client.logRateDocumentSuggestion({
+            rating,
+            suggestion: fakeDocumentSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.suggestionRate,
+            {
+                ...fakeDocumentSuggestion,
+                rate: rating,
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logMoveToNextCaseStep', async () => {
+        await client.logMoveToNextCaseStep({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.nextCaseStep, noActionData, fakeTicket);
+    });
+
+    it('should send proper payload for #logCaseCancelled', async () => {
+        await client.logCaseCancelled({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.caseCancelled,
+            {
+                reason: 'Quit',
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logCaseSolved', async () => {
+        await client.logCaseSolved({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.caseSolved,
+            {
+                reason: 'Solved',
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logCaseCreated', async () => {
+        await client.logCaseCreated({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.caseCreated, noActionData, fakeTicket);
+    });
+});

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -109,7 +109,7 @@ describe('CaseAssistClient', () => {
         }
     };
 
-    it('should not send events when #enabled option is #false', async () => {
+    it('should not send events when #enableAnalytics option is #false', async () => {
         client = new CaseAssistClient({
             enableAnalytics: false,
         });

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -1,5 +1,11 @@
 import {CaseAssistClient} from './caseAssistClient';
-import {CaseAssistActions, DocumentSuggestion, FieldSuggestion} from './caseAssistActions';
+import {
+    CaseAssistActions,
+    CaseAssistEvents,
+    CaseCancelledReasons,
+    DocumentSuggestion,
+    FieldSuggestion,
+} from './caseAssistActions';
 
 import {mockFetch} from '../../tests/fetchMock';
 import {TicketProperties} from '../plugins/svc';
@@ -83,7 +89,8 @@ describe('CaseAssistClient', () => {
         expectMatchProperty(content, 'svc_action', actionName);
         expectMatchProperty(content, 'svc_action_data', actionData);
 
-        const expectedEvent = actionName === CaseAssistActions.enterInterface ? 'flowStart' : 'click';
+        const expectedEvent =
+            actionName === CaseAssistActions.enterInterface ? CaseAssistEvents.flowStart : CaseAssistEvents.click;
         expectMatchProperty(content, 'ea', expectedEvent);
     };
 
@@ -215,7 +222,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(
             CaseAssistActions.caseCancelled,
             {
-                reason: 'Quit',
+                reason: CaseCancelledReasons.quit,
             },
             fakeTicket
         );
@@ -229,7 +236,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(
             CaseAssistActions.caseSolved,
             {
-                reason: 'Solved',
+                reason: CaseCancelledReasons.solved,
             },
             fakeTicket
         );

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -1,0 +1,112 @@
+import CoveoAnalyticsClient, {AnalyticsClient, ClientOptions} from '../client/analytics';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import {SVCPlugin} from '../plugins/svc';
+import {
+    CaseCancelledMetadata,
+    CaseCreatedMetadata,
+    CaseSolvedMetadata,
+    EnterInterfaceMetadata,
+    MoveToNextCaseStepMetadata,
+    RateDocumentSuggestionMetadata,
+    SelectDocumentSuggestionMetadata,
+    SelectFieldSuggestionMetadata,
+    UpdateCaseFieldMetadata,
+} from './caseAssistActions';
+
+export interface CaseAssistClientOptions extends ClientOptions {
+    enableAnalytics: boolean;
+}
+
+export class CaseAssistClient {
+    private client: AnalyticsClient;
+    private svc: SVCPlugin;
+
+    constructor(private options: Partial<CaseAssistClientOptions>) {
+        this.client = options.enableAnalytics === false ? new NoopAnalytics() : new CoveoAnalyticsClient(options);
+        this.svc = new SVCPlugin({client: this.client});
+    }
+
+    public disable() {
+        if (this.client instanceof CoveoAnalyticsClient) {
+            this.client.clear();
+        }
+        this.client = new NoopAnalytics();
+        this.svc = new SVCPlugin({client: this.client});
+    }
+
+    public enable() {
+        this.client = new CoveoAnalyticsClient(this.options);
+        this.svc = new SVCPlugin({client: this.client});
+    }
+
+    public logEnterInterface(meta: EnterInterfaceMetadata) {
+        this.svc.setAction('ticket_create_start');
+        this.svc.setTicket(meta.ticket);
+        return this.sendFlowStartEvent();
+    }
+
+    public logUpdateCaseField(meta: UpdateCaseFieldMetadata) {
+        this.svc.setAction('ticket_field_update', {
+            fieldName: meta.fieldName,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logSelectFieldSuggestion(meta: SelectFieldSuggestionMetadata) {
+        this.svc.setAction('ticket_classification_click', meta.suggestion);
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logSelectDocumentSuggestion(meta: SelectDocumentSuggestionMetadata) {
+        this.svc.setAction('suggestion_click', meta.suggestion);
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logRateDocumentSuggestion(meta: RateDocumentSuggestionMetadata) {
+        this.svc.setAction('suggestion_rate', {
+            rate: meta.rating,
+            ...meta.suggestion,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logMoveToNextCaseStep(meta: MoveToNextCaseStepMetadata) {
+        this.svc.setAction('ticket_next_stage');
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseCancelled(meta: CaseCancelledMetadata) {
+        this.svc.setAction('ticket_cancel', {
+            reason: 'Quit',
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseSolved(meta: CaseSolvedMetadata) {
+        this.svc.setAction('ticket_cancel', {
+            reason: 'Solved',
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseCreated(meta: CaseCreatedMetadata) {
+        this.svc.setAction('ticket_create');
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    private sendFlowStartEvent() {
+        return this.client.sendEvent('event', 'svc', 'flowStart');
+    }
+
+    private sendClickEvent() {
+        return this.client.sendEvent('event', 'svc', 'click');
+    }
+}

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -17,7 +17,7 @@ import {
 } from './caseAssistActions';
 
 export interface CaseAssistClientOptions extends ClientOptions {
-    enableAnalytics: boolean;
+    enableAnalytics?: boolean;
 }
 
 export class CaseAssistClient {
@@ -25,7 +25,9 @@ export class CaseAssistClient {
     private svc: SVCPlugin;
 
     constructor(private options: Partial<CaseAssistClientOptions>) {
-        this.coveoAnalyticsClient = options.enableAnalytics ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
+        const analyticsEnabled = options.enableAnalytics ?? true;
+
+        this.coveoAnalyticsClient = analyticsEnabled ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
         this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
     }
 

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -21,25 +21,25 @@ export interface CaseAssistClientOptions extends ClientOptions {
 }
 
 export class CaseAssistClient {
-    private client: AnalyticsClient;
+    public coveoAnalyticsClient: AnalyticsClient;
     private svc: SVCPlugin;
 
     constructor(private options: Partial<CaseAssistClientOptions>) {
-        this.client = options.enableAnalytics ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
-        this.svc = new SVCPlugin({client: this.client});
+        this.coveoAnalyticsClient = options.enableAnalytics ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
     }
 
     public disable() {
-        if (this.client instanceof CoveoAnalyticsClient) {
-            this.client.clear();
+        if (this.coveoAnalyticsClient instanceof CoveoAnalyticsClient) {
+            this.coveoAnalyticsClient.clear();
         }
-        this.client = new NoopAnalytics();
-        this.svc = new SVCPlugin({client: this.client});
+        this.coveoAnalyticsClient = new NoopAnalytics();
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
     }
 
     public enable() {
-        this.client = new CoveoAnalyticsClient(this.options);
-        this.svc = new SVCPlugin({client: this.client});
+        this.coveoAnalyticsClient = new CoveoAnalyticsClient(this.options);
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
     }
 
     public logEnterInterface(meta: EnterInterfaceMetadata) {
@@ -106,10 +106,10 @@ export class CaseAssistClient {
     }
 
     private sendFlowStartEvent() {
-        return this.client.sendEvent('event', 'svc', CaseAssistEvents.flowStart);
+        return this.coveoAnalyticsClient.sendEvent('event', 'svc', CaseAssistEvents.flowStart);
     }
 
     private sendClickEvent() {
-        return this.client.sendEvent('event', 'svc', CaseAssistEvents.click);
+        return this.coveoAnalyticsClient.sendEvent('event', 'svc', CaseAssistEvents.click);
     }
 }

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,4 +1,5 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
+export {CaseAssistClient} from '../caseAssist/caseAssistClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export * as history from '../history';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -8,5 +8,6 @@ export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
+export {CaseAssistClient} from '../caseAssist/caseAssistClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};


### PR DESCRIPTION
https://coveord.atlassian.net/browse/SFINT-3835

This PR adds a strongly-typed client to log the Case Assist events. See [Log Case Assist Events](https://docs.coveo.com/en/3437/service/log-case-assist-events) for details regarding the information that are passed to the `svc` plugin.
