### PR TITLE
Add clientId & originContext to searchPageClient events payload

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -71,6 +71,9 @@ export interface AnalyticsClient {
     registerAfterSendEventHook(hook: AnalyticsClientSendEventHook): void;
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void;
     runtime: IRuntimeEnvironment;
+    /**
+     * @deprecated
+     */
     readonly currentVisitorId: string;
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -32,7 +32,8 @@ export interface EventBaseRequest {
     userDisplayName?: any;
     splitTestRunName?: string;
     splitTestRunVersion?: string;
-
+    clientId?: string;
+    originContext?: string;
     originLevel1?: string;
     originLevel2?: string;
     originLevel3?: string;

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -56,6 +56,7 @@ describe('SearchPageClient', () => {
         }),
         getSearchUID: () => 'my-uid',
         getPipeline: () => 'my-pipeline',
+        getOriginContext: () => 'origin-context',
         getOriginLevel1: () => 'origin-level-1',
         getOriginLevel2: () => 'origin-level-2',
         getOriginLevel3: () => 'origin-level-3',
@@ -68,9 +69,9 @@ describe('SearchPageClient', () => {
         fetchMockBeforeEach();
 
         client = initClient();
+        client.coveoAnalyticsClient.runtime.storage.setItem('visitorId', 'visitor-id');
         fetchMock.mock(/.*/, {
             visitId: 'visit-id',
-            visitorId: 'visitor-id',
         });
     });
 
@@ -83,6 +84,7 @@ describe('SearchPageClient', () => {
     };
 
     const expectOrigins = () => ({
+        originContext: 'origin-context',
         originLevel1: 'origin-level-1',
         originLevel2: 'origin-level-2',
         originLevel3: 'origin-level-3',
@@ -99,6 +101,7 @@ describe('SearchPageClient', () => {
             customData,
             facetState: fakeFacetState,
             language: 'en',
+            clientId: 'visitor-id',
             ...expectOrigins(),
         });
     };
@@ -111,6 +114,7 @@ describe('SearchPageClient', () => {
             customData,
             queryPipeline: 'my-pipeline',
             language: 'en',
+            clientId: 'visitor-id',
             ...doc,
             ...expectOrigins(),
         });
@@ -125,6 +129,7 @@ describe('SearchPageClient', () => {
             lastSearchQueryUid: 'my-uid',
             customData,
             language: 'en',
+            clientId: 'visitor-id',
             ...expectOrigins(),
         });
     };
@@ -138,6 +143,7 @@ describe('SearchPageClient', () => {
             lastSearchQueryUid: 'my-uid',
             customData,
             language: 'en',
+            clientId: 'visitor-id',
             ...expectOrigins(),
         });
     };


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1409

2 parameters that were sent with the JSUI & that are still relevant with Headless. The clientId is the same as the visitorId.