### PR TITLE
SFINT-4444 searchHub added to payload sent by the Case Assist analytics Client

### DIFF
--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -1,4 +1,4 @@
-import {CaseAssistClient} from './caseAssistClient';
+import {CaseAssistClient, CaseAssistClientProvider} from './caseAssistClient';
 import {
     CaseAssistActions,
     CaseAssistEvents,
@@ -13,7 +13,12 @@ import {TicketProperties} from '../plugins/svc';
 const {fetchMock, fetchMockBeforeEach} = mockFetch();
 
 describe('CaseAssistClient', () => {
+    const defaultSearchHub = 'origin-level-1';
     let client: CaseAssistClient;
+
+    const provider: CaseAssistClientProvider = {
+        getOriginLevel1: () => defaultSearchHub,
+    };
 
     beforeEach(() => {
         fetchMockBeforeEach();
@@ -29,9 +34,12 @@ describe('CaseAssistClient', () => {
     });
 
     const initClient = () => {
-        return new CaseAssistClient({
-            enableAnalytics: true,
-        });
+        return new CaseAssistClient(
+            {
+                enableAnalytics: true,
+            },
+            provider
+        );
     };
 
     const noTicket: Record<string, unknown> = undefined;
@@ -82,6 +90,7 @@ describe('CaseAssistClient', () => {
 
         expectMatchActionPayload(content, actionName, actionData);
         expectMatchTicketPayload(content, ticket);
+        expectMatchProperty(content, 'searchHub', defaultSearchHub);
     };
 
     const expectMatchActionPayload = (

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -16,6 +16,10 @@ import {
     UpdateCaseFieldMetadata,
 } from './caseAssistActions';
 
+export interface CaseAssistClientProvider {
+    getOriginLevel1: () => string;
+}
+
 export interface CaseAssistClientOptions extends ClientOptions {
     enableAnalytics?: boolean;
 }
@@ -24,7 +28,7 @@ export class CaseAssistClient {
     public coveoAnalyticsClient: AnalyticsClient;
     private svc: SVCPlugin;
 
-    constructor(private options: Partial<CaseAssistClientOptions>) {
+    constructor(private options: Partial<CaseAssistClientOptions>, private provider?: CaseAssistClientProvider) {
         const analyticsEnabled = options.enableAnalytics ?? true;
 
         this.coveoAnalyticsClient = analyticsEnabled ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
@@ -108,10 +112,28 @@ export class CaseAssistClient {
     }
 
     private sendFlowStartEvent() {
-        return this.coveoAnalyticsClient.sendEvent('event', 'svc', CaseAssistEvents.flowStart);
+        return this.coveoAnalyticsClient.sendEvent(
+            'event',
+            'svc',
+            CaseAssistEvents.flowStart,
+            this.provider
+                ? {
+                      searchHub: this.provider.getOriginLevel1(),
+                  }
+                : null
+        );
     }
 
     private sendClickEvent() {
-        return this.coveoAnalyticsClient.sendEvent('event', 'svc', CaseAssistEvents.click);
+        return this.coveoAnalyticsClient.sendEvent(
+            'event',
+            'svc',
+            CaseAssistEvents.click,
+            this.provider
+                ? {
+                      searchHub: this.provider.getOriginLevel1(),
+                  }
+                : null
+        );
     }
 }

--- a/src/coveoua/headless.ts
+++ b/src/coveoua/headless.ts
@@ -1,5 +1,5 @@
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
-export {CaseAssistClient} from '../caseAssist/caseAssistClient';
+export {CaseAssistClient, CaseAssistClientProvider} from '../caseAssist/caseAssistClient';
 export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
 export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export * as history from '../history';

--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -8,6 +8,6 @@ export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
 export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
-export {CaseAssistClient} from '../caseAssist/caseAssistClient';
+export {CaseAssistClient, CaseAssistClientProvider} from '../caseAssist/caseAssistClient';
 
 export {analytics, donottrack, history, SimpleAnalytics, storage};


### PR DESCRIPTION
[SFINT-4444](https://coveord.atlassian.net/browse/SFINT-4444)

 - New optional parameter `provider` of type `CaseAssistClientProvider` added to instantiate the `CaseAssistClient`. This parameter will allow the client to add the search hub to the payload of all the case assist analytics events sent.