### PR TITLE
add call to delete http cookie

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -303,6 +303,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         store.clear();
     }
 
+    public deleteHttpOnlyVisitorId() {
+        this.runtime.client.deleteHttpCookieVisitorId();
+    }
+
     async sendSearchEvent(request: SearchEventRequest): Promise<SearchEventResponse | void> {
         return this.sendEvent(EventType.search, request);
     }

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -31,6 +31,10 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         return;
     }
 
+    public deleteHttpCookieVisitorId() {
+        return Promise.resolve();
+    }
+
     private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {
         return this.isEventTypeLegacy(eventType)
             ? this.encodeForLegacyType(eventType, payload)

--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -44,6 +44,12 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
         }
     }
 
+    public async deleteHttpCookieVisitorId() {
+        const {baseUrl} = this.opts;
+        const url = `${baseUrl}/analytics/visit`;
+        await fetch(url, {headers: this.getHeaders(), method: 'DELETE'});
+    }
+
     private shouldAppendVisitorId(eventType: EventType) {
         return [EventType.click, EventType.custom, EventType.search, EventType.view].indexOf(eventType) !== -1;
     }

--- a/src/client/analyticsRequestClient.ts
+++ b/src/client/analyticsRequestClient.ts
@@ -7,6 +7,7 @@ export interface VisitorIdProvider {
 
 export interface AnalyticsRequestClient {
     sendEvent(eventType: string, payload: IRequestPayload): Promise<AnyEventResponse | void>;
+    deleteHttpCookieVisitorId: () => Promise<void>;
 }
 
 export interface IAnalyticsClientOptions {
@@ -29,6 +30,10 @@ export interface IAnalyticsRequestOptions extends RequestInit {
 
 export class NoopAnalyticsClient implements AnalyticsRequestClient {
     public async sendEvent(_: EventType, __: IRequestPayload): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public async deleteHttpCookieVisitorId() {
         return Promise.resolve();
     }
 }


### PR DESCRIPTION
Call the API to delete HTTP cookie for visitorId: https://platform.cloud.coveo.com/docs?urls.primaryName=Usage%20Analytics%20Write#/Analytics%20API%20-%20Version%2015/delete__v15_analytics_visit

It's a bit "overkill" for most modern Coveo implementation, since we typically do not rely on the HTTP only visitorId cookie (it's normally all client side generated).

But, does not hurt too much to add it 🤷 . 
In the eventuality that for some reason that cookie is still used for a particular implementation.