### PR TITLE
make getOriginContext optional

### DIFF
--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -33,7 +33,7 @@ export interface SearchPageClientProvider {
     getSearchEventRequestPayload: () => Omit<SearchEventRequest, 'actionCause' | 'searchQueryUid'>;
     getSearchUID: () => string;
     getPipeline: () => string;
-    getOriginContext: () => string;
+    getOriginContext?: () => string;
     getOriginLevel1: () => string;
     getOriginLevel2: () => string;
     getOriginLevel3: () => string;
@@ -384,7 +384,7 @@ export class CoveoSearchPageClient {
 
     private getOrigins() {
         return {
-            originContext: this.provider.getOriginContext(),
+            originContext: this.provider.getOriginContext?.(),
             originLevel1: this.provider.getOriginLevel1(),
             originLevel2: this.provider.getOriginLevel2(),
             originLevel3: this.provider.getOriginLevel3(),


### PR DESCRIPTION
Previous was a breaking change, last time we only bumped a minor for these types of changes. But if we follow semver, it should be v3. IMO not necessary as it's an optional parameter to send