### PR TITLE
Revert "use new npm token to publish (#322)" [COM-160]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
   }
 
   environment {
-    NPM_TOKEN = credentials("npmjs_com_token")
+    NPM_TOKEN = credentials("coveo-analytics-js-npm-deployment-token")
     GIT = credentials('github-coveobot')
     GH_TOKEN = credentials('github-coveobot_token')
     SNYK_TOKEN = credentials("snyk_token")


### PR DESCRIPTION
The token was updated so we could publish with it again instead.

This reverts commit 34798fad758f963a9606a5e1f7ebccd6f2c76652.

[COM-160]

[COM-160]: https://coveord.atlassian.net/browse/COM-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ