### PR TITLE
DNT: add support for the new "unspecified" value

### DIFF
--- a/src/donottrack.spec.ts
+++ b/src/donottrack.spec.ts
@@ -94,5 +94,29 @@ describe('doNotTrack', () => {
                 expect(doNotTrack()).toBeTruthy();
             });
         });
+
+        [false, 'no', '0', 'unspecified'].forEach((value) => {
+            it('should fallback on `navigator.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorDoNotTrack: value,
+                });
+
+                expect(doNotTrack()).toBeFalsy();
+            });
+
+            it('should fallback on `navigator.msDoNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorMsDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeFalsy();
+            });
+
+            it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    windowDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeFalsy();
+            });
+        });
     });
 });

--- a/src/donottrack.ts
+++ b/src/donottrack.ts
@@ -6,6 +6,8 @@
 
 import {hasNavigator} from './detector';
 
+const doNotTrackValues = ['1', 1, 'yes', true];
+
 export function doNotTrack(): boolean {
     return (
         hasNavigator() &&
@@ -14,7 +16,7 @@ export function doNotTrack(): boolean {
             (<any>navigator).doNotTrack,
             (<any>navigator).msDoNotTrack,
             (<any>window).doNotTrack,
-        ].some((value) => !!value)
+        ].some((value) => doNotTrackValues.indexOf(value) !== -1)
     );
 }
 


### PR DESCRIPTION
We're having some problems with the DNT support on Firefox.
The "unspecified" value used by firefox (and documentation here:  https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack) is treated as a TRUE value by our library, enabling the Do Not Track for all the Firefox users even if they didn't enable it.