### PR TITLE
[SFINT-4631] Case metadata added to the insight analytics events

### DIFF
--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -1,3 +1,16 @@
+import {
+    CategoryFacetMetadata,
+    FacetBaseMeta,
+    FacetMetadata,
+    FacetRangeMetadata,
+    FacetSortMeta,
+    InterfaceChangeMetadata,
+    PagerMetadata,
+    QueryErrorMeta,
+    ResultsSortMetadata,
+    StaticFilterToggleValueMetadata,
+} from '../searchPage/searchPageEvents';
+
 export enum InsightEvents {
     /**
      * Identifies the search event that gets logged when the query context is updated as a result of updating one of the case context fields.
@@ -9,15 +22,33 @@ export enum InsightEvents {
     expandToFullUI = 'expandToFullUI',
 }
 
-interface CaseMetadata {
-    caseId: string;
-    caseNumber: string;
-    caseContext: Record<string, string>;
+export interface CaseMetadata {
+    caseId?: string;
+    caseNumber?: string;
+    caseContext?: Record<string, string>;
 }
-
-export interface ContextChangedMetadata extends CaseMetadata {}
 
 export interface ExpandToFullUIMetadata extends CaseMetadata {
     fullSearchComponentName: string;
     triggeredBy: string;
 }
+
+export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}
+
+export interface InsightFacetMetadata extends FacetMetadata, CaseMetadata {}
+
+export interface InsightStaticFilterToggleValueMetadata extends StaticFilterToggleValueMetadata, CaseMetadata {}
+
+export interface InsightFacetRangeMetadata extends FacetRangeMetadata, CaseMetadata {}
+
+export interface InsightCategoryFacetMetadata extends CategoryFacetMetadata, CaseMetadata {}
+
+export interface InsightFacetSortMeta extends FacetSortMeta, CaseMetadata {}
+
+export interface InsightFacetBaseMeta extends FacetBaseMeta, CaseMetadata {}
+
+export interface InsightQueryErrorMeta extends QueryErrorMeta, CaseMetadata {}
+
+export interface InsightPagerMetadata extends PagerMetadata, CaseMetadata {}
+
+export interface InsightResultsSortMetadata extends ResultsSortMetadata, CaseMetadata {}


### PR DESCRIPTION
[SFINT-4631](https://coveord.atlassian.net/browse/SFINT-4631)

In this PR I added the possibility to include the case metadata in the analytics event sent for the insight panel.
I tried adding this possibility without introducing any breaking change.

# Examples

## Search Event

#### Example of the payload sent in a search event (`searchboxSubmit`) before this PR:

<img width="496" alt="Before" src="https://user-images.githubusercontent.com/86681870/190156831-17ae0dca-2f21-4bde-838b-79bd2e3ed139.png">

#### Example of the payload that need to be sent in a search event (`searchboxSubmit`) :

<img width="503" alt="SearchboxSubmitEent" src="https://user-images.githubusercontent.com/86681870/190156037-680a1483-8001-4494-aca6-2a627fae014b.png">

## Custom Event

#### Example of the payload sent in a custom event (`getMoreResults`) before this PR:

<img width="501" alt="BeforeCustom" src="https://user-images.githubusercontent.com/86681870/190157956-7a414893-063f-4c3f-8c41-bf2ee9726354.png">


#### Example of the payload that need to be sent in a custom event (`getMoreResullts`) :

<img width="471" alt="AfterCustom" src="https://user-images.githubusercontent.com/86681870/190158109-e8aacf0d-229d-4488-9e43-8a2e02c19c86.png">


