### PR TITLE
feat: add instant results click event

### DIFF
--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -25,6 +25,7 @@ import {
     SmartSnippetDocumentIdentifier,
     StaticFilterMetadata,
     StaticFilterToggleValueMetadata,
+    DocumentMetadata,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -138,8 +139,12 @@ export class CoveoSearchPageClient {
         return this.logClickEvent(SearchPageEvents.documentQuickview, info, identifier);
     }
 
-    public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier);
+    public logDocumentOpen(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: DocumentMetadata
+    ) {
+        return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier, metadata);
     }
 
     public logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -345,6 +345,10 @@ export interface DocumentIdentifier {
     contentIDValue: string;
 }
 
+export interface DocumentMetadata {
+    location: string;
+}
+
 export interface InterfaceChangeMetadata {
     interfaceChangeTo: string;
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-1775

[EDIT]:

after our conversation during stand up today, I'm thinking of sending an extra bit of `customData` called `location` (happy to change name and value upon request) so that the event is the same as a regular result click, but you can differentiate by location

![Screenshot 2022-06-21 at 17 07 26](https://user-images.githubusercontent.com/30511433/174847047-247415c5-2187-42bd-81cb-02be0d6a30cb.png)

the default would be not to have a location, or we can add a `mainResultList` via atomic

cc @lvu285 