### PR TITLE
add support for a-b testing

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -69,6 +69,8 @@ describe('SearchPageClient', () => {
         getLanguage: () => 'en',
         getFacetState: () => fakeFacetState,
         getIsAnonymous: () => false,
+        getSplitTestRunName: () => 'split-test-run-something',
+        getSplitTestRunVersion: () => 'split-test-run-something/foo',
     };
 
     beforeEach(() => {
@@ -96,6 +98,11 @@ describe('SearchPageClient', () => {
         originLevel3: 'origin-level-3',
     });
 
+    const expectSplitTestRun = () => ({
+        splitTestRunName: 'split-test-run-something',
+        splitTestRunVersion: 'split-test-run-something/foo',
+    });
+
     const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
         const [, {body}] = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
@@ -109,6 +116,7 @@ describe('SearchPageClient', () => {
             language: 'en',
             clientId: 'visitor-id',
             ...expectOrigins(),
+            ...expectSplitTestRun(),
         });
     };
 
@@ -123,6 +131,7 @@ describe('SearchPageClient', () => {
             clientId: 'visitor-id',
             ...doc,
             ...expectOrigins(),
+            ...expectSplitTestRun(),
         });
     };
 
@@ -137,6 +146,7 @@ describe('SearchPageClient', () => {
             language: 'en',
             clientId: 'visitor-id',
             ...expectOrigins(),
+            ...expectSplitTestRun(),
         });
     };
 
@@ -151,6 +161,7 @@ describe('SearchPageClient', () => {
             language: 'en',
             clientId: 'visitor-id',
             ...expectOrigins(),
+            ...expectSplitTestRun(),
         });
     };
 

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -42,6 +42,8 @@ export interface SearchPageClientProvider {
     getLanguage: () => string;
     getIsAnonymous: () => boolean;
     getFacetState?: () => FacetStateMetadata[];
+    getSplitTestRunName?: () => string | undefined;
+    getSplitTestRunVersion?: () => string | undefined;
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -417,6 +419,7 @@ export class CoveoSearchPageClient {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
         return {
             ...this.getOrigins(),
+            ...this.getSplitTestRun(),
             customData,
             language: this.provider.getLanguage(),
             facetState: this.provider.getFacetState ? this.provider.getFacetState() : [],
@@ -438,5 +441,14 @@ export class CoveoSearchPageClient {
         return this.coveoAnalyticsClient instanceof CoveoAnalyticsClient
             ? this.coveoAnalyticsClient.getCurrentVisitorId()
             : undefined;
+    }
+
+    private getSplitTestRun() {
+        const splitTestRunName = this.provider.getSplitTestRunName ? this.provider.getSplitTestRunName() : '';
+        const splitTestRunVersion = this.provider.getSplitTestRunVersion ? this.provider.getSplitTestRunVersion() : '';
+        return {
+            ...(splitTestRunName && {splitTestRunName}),
+            ...(splitTestRunVersion && {splitTestRunVersion}),
+        };
     }
 }


### PR DESCRIPTION
This metadata contains information about the A/B test feature of the Search API query pipeline.

By sending back the information to UA, it can be leveraged to create analytics dashboards specifically created to showcase/analyze performance of two different version of a query pipeline.

There is an accompanying PR in Headless related to this.