### PR TITLE
added analytics for smart snippet inline links

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -633,6 +633,32 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #logOpenSmartSnippetInlineLink', async () => {
+        const meta = {
+            ...fakeDocID,
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        await client.logOpenSmartSnippetInlineLink(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetSuggestionInlineLink', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        await client.logOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, {
+            ...meta,
+            contentIDKey: meta.documentId.contentIdKey,
+            contentIDValue: meta.documentId.contentIdValue,
+        });
+    });
+
     it('should send proper payload for #logRecentQueryClick', async () => {
         await client.logRecentQueryClick();
         expectMatchPayload(SearchPageEvents.recentQueryClick);

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -26,6 +26,7 @@ import {
     StaticFilterMetadata,
     StaticFilterToggleValueMetadata,
     UndoTriggerRedirectMetadata,
+    SmartSnippetLinkMeta,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -325,6 +326,33 @@ export class CoveoSearchPageClient {
             info,
             {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
             snippet
+        );
+    }
+
+    public logOpenSmartSnippetInlineLink(
+        info: PartialDocumentInformation,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetInlineLink,
+            info,
+            {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
+            identifierAndLink
+        );
+    }
+
+    public logOpenSmartSnippetSuggestionInlineLink(
+        info: PartialDocumentInformation,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetSuggestionInlineLink,
+            info,
+            {
+                contentIDKey: snippetAndLink.documentId.contentIdKey,
+                contentIDValue: snippetAndLink.documentId.contentIdValue,
+            },
+            snippetAndLink
         );
     }
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -239,6 +239,14 @@ export enum SearchPageEvents {
      */
     openSmartSnippetSuggestionSource = 'openSmartSnippetSuggestionSource',
     /**
+     * Identifies the custom event that gets logged when a user clicks on a link in the answer of a smart snippet.
+     */
+    openSmartSnippetInlineLink = 'openSmartSnippetInlineLink',
+    /**
+     * Identifies the custom event that gets logged when a user clicks on a link in the snippet suggestion for a related question.
+     */
+    openSmartSnippetSuggestionInlineLink = 'openSmartSnippetSuggestionInlineLink',
+    /**
      * Identifies the search event that gets logged when a recent queries list item gets clicked.
      */
     recentQueryClick = 'recentQueriesClick',
@@ -417,6 +425,11 @@ export interface SmartSnippetSuggestionMeta {
     question: string;
     answerSnippet: string;
     documentId: SmartSnippetDocumentIdentifier;
+}
+
+export interface SmartSnippetLinkMeta {
+    linkText: string;
+    linkURL: string;
 }
 
 export interface SmartSnippetDocumentIdentifier {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2014

Copies https://github.com/coveo/search-ui/pull/1901

Analytics logged when clicking this:
![image](https://user-images.githubusercontent.com/54454747/189692780-9046cc83-1726-47eb-9c33-a876082816ff.png)
