### PR TITLE
[COM-160] ssm data parameter cannot set type

### DIFF
--- a/terraform/coveo-analytics-js/invalidate-cloudfront.tf
+++ b/terraform/coveo-analytics-js/invalidate-cloudfront.tf
@@ -4,7 +4,6 @@ variable "package_version" {
 
 data "aws_ssm_parameter" "svc_coveoanalyticsjs_secret" {
   name = "/${var.env}/coveoanalyticsjs/svcAccountSecret"
-  type = "SecureString"
 }
 
 resource "null_resource" "invalidate-cloudfront" {


### PR DESCRIPTION
```
 Error: Computed attributes cannot be set
 on invalidate-cloudfront.tf line 7, in data "aws_ssm_parameter" "svc_coveoanalyticsjs_secret":
  7:   type = "SecureString"
```