### PR TITLE
KIT-1498 added open smart snippet source analytics

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -527,6 +527,11 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #logOpenSmartSnippetSource', async () => {
+        await client.logOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
+    });
+
     it('should send proper payload for #logRecentQueryClick', async () => {
         await client.logRecentQueryClick();
         expectMatchPayload(SearchPageEvents.recentQueryClick);

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -286,6 +286,10 @@ export class CoveoSearchPageClient {
         return this.logCustomEvent(SearchPageEvents.collapseSmartSnippetSuggestion, {documentId});
     }
 
+    public logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.logClickEvent(SearchPageEvents.openSmartSnippetSource, info, identifier);
+    }
+
     public logRecentQueryClick() {
         return this.logSearchEvent(SearchPageEvents.recentQueryClick);
     }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -214,6 +214,10 @@ export enum SearchPageEvents {
      */
     collapseSmartSnippetSuggestion = 'collapseSmartSnippetSuggestion',
     /**
+     * Identifies the custom event that gets logged when a user clicks on the source of an answer in a smart snippet.
+     */
+    openSmartSnippetSource = 'openSmartSnippetSource',
+    /**
      * Identifies the search event that gets logged when a recent queries list item gets clicked.
      */
     recentQueryClick = 'recentQueriesClick',


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1498

JSUI equivalent:
```ts
export var analyticsActionCauseList = {
  ...
  /**
   * The custom event logged when a user clicks on the source of an answer in a [SmartSnippet]{@link SmartSnippet}..
   *
   * ```javascript
   * {
   *  actionCause: "openSmartSnippetSource",
   *  actionType: "smartSnippet"
   * }
   * ```
   */
  openSmartSnippetSource: <IAnalyticsActionCause>{
    name: 'openSmartSnippetSource',
    type: 'smartSnippet'
  },
  ...
}
```

```ts
private sendClickSourceAnalytics(element: HTMLElement, href: string) {
  return this.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetOpenSourceMeta>(
    analyticsActionCauseList.openSmartSnippetSource,
    {
      searchQueryUid: this.searchUid,
      documentTitle: this.lastRenderedResult.title,
      author: Utils.getFieldValue(this.lastRenderedResult, 'author'),
      documentURL: href
    },
    this.lastRenderedResult,
    element
  );
}
```