### PR TITLE
bump version to minor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "coveo.analytics",
-    "version": "2.18.66",
+    "version": "2.19.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "coveo.analytics",
-            "version": "2.18.66",
+            "version": "2.19.0",
             "license": "MIT",
             "dependencies": {
                 "@react-native-async-storage/async-storage": "^1.15.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.18.66",
+    "version": "2.19.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",


### PR DESCRIPTION
Safer to prevent breaking changes (since value is now optional and HistoryElement is read)

(deprecated previous bump 2.18.66)