### PR TITLE
[SFINT-4408] Metadata sent updated in logSelectDocumentSuggestion and logSelectFieldSuggestion

### DIFF
--- a/src/caseAssist/caseAssistActions.ts
+++ b/src/caseAssist/caseAssistActions.ts
@@ -71,6 +71,7 @@ export interface FieldSuggestion {
         value: string;
         confidence: number;
     };
+    autoSelection?: boolean;
 }
 
 export interface DocumentSuggestion {
@@ -83,4 +84,6 @@ export interface DocumentSuggestion {
         documentUrl: string;
         documentPosition: number;
     };
+    fromQuickview?: boolean;
+    openDocument?: boolean;
 }

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -50,26 +50,33 @@ describe('CaseAssistClient', () => {
         },
     };
 
-    const fakeFieldSuggestion: FieldSuggestion = {
-        classification: {
-            value: 'some-field-value',
-            confidence: 0.5,
-        },
-        classificationId: 'field-suggestion-id',
-        fieldName: 'some-field',
-        responseId: 'field-suggestion-response-id',
+    const fakeFieldSuggestion = (autoSelection?: boolean): FieldSuggestion => {
+        return {
+            classification: {
+                value: 'some-field-value',
+                confidence: 0.5,
+            },
+            classificationId: 'field-suggestion-id',
+            fieldName: 'some-field',
+            responseId: 'field-suggestion-response-id',
+            ...(autoSelection && {autoSelection}),
+        };
     };
 
-    const fakeDocumentSuggestion: DocumentSuggestion = {
-        responseId: 'document-suggestion-response-id',
-        suggestionId: 'document-suggestion-id',
-        suggestion: {
-            documentPosition: 0,
-            documentTitle: 'the document title',
-            documentUri: 'some-document-uri',
-            documentUriHash: 'documenturihash',
-            documentUrl: 'some-document-url',
-        },
+    const fakeDocumentSuggestion = (fromQuickview?: boolean, openDocument?: boolean): DocumentSuggestion => {
+        return {
+            responseId: 'document-suggestion-response-id',
+            suggestionId: 'document-suggestion-id',
+            suggestion: {
+                documentPosition: 0,
+                documentTitle: 'the document title',
+                documentUri: 'some-document-uri',
+                documentUriHash: 'documenturihash',
+                documentUrl: 'some-document-url',
+            },
+            ...(fromQuickview && {fromQuickview}),
+            ...(openDocument && {openDocument}),
+        };
     };
 
     const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
@@ -181,20 +188,47 @@ describe('CaseAssistClient', () => {
 
     it('should send proper payload for #logSelectFieldSuggestion', async () => {
         await client.logSelectFieldSuggestion({
-            suggestion: fakeFieldSuggestion,
+            suggestion: fakeFieldSuggestion(),
             ticket: fakeTicket,
         });
 
-        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion, fakeTicket);
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(), fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection property is set to true', async () => {
+        await client.logSelectFieldSuggestion({
+            suggestion: fakeFieldSuggestion(true),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(true), fakeTicket);
     });
 
     it('should send proper payload for #logSelectDocumentSuggestion', async () => {
         await client.logSelectDocumentSuggestion({
-            suggestion: fakeDocumentSuggestion,
+            suggestion: fakeDocumentSuggestion(),
             ticket: fakeTicket,
         });
 
-        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion, fakeTicket);
+        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(), fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion when the fromQuickview parameter is set to true', async () => {
+        await client.logSelectDocumentSuggestion({
+            suggestion: fakeDocumentSuggestion(true),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(true), fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion when the openDocument parameter is set to true', async () => {
+        await client.logSelectDocumentSuggestion({
+            suggestion: fakeDocumentSuggestion(false, true),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(false, true), fakeTicket);
     });
 
     it('should send proper payload for #logRateDocumentSuggestion', async () => {
@@ -202,14 +236,14 @@ describe('CaseAssistClient', () => {
 
         await client.logRateDocumentSuggestion({
             rating,
-            suggestion: fakeDocumentSuggestion,
+            suggestion: fakeDocumentSuggestion(),
             ticket: fakeTicket,
         });
 
         expectMatchPayload(
             CaseAssistActions.suggestionRate,
             {
-                ...fakeDocumentSuggestion,
+                ...fakeDocumentSuggestion(),
                 rate: rating,
             },
             fakeTicket

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -192,7 +192,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(), fakeTicket);
     });
 
-    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection parameter is set to true', async () => {
+    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection property is set to true', async () => {
         const myFakeFieldSuggestion = fakeFieldSuggestion();
         myFakeFieldSuggestion.autoSelection = true;
         await client.logSelectFieldSuggestion({
@@ -212,7 +212,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(), fakeTicket);
     });
 
-    it('should send proper payload for #logSelectDocumentSuggestion when the fromQuickview parameter is set to true', async () => {
+    it('should send proper payload for #logSelectDocumentSuggestion when the fromQuickview property is set to true', async () => {
         const myFakeDocumentSuggestion = fakeDocumentSuggestion();
         myFakeDocumentSuggestion.fromQuickview = true;
         await client.logSelectDocumentSuggestion({
@@ -223,7 +223,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(CaseAssistActions.suggestionClick, myFakeDocumentSuggestion, fakeTicket);
     });
 
-    it('should send proper payload for #logSelectDocumentSuggestion when the openDocument parameter is set to true', async () => {
+    it('should send proper payload for #logSelectDocumentSuggestion when the openDocument property is set to true', async () => {
         const myFakeDocumentSuggestion = fakeDocumentSuggestion();
         myFakeDocumentSuggestion.openDocument = true;
         await client.logSelectDocumentSuggestion({

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -195,7 +195,7 @@ describe('CaseAssistClient', () => {
         expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(), fakeTicket);
     });
 
-    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection property is set to true', async () => {
+    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection parameter is set to true', async () => {
         await client.logSelectFieldSuggestion({
             suggestion: fakeFieldSuggestion(true),
             ticket: fakeTicket,

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -50,7 +50,7 @@ describe('CaseAssistClient', () => {
         },
     };
 
-    const fakeFieldSuggestion = (autoSelection?: boolean): FieldSuggestion => {
+    const fakeFieldSuggestion = (): FieldSuggestion => {
         return {
             classification: {
                 value: 'some-field-value',
@@ -59,11 +59,10 @@ describe('CaseAssistClient', () => {
             classificationId: 'field-suggestion-id',
             fieldName: 'some-field',
             responseId: 'field-suggestion-response-id',
-            ...(autoSelection && {autoSelection}),
         };
     };
 
-    const fakeDocumentSuggestion = (fromQuickview?: boolean, openDocument?: boolean): DocumentSuggestion => {
+    const fakeDocumentSuggestion = (): DocumentSuggestion => {
         return {
             responseId: 'document-suggestion-response-id',
             suggestionId: 'document-suggestion-id',
@@ -74,8 +73,6 @@ describe('CaseAssistClient', () => {
                 documentUriHash: 'documenturihash',
                 documentUrl: 'some-document-url',
             },
-            ...(fromQuickview && {fromQuickview}),
-            ...(openDocument && {openDocument}),
         };
     };
 
@@ -196,12 +193,14 @@ describe('CaseAssistClient', () => {
     });
 
     it('should send proper payload for #logSelectFieldSuggestion when the autoSelection parameter is set to true', async () => {
+        const myFakeFieldSuggestion = fakeFieldSuggestion();
+        myFakeFieldSuggestion.autoSelection = true;
         await client.logSelectFieldSuggestion({
-            suggestion: fakeFieldSuggestion(true),
+            suggestion: myFakeFieldSuggestion,
             ticket: fakeTicket,
         });
 
-        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(true), fakeTicket);
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, myFakeFieldSuggestion, fakeTicket);
     });
 
     it('should send proper payload for #logSelectDocumentSuggestion', async () => {
@@ -214,21 +213,25 @@ describe('CaseAssistClient', () => {
     });
 
     it('should send proper payload for #logSelectDocumentSuggestion when the fromQuickview parameter is set to true', async () => {
+        const myFakeDocumentSuggestion = fakeDocumentSuggestion();
+        myFakeDocumentSuggestion.fromQuickview = true;
         await client.logSelectDocumentSuggestion({
-            suggestion: fakeDocumentSuggestion(true),
+            suggestion: myFakeDocumentSuggestion,
             ticket: fakeTicket,
         });
 
-        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(true), fakeTicket);
+        expectMatchPayload(CaseAssistActions.suggestionClick, myFakeDocumentSuggestion, fakeTicket);
     });
 
     it('should send proper payload for #logSelectDocumentSuggestion when the openDocument parameter is set to true', async () => {
+        const myFakeDocumentSuggestion = fakeDocumentSuggestion();
+        myFakeDocumentSuggestion.openDocument = true;
         await client.logSelectDocumentSuggestion({
-            suggestion: fakeDocumentSuggestion(false, true),
+            suggestion: myFakeDocumentSuggestion,
             ticket: fakeTicket,
         });
 
-        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(false, true), fakeTicket);
+        expectMatchPayload(CaseAssistActions.suggestionClick, myFakeDocumentSuggestion, fakeTicket);
     });
 
     it('should send proper payload for #logRateDocumentSuggestion', async () => {


### PR DESCRIPTION
### New properties needed  to be added to the metadata sent by logSelectDocumentSuggestion to report correctly the following events:
- Opening the Quickview of a document suggestion.
- Opening the document suggestion after clicking on its title from the Quickview.

### New property needed  to be added in the metadata sent by logSelectFieldSuggestion to report correctly the following event:

- Auto-selecting the classification with the highest confidence.
