### PR TITLE
fixed browser export to match typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "coveo.analytics",
-    "version": "2.20.20",
+    "version": "2.20.18",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",
-    "browser": "dist/coveoua.browser.js",
+    "browser": "dist/coveoua.js",
     "types": "dist/definitions/coveoua/library.d.ts",
     "scripts": {
         "lint:check": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.20.18",
+    "version": "2.20.21",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,12 @@ const browserUMD = {
             name: 'coveoua',
             sourcemap: true,
         },
+        {
+            file: './dist/coveoua.browser.js',
+            format: 'umd',
+            name: 'coveoua',
+            sourcemap: true,
+        },
     ],
     plugins: [
         browserFetch(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,12 +31,6 @@ const browserUMD = {
             name: 'coveoua',
             sourcemap: true,
         },
-        {
-            file: './dist/coveoua.browser.js',
-            format: 'iife',
-            name: 'coveoua',
-            sourcemap: true,
-        },
     ],
     plugins: [
         browserFetch(),

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -41,4 +41,4 @@ if (coveoua.q) {
     [...initEvents, ...otherEvents].forEach((args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args));
 }
 
-export default self.coveoua;
+export default analytics;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2003

Not completely sure about merging this, but opening a PR nonetheless to at-least discuss the issue.

# Where relevant files come from
* `coveoua.js` is generated by rollup from `browser.ts` in UMD format.
* `coveoua.browser.js` is generated by rollup from `browser.ts` in IIFE format.
* `library.js` is generated by rollup from `library.ts` in CommonJS format.
* `library.d.ts` is generated by typescript from `library.ts`. It's the file `package.json`'s `type` key points to.

# The problem
There's a mismatch between what's actually exported by `coveoua.js`/`coveoua.browser.js` and the types defined by `library.d.ts`.

With Next.JS, trying to import and use `CoveoAnalyticsClient` from `coveo.analytics` client-side caused the following error, even though the code editor shows no error:
![image](https://user-images.githubusercontent.com/54454747/188897778-d7fc44a4-02e8-41d9-8f86-be35baecc4b3.png)

# The cause
Client-side, Next.JS was using the `coveoua.browser.js` file from `coveo.analytics`. 

`coveoua.browser.js` doesn't work in Next.JS for two reasons:
1. Since `coveoua.browser.js` is generated in IIFE format, all exports are stripped.
2. Even if export were to not be stripped (such as in `coveoua.js`), `browser.ts` exports the `coveoua` function as a default export and doesn't export anything else.

Even when changing the `browser` key to a different file in `package.json`, Next.JS still uses the same file.

# The solution

# Part 1
According to [rollup's documentation](https://rollupjs.org/guide/en/#outputformat):
> Universal Module Definition, works as `amd`, `cjs` and `iife` all in one

Therefore, the `coveoua.browser.js` file is redundant and we could technically remove it. However, since it's included in the deployment package, I decided to instead change its format to `"umd"` just like the other file. Simply copying `coveo.js` to `coveo.browser.js` wouldn't work since there's `.map` files associated which each files.

I tested, and with the UMD format, `window.coveoua` and `window.coveoanalytics` are still defined.

# Part 2
I changed the export of `browser.ts` to match `library.ts`.

This is technically breaking if somebody loaded `coveoua.js` without Typescript for the sole purpose of calling its default export (the `coveoua` function) directly despite it existing already in `window.coveoua`. For this reason, I'm more hesitant to merge this PR, although this issue seems somewhat unlikely.