### PR TITLE
KIT-1486 exported SmartSnippetFeedbackReason

### DIFF
--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -9,5 +9,6 @@ export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
 export {CaseAssistClient} from '../caseAssist/caseAssistClient';
+export {SmartSnippetFeedbackReason} from '../searchPage/searchPageEvents';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -8,7 +8,7 @@ export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
-export {CaseAssistClient} from '../caseAssist/caseAssistClient';
 export {SmartSnippetFeedbackReason} from '../searchPage/searchPageEvents';
+export {CaseAssistClient} from '../caseAssist/caseAssistClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -8,7 +8,6 @@ export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
-export {SmartSnippetFeedbackReason} from '../searchPage/searchPageEvents';
 export {CaseAssistClient} from '../caseAssist/caseAssistClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -370,12 +370,7 @@ export interface QueryErrorMeta {
     errorMessage: string;
 }
 
-export enum SmartSnippetFeedbackReason {
-    DoesNotAnswer = 'does_not_answer',
-    PartiallyAnswers = 'partially_answers',
-    WasNotAQuestion = 'was_not_a_question',
-    Other = 'other',
-}
+export type SmartSnippetFeedbackReason = 'does_not_answer' | 'partially_answers' | 'was_not_a_question' | 'other';
 
 export interface SmartSnippetSuggestionMeta {
     contentIdKey: string;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1486

Source: https://github.com/coveo/ui-kit/pull/1843/files#r831436327

I'm not so sure about exporting this type from UA since I don't see a whole lot that's exported in general.

However, this is the only case I could find in the library of an enum being taken as a parameter for logging analytics. Unfortunately, enums aren't simply translated to an alias type, so that means that anyone using Typescript to call the library is expected to either provide the same enum (impossible since it's not exported) or work around that requirement by using utility types and a `as`.