### PR TITLE
SFINT-4423 stage metadata added to ticket_next_stage event

### DIFF
--- a/src/caseAssist/caseAssistActions.ts
+++ b/src/caseAssist/caseAssistActions.ts
@@ -49,6 +49,7 @@ export interface RateDocumentSuggestionMetadata {
 
 export interface MoveToNextCaseStepMetadata {
     ticket: TicketProperties;
+    stage?: string;
 }
 
 export interface CaseCancelledMetadata {

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -254,11 +254,14 @@ describe('CaseAssistClient', () => {
     });
 
     it('should send proper payload for #logMoveToNextCaseStep', async () => {
+        const stageName = 'stage 1';
+
         await client.logMoveToNextCaseStep({
             ticket: fakeTicket,
+            stage: stageName,
         });
 
-        expectMatchPayload(CaseAssistActions.nextCaseStep, noActionData, fakeTicket);
+        expectMatchPayload(CaseAssistActions.nextCaseStep, {stage: stageName}, fakeTicket);
     });
 
     it('should send proper payload for #logCaseCancelled', async () => {

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -80,7 +80,9 @@ export class CaseAssistClient {
     }
 
     public logMoveToNextCaseStep(meta: MoveToNextCaseStepMetadata) {
-        this.svc.setAction(CaseAssistActions.nextCaseStep);
+        this.svc.setAction(CaseAssistActions.nextCaseStep, {
+            stage: meta?.stage,
+        });
         this.svc.setTicket(meta.ticket);
         return this.sendClickEvent();
     }


### PR DESCRIPTION
[SFINT-4423](https://coveord.atlassian.net/browse/SFINT-4423)

- #### New metadata field `stage` added to `ticket_next_stage event`, this optional  field will contain the information about **the name of the stage** from where the ticket_next_stage event was fired.