### PR TITLE
KIT-1902 Update react native warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "build": "rollup -c",
         "start": "rollup -c -w --environment SERVE",
         "test": "jest --clearCache && jest --coverage",
-        "test:watch": "jest --watch",
+        "test:watch": "jest --clearCache && jest --watch",
         "prepare-deploy": "mkdir -p deploy && cp dist/coveoua*.js dist/coveoua*.js.map deploy",
         "clean": "rimraf -rf dist dist_test coverage"
     },

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -4,7 +4,7 @@ import {IAnalyticsRequestOptions} from './analyticsRequestClient';
 import {CookieAndLocalStorage, CookieStorage, NullStorage} from '../storage';
 import HistoryStore from '../history';
 import {mockFetch} from '../../tests/fetchMock';
-import {BrowserRuntime, NoopRuntime} from './runtimeEnvironment';
+import {BrowserRuntime} from './runtimeEnvironment';
 import * as doNotTrack from '../donottrack';
 import {Cookie} from '../cookieutils';
 

--- a/src/react-native/index.ts
+++ b/src/react-native/index.ts
@@ -1,2 +1,3 @@
+// TODO: v3 add in "coveo.analytics/react-native" subpackage
 export {ReactNativeRuntime} from './react-native-runtime';
 export {ReactNativeStorage} from './react-native-storage';

--- a/src/react-native/react-native-runtime.ts
+++ b/src/react-native/react-native-runtime.ts
@@ -9,6 +9,7 @@ export class ReactNativeRuntime implements IRuntimeEnvironment {
     public client: AnalyticsFetchClient;
 
     // TODO: v3 switch to ClientOptions type, add default options
+    // TODO: v3 reuse own ReactNativeStorage to implement VisitorIdProvider's getCurrentVisitorId, setCurrentVisitorId
     constructor(clientOptions: IAnalyticsClientOptions) {
         this.storage = new ReactNativeStorage();
         this.client = new AnalyticsFetchClient(clientOptions);

--- a/src/react-native/react-native-runtime.ts
+++ b/src/react-native/react-native-runtime.ts
@@ -4,6 +4,7 @@ import {ReactNativeStorage} from './react-native-storage';
 import {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 import {IAnalyticsClientOptions} from '../client/analyticsRequestClient';
 
+// TODO: improve usability & document use in major version bump
 export class ReactNativeRuntime implements IRuntimeEnvironment {
     public storage: WebStorage;
     public client: AnalyticsFetchClient;

--- a/src/react-native/react-native-runtime.ts
+++ b/src/react-native/react-native-runtime.ts
@@ -4,11 +4,11 @@ import {ReactNativeStorage} from './react-native-storage';
 import {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 import {IAnalyticsClientOptions} from '../client/analyticsRequestClient';
 
-// TODO: improve usability & document use in major version bump
 export class ReactNativeRuntime implements IRuntimeEnvironment {
     public storage: WebStorage;
     public client: AnalyticsFetchClient;
 
+    // TODO: v3 switch to ClientOptions type, add default options
     constructor(clientOptions: IAnalyticsClientOptions) {
         this.storage = new ReactNativeStorage();
         this.client = new AnalyticsFetchClient(clientOptions);

--- a/src/react-native/react-native-utils.ts
+++ b/src/react-native/react-native-utils.ts
@@ -3,11 +3,13 @@ export const ReactNativeRuntimeWarning = `
         for an optimal experience please install @react-native-async-storage/async-storage and instantiate 
         your analytics client as follows:
         
-        import {ReactNativeRuntime} from 'coveo.analytics/react-native';
+        import {ReactNativeRuntime} from 'coveo.analytics/src/react-native';
         
-        const analytics = new CoveoAnalytics({
+        const analytics = new CoveoAnalyticsClient({
             ...your options,
-            runtimeEnvironment: new ReactNativeRuntime();
+            runtimeEnvironment: new ReactNativeRuntime({
+                baseUrl: '...',
+            });
         })
     `;
 

--- a/src/react-native/react-native.spec.ts
+++ b/src/react-native/react-native.spec.ts
@@ -1,0 +1,27 @@
+import CoveoAnalyticsClient from '../client/analytics';
+import {ReactNativeRuntime} from './index';
+
+describe('ReactNativeRuntime', () => {
+    let runtimeEnvironment: ReactNativeRuntime;
+    let client: CoveoAnalyticsClient;
+
+    beforeEach(() => {
+        runtimeEnvironment = new ReactNativeRuntime({
+            baseUrl: 'https://www.coveo.com',
+            visitorIdProvider: {getCurrentVisitorId: jest.fn(), setCurrentVisitorId: jest.fn()},
+        });
+        client = new CoveoAnalyticsClient({runtimeEnvironment});
+    });
+
+    it('should call "storage.getItem" when getting the visitor ID', async () => {
+        spyOn(runtimeEnvironment.storage, 'getItem');
+        await client.getCurrentVisitorId();
+        expect(runtimeEnvironment.storage.getItem).toHaveBeenCalled();
+    });
+
+    it('should call "storage.getItem" when getting the visitor ID', async () => {
+        spyOn(runtimeEnvironment.storage, 'setItem');
+        await client.setCurrentVisitorId('myid');
+        expect(runtimeEnvironment.storage.setItem).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Without breaking, this is how the ReactNative runtime can be used

- the path was wrong, the react-native subfolder is inside the src, [which is exported ](https://github.com/coveo/coveo.analytics.js/blob/master/package.json#L67)
- the client is CoveoAnalyticsClient, not CoveoAnalytics
- there is a required param for the constructor of ReactNativeRuntime

We should definitely improve this in a major version