### PR TITLE
Make "view" events send clientId inside payload

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,7 @@
         });
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
         coveoua('send', 'pageview', '/firstpage');
+        coveoua('send', 'view', {contentIdKey: 'test', contentIdValue: 'value', contentType: 'product'});
 
         setTimeout(function () {
             coveoua('ec:setAction', 'purchase', {storeid: 'amazing'});

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -211,7 +211,7 @@ describe('simpleanalytics', () => {
             expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({somedata: 'asd'});
         });
 
-        it.only('can send view event with clientId', async () => {
+        it('can send view event with clientId', async () => {
             handleOneAnalyticsEvent('init', 'MYTOKEN', {plugins: []});
             await handleOneAnalyticsEvent('send', 'view');
 

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -1,11 +1,12 @@
 import {handleOneAnalyticsEvent} from './simpleanalytics';
-import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
+import {createAnalyticsClientMock, visitorIdMock} from '../../tests/analyticsClientMock';
 import {EC} from '../plugins/ec';
 import {SVC} from '../plugins/svc';
 import {TestPlugin} from '../../tests/pluginMock';
 import {uuidv4} from '../client/crypto';
 import {PluginOptions} from '../plugins/BasePlugin';
 import {mockFetch} from '../../tests/fetchMock';
+import {CookieStorage} from '../storage';
 
 jest.mock('../plugins/svc', () => {
     const SVC = jest.fn().mockImplementation(() => {});
@@ -21,6 +22,11 @@ jest.mock('../plugins/ec', () => {
         EC: EC,
     };
 });
+
+const uuidv4Mock = jest.fn();
+jest.mock('../client/crypto', () => ({
+    uuidv4: () => uuidv4Mock(),
+}));
 
 const {fetchMock, fetchMockBeforeEach} = mockFetch();
 
@@ -46,7 +52,10 @@ describe('simpleanalytics', () => {
         jest.clearAllMocks();
         fetchMockBeforeEach();
 
+        new CookieStorage().removeItem('visitorId');
+        localStorage.clear();
         fetchMock.mock('*', {});
+        uuidv4Mock.mockImplementationOnce(() => visitorIdMock);
         handleOneAnalyticsEvent('reset');
     });
 
@@ -199,7 +208,16 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/pageview`);
-            expect(JSON.parse(fetchMock.lastCall()[1].body.toString())).toEqual({somedata: 'asd'});
+            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({somedata: 'asd'});
+        });
+
+        it.only('can send view event with clientId', async () => {
+            handleOneAnalyticsEvent('init', 'MYTOKEN', {plugins: []});
+            await handleOneAnalyticsEvent('send', 'view');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/view?visitor=${visitorIdMock}`);
+            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString()).clientId).toBe(visitorIdMock);
         });
 
         it('can send any event to the endpoint', async () => {
@@ -227,7 +245,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()[1].body.toString())).toEqual({userId: 'something'});
+            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({userId: 'something'});
         });
 
         it('can set parameters using an object', async () => {
@@ -239,7 +257,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()[1].body.toString())).toEqual({userId: 'something'});
+            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({userId: 'something'});
         });
     });
 
@@ -360,7 +378,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()[1].body.toString())).toEqual({});
+            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({});
         });
     });
 

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -1,4 +1,4 @@
-import {AnyEventResponse, SendEventArguments, VariableArgumentsPayload} from '../events';
+import {AnyEventResponse, EventType, SendEventArguments, VariableArgumentsPayload} from '../events';
 import {AnalyticsClient, CoveoAnalyticsClient, Endpoints} from '../client/analytics';
 import {Plugins} from './plugins';
 import {PluginOptions} from '../plugins/BasePlugin';
@@ -45,6 +45,7 @@ export class CoveoUA {
                 ...payload,
                 ...this.params,
             }));
+            this.client.addEventTypeMapping(EventType.view, {newEventType: EventType.view, addClientIdParameter: true});
         } else {
             throw new Error(`You must pass either your token or a valid object when you call 'init'`);
         }

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -1,6 +1,8 @@
 import {AnalyticsClient} from '../src/client/analytics';
 import {NoopRuntime} from '../src/client/runtimeEnvironment';
 
+export const visitorIdMock = 'mockvisitorid';
+
 export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     getPayload: jest.fn((eventType, ...payload) => Promise.resolve()),
     getParameters: jest.fn((eventType, ...payload) => Promise.resolve()),
@@ -16,4 +18,5 @@ export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     registerAfterSendEventHook: jest.fn(),
     runtime: new NoopRuntime(),
     currentVisitorId: '',
+    getCurrentVisitorId: jest.fn(() => Promise.resolve(visitorIdMock)),
 });


### PR DESCRIPTION
Headless (SearchPageClient) properly sends the client id as part of the payload, but not the simple analytics client & its view event which we make customer use to register view events

- https://docs.coveo.com/en/headless/latest/usage/headless-usage-analytics/headless-view-events/
- https://coveord.atlassian.net/browse/KIT-1846
- https://discuss.coveo.com/t/support-00079621-clientid-null-in-view-event-page-views-not-tracked-properly-as-a-result/7922/22
- https://discuss.coveo.com/t/migration-from-visitor-id-to-client-id/8217