### PR TITLE
KIT-2058 added "make" functions to prepare search analytics

### DIFF
--- a/src/coveoua/library.ts
+++ b/src/coveoua/library.ts
@@ -7,7 +7,12 @@ export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/anal
 export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
 export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
 export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
-export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
+export {
+    CoveoSearchPageClient,
+    SearchPageClientProvider,
+    EventDescription,
+    EventBuilder,
+} from '../searchPage/searchPageClient';
 export {CaseAssistClient, CaseAssistClientProvider} from '../caseAssist/caseAssistClient';
 export {CoveoInsightClient, InsightClientProvider} from '../insight/insightClient';
 

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1,4 +1,4 @@
-import {CoveoSearchPageClient, SearchPageClientProvider} from './searchPageClient';
+import {CoveoSearchPageClient, EventDescription, SearchPageClientProvider} from './searchPageClient';
 import {
     SearchPageEvents,
     PartialDocumentInformation,
@@ -120,6 +120,14 @@ describe('SearchPageClient', () => {
         });
     };
 
+    const expectMatchDescription = (description: EventDescription, actionCause: SearchPageEvents, meta = {}) => {
+        const customData = {foo: 'bar', ...meta};
+        expect(description).toMatchObject({
+            actionCause,
+            customData,
+        });
+    };
+
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
         const [, {body}] = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
@@ -174,6 +182,13 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.interfaceLoad);
     });
 
+    it('should send proper payload for #makeInterfaceLoad', async () => {
+        const built = client.makeInterfaceLoad();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.interfaceLoad);
+        expectMatchDescription(built.description, SearchPageEvents.interfaceLoad);
+    });
+
     it('should send proper payload for #interfaceChange', async () => {
         await client.logInterfaceChange({
             interfaceChangeTo: 'bob',
@@ -181,9 +196,23 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
     });
 
+    it('should send proper payload for #makeInterfaceChange', async () => {
+        const built = client.makeInterfaceChange({interfaceChangeTo: 'bob'});
+        await built.log();
+        expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+        expectMatchDescription(built.description, SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+    });
+
     it('should send proper payload for #didyoumeanAutomatic', async () => {
         await client.logDidYouMeanAutomatic();
         expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
+    });
+
+    it('should send proper payload for #makeDidyoumeanAutomatic', async () => {
+        const built = client.makeDidYouMeanAutomatic();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
+        expectMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
     });
 
     it('should send proper payload for #didyoumeanClick', async () => {
@@ -191,9 +220,23 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.didyoumeanClick);
     });
 
+    it('should send proper payload for #makeDidyoumeanClick', async () => {
+        const built = client.makeDidYouMeanClick();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.didyoumeanClick);
+        expectMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
+    });
+
     it('should send proper payload for #resultsSort', async () => {
         await client.logResultsSort({resultsSortBy: 'date ascending'});
         expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+    });
+
+    it('should send proper payload for #makeResultsSort', async () => {
+        const built = client.makeResultsSort({resultsSortBy: 'date ascending'});
+        await built.log();
+        expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+        expectMatchDescription(built.description, SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
     });
 
     it('should send proper payload for #searchboxSubmit', async () => {
@@ -201,9 +244,23 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.searchboxSubmit);
     });
 
+    it('should send proper payload for #makeSearchboxSubmit', async () => {
+        const built = client.makeSearchboxSubmit();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.searchboxSubmit);
+        expectMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
+    });
+
     it('should send proper payload for #searchboxClear', async () => {
         await client.logSearchboxClear();
         expectMatchPayload(SearchPageEvents.searchboxClear);
+    });
+
+    it('should send proper payload for #makeSearchboxClear', async () => {
+        const built = client.makeSearchboxClear();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.searchboxClear);
+        expectMatchDescription(built.description, SearchPageEvents.searchboxClear);
     });
 
     it('should send proper payload for #searchboxAsYouType', async () => {
@@ -211,9 +268,11 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.searchboxAsYouType);
     });
 
-    it('should send proper payload for #searchboxAsYouType', async () => {
-        await client.logBreadcrumbResetAll();
-        expectMatchPayload(SearchPageEvents.breadcrumbResetAll);
+    it('should send proper payload for #makeSearchboxAsYouType', async () => {
+        const built = client.makeSearchboxAsYouType();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.searchboxAsYouType);
+        expectMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
     });
 
     it('should send proper payload for #documentQuickview', async () => {
@@ -221,9 +280,23 @@ describe('SearchPageClient', () => {
         expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
     });
 
+    it('should send proper payload for #makeDocumentQuickview', async () => {
+        const built = client.makeDocumentQuickview(fakeDocInfo, fakeDocID);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.documentQuickview, {...fakeDocID});
+    });
+
     it('should send proper payload for #documentOpen', async () => {
         await client.logDocumentOpen(fakeDocInfo, fakeDocID);
         expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeDocumentOpen', async () => {
+        const built = client.makeDocumentOpen(fakeDocInfo, fakeDocID);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.documentOpen, {...fakeDocID});
     });
 
     it('should send proper payload for #showMoreFoldedResults', async () => {
@@ -231,9 +304,23 @@ describe('SearchPageClient', () => {
         expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
     });
 
+    it('should send proper payload for #makeShowMoreFoldedResults', async () => {
+        const built = client.makeShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.showMoreFoldedResults, fakeDocID);
+    });
+
     it('should send proper payload for #showLessFoldedResults', async () => {
         await client.logShowLessFoldedResults();
         expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+    });
+
+    it('should send proper payload for #makeShowLessFoldedResults', async () => {
+        const built = client.makeShowLessFoldedResults();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+        expectMatchDescription(built.description, SearchPageEvents.showLessFoldedResults);
     });
 
     it('should send proper payload for #omniboxAnalytics', async () => {
@@ -248,6 +335,20 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
     });
 
+    it('should send proper payload for #makeOmniboxAnalytics', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        const built = client.makeOmniboxAnalytics(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
+        expectMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
+    });
+
     it('should send proper payload for #logOmniboxFromLink', async () => {
         const meta: OmniboxSuggestionsMetadata = {
             partialQueries: 'a;b;c',
@@ -260,9 +361,30 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
     });
 
+    it('should send proper payload for #makeOmniboxFromLink', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        const built = client.makeOmniboxFromLink(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
+        expectMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
+    });
+
     it('should send proper payload for #logSearchFromLink', async () => {
         await client.logSearchFromLink();
         expectMatchPayload(SearchPageEvents.searchFromLink);
+    });
+
+    it('should send proper payload for #makeSearchFromLink', async () => {
+        const built = client.makeSearchFromLink();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.searchFromLink);
+        expectMatchDescription(built.description, SearchPageEvents.searchFromLink);
     });
 
     it('should send proper payload for #logTriggerNotify', async () => {
@@ -273,12 +395,32 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
     });
 
+    it('should send proper payload for #makeTriggerNotify', async () => {
+        const meta = {
+            notification: 'foo',
+        };
+        const built = client.makeTriggerNotify(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerNotify, meta);
+    });
+
     it('should send proper payload for #logTriggerExecute', async () => {
         const meta = {
             executed: 'foo',
         };
         await client.logTriggerExecute(meta);
         expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
+    });
+
+    it('should send proper payload for #makeTriggerExecute', async () => {
+        const meta = {
+            executed: 'foo',
+        };
+        const built = client.makeTriggerExecute(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerExecute, meta);
     });
 
     it('should send proper payload for #logTriggerQuery', async () => {
@@ -289,12 +431,32 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
     });
 
+    it('should send proper payload for #makeTriggerQuery', async () => {
+        const meta = {
+            query: 'queryText',
+        };
+        const built = client.makeTriggerQuery();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
+        expectMatchDescription(built.description, SearchPageEvents.triggerQuery, meta);
+    });
+
     it('should send proper payload for #logUndoTriggerQuery', async () => {
         const meta = {
             undoneQuery: 'foo',
         };
         await client.logUndoTriggerQuery(meta);
         expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
+    });
+
+    it('should send proper payload for #makeUndoTriggerQuery', async () => {
+        const meta = {
+            undoneQuery: 'foo',
+        };
+        const built = client.makeUndoTriggerQuery(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
+        expectMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
     });
 
     it('should send proper payload for #logTriggerRedirect', async () => {
@@ -305,6 +467,16 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
     });
 
+    it('should send proper payload for #makeTriggerRedirect', async () => {
+        const meta = {
+            redirectedTo: 'foo',
+        };
+        const built = client.makeTriggerRedirect(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerRedirect, meta);
+    });
+
     it('should send proper payload for #logPagerResize', async () => {
         const meta = {
             currentResultsPerPage: 123,
@@ -313,10 +485,28 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
     });
 
+    it('should send proper payload for #makePagerResize', async () => {
+        const meta = {
+            currentResultsPerPage: 123,
+        };
+        const built = client.makePagerResize(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerResize, meta);
+    });
+
     it('should send proper payload for #logPagerNumber', async () => {
         const meta = {pagerNumber: 123};
         await client.logPagerNumber(meta);
         expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
+    });
+
+    it('should send proper payload for #makePagerNumber', async () => {
+        const meta = {pagerNumber: 123};
+        const built = client.makePagerNumber(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerNumber, meta);
     });
 
     it('should send proper payload for #logPagerNext', async () => {
@@ -325,10 +515,26 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
     });
 
+    it('should send proper payload for #makePagerNext', async () => {
+        const meta = {pagerNumber: 123};
+        const built = client.makePagerNext(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerNext, meta);
+    });
+
     it('should send proper payload for #logPagerPrevious', async () => {
         const meta = {pagerNumber: 123};
         await client.logPagerPrevious(meta);
         expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
+    });
+
+    it('should send proper payload for #makePagerPrevious', async () => {
+        const meta = {pagerNumber: 123};
+        const built = client.makePagerPrevious(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerPrevious, meta);
     });
 
     it('should send proper payload for #logPagerScrolling', async () => {
@@ -336,11 +542,26 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
     });
 
+    it('should send proper payload for #makePagerScrolling', async () => {
+        const built = client.makePagerScrolling();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
+        expectMatchDescription(built.description, SearchPageEvents.pagerScrolling);
+    });
+
     it('should send the proper payload for #logStaticFilterClearAll', async () => {
         const staticFilterId = 'filetypes';
         await client.logStaticFilterClearAll({staticFilterId});
 
         expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
+    });
+
+    it('should send the proper payload for #makeStaticFilterClearAll', async () => {
+        const staticFilterId = 'filetypes';
+        const built = client.makeStaticFilterClearAll({staticFilterId});
+        await built.log();
+        expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
+        expectMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
     });
 
     it('should send the proper payload for #logStaticFilterSelect', async () => {
@@ -356,6 +577,21 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
     });
 
+    it('should send the proper payload for #makeStaticFilterSelect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        const built = client.makeStaticFilterSelect(meta);
+        await built.log();
+
+        expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
+    });
+
     it('should send the proper payload for #logStaticFilterDeselect', async () => {
         const meta: StaticFilterToggleValueMetadata = {
             staticFilterId: 'filetypes',
@@ -369,6 +605,20 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
     });
 
+    it('should send the proper payload for #makeStaticFilterDeselect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        const built = client.makeStaticFilterDeselect(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
+    });
+
     it('should send proper payload for #logFacetSearch', async () => {
         const meta = {
             facetField: '@foo',
@@ -377,6 +627,18 @@ describe('SearchPageClient', () => {
         };
         await client.logFacetSearch(meta);
         expectMatchPayload(SearchPageEvents.facetSearch, meta);
+    });
+
+    it('should send proper payload for #makeFacetSearch', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = client.makeFacetSearch(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetSearch, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
     });
 
     it('should send proper payload for #logFacetSelect', async () => {
@@ -391,6 +653,19 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.facetSelect, meta);
     });
 
+    it('should send proper payload for #makeFacetSelect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = await client.makeFacetSelect(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetSelect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
+    });
+
     it('should send proper payload for #logFacetDeselect', async () => {
         const meta = {
             facetField: '@foo',
@@ -401,6 +676,20 @@ describe('SearchPageClient', () => {
 
         await client.logFacetDeselect(meta);
         expectMatchPayload(SearchPageEvents.facetDeselect, meta);
+    });
+
+    it('should send proper payload for #makeFacetDeselect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+
+        const built = client.makeFacetDeselect(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetDeselect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
     });
 
     it('should send proper payload for #logFacetExclude', async () => {
@@ -414,6 +703,19 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.facetExclude, meta);
     });
 
+    it('should send proper payload for #makeFacetExclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = client.makeFacetExclude(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetExclude, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
+    });
+
     it('should send proper payload for #logFacetUnexclude', async () => {
         const meta = {
             facetField: '@foo',
@@ -425,6 +727,19 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
     });
 
+    it('should send proper payload for #makeFacetUnexclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = client.makeFacetUnexclude(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
+    });
+
     it('should send proper payload for #logFacetSelectAll', async () => {
         const meta = {
             facetField: '@foo',
@@ -433,6 +748,18 @@ describe('SearchPageClient', () => {
         };
         await client.logFacetSelectAll(meta);
         expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
+    });
+
+    it('should send proper payload for #makeFacetSelectAll', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = client.makeFacetSelectAll(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
     });
 
     it('should send proper payload for #logFacetUpdateSort', async () => {
@@ -446,6 +773,19 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
     });
 
+    it('should send proper payload for #makeFacetUpdateSort', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            criteria: 'bazz',
+        };
+        const built = client.makeFacetUpdateSort(meta);
+        await built.log();
+        expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
+    });
+
     it('should send proper payload for #logFacetShowMore', async () => {
         const meta = {
             facetField: '@foo',
@@ -456,6 +796,18 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
     });
 
+    it('should send proper payload for #makeFacetShowMore', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = client.makeFacetShowMore(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetShowMore, meta);
+    });
+
     it('should send proper payload for #logFacetShowLess', async () => {
         const meta = {
             facetField: '@foo',
@@ -464,6 +816,18 @@ describe('SearchPageClient', () => {
         };
         await client.logFacetShowLess(meta);
         expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
+    });
+
+    it('should send proper payload for #makeFacetShowLess', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = client.makeFacetShowLess(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetShowLess, meta);
     });
 
     it('should send proper payload for #logQueryError', async () => {
@@ -479,9 +843,32 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
     });
 
+    it('should send proper payload for #makeQueryError', async () => {
+        const meta = {
+            query: 'q',
+            aq: 'aq',
+            cq: 'cq',
+            dq: 'dq',
+            errorMessage: 'boom',
+            errorType: 'a bad one',
+        };
+        const built = client.makeQueryError(meta);
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
+        expectMatchDescription(built.description, SearchPageEvents.queryError, meta);
+    });
+
     it('should send proper payload for #logQueryErrorBack', async () => {
         await client.logQueryErrorBack();
         expectMatchPayload(SearchPageEvents.queryErrorBack);
+    });
+
+    it('should send proper payload for #makeQueryErrorBack', async () => {
+        const built = client.makeQueryErrorBack();
+        await built.log();
+
+        expectMatchPayload(SearchPageEvents.queryErrorBack);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorBack);
     });
 
     it('should send proper payload for #logQueryErrorRetry', async () => {
@@ -489,9 +876,23 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.queryErrorRetry);
     });
 
+    it('should send proper payload for #makeQueryErrorRetry', async () => {
+        const built = client.makeQueryErrorRetry();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.queryErrorRetry);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorRetry);
+    });
+
     it('should send proper payload for #logQueryErrorClear', async () => {
         await client.logQueryErrorClear();
         expectMatchPayload(SearchPageEvents.queryErrorClear);
+    });
+
+    it('should send proper payload for #makeQueryErrorClear', async () => {
+        const built = client.makeQueryErrorClear();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.queryErrorClear);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorClear);
     });
 
     it('should send proper payload for #logRecommendationInterfaceLoad', async () => {
@@ -499,8 +900,21 @@ describe('SearchPageClient', () => {
         expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
     });
 
+    it('should send proper payload for #makeRecommendationInterfaceLoad', async () => {
+        const built = client.makeRecommendationInterfaceLoad();
+        await built.log();
+        expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
+        expectMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
+    });
+
     it('should send proper payload for #logRecommendation', async () => {
         await client.logRecommendation();
+        expectMatchCustomEventPayload(SearchPageEvents.recommendation);
+    });
+
+    it('should send proper payload for #makeRecommendation', async () => {
+        const built = client.makeRecommendation();
+        await built.log();
         expectMatchCustomEventPayload(SearchPageEvents.recommendation);
     });
 
@@ -509,9 +923,23 @@ describe('SearchPageClient', () => {
         expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
     });
 
+    it('should send proper payload for #makeRecommendationOpen', async () => {
+        const built = client.makeRecommendationOpen(fakeDocInfo, fakeDocID);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.recommendationOpen, {...fakeDocID});
+    });
+
     it('should send proper payload for #fetchMoreResults', async () => {
         await client.logFetchMoreResults();
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    });
+
+    it('should send proper payload for #makeFetchMoreResults', async () => {
+        const built = client.makeFetchMoreResults();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+        expectMatchDescription(built.description, SearchPageEvents.pagerScrolling);
     });
 
     it('should send proper payload for #logLikeSmartSnippet', async () => {
@@ -519,9 +947,23 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
     });
 
+    it('should send proper payload for #makeLikeSmartSnippet', async () => {
+        const built = client.makeLikeSmartSnippet();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.likeSmartSnippet);
+    });
+
     it('should send proper payload for #logDislikeSmartSnippet', async () => {
         await client.logDislikeSmartSnippet();
         expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
+    });
+
+    it('should send proper payload for #makeDislikeSmartSnippet', async () => {
+        const built = client.makeDislikeSmartSnippet();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.dislikeSmartSnippet);
     });
 
     it('should send proper payload for #logExpandSmartSnippet', async () => {
@@ -529,9 +971,23 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
     });
 
+    it('should send proper payload for #makeExpandSmartSnippet', async () => {
+        const built = client.makeExpandSmartSnippet();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippet);
+    });
+
     it('should send proper payload for #logCollapseSmartSnippet', async () => {
         await client.logCollapseSmartSnippet();
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
+    });
+
+    it('should send proper payload for #makeCollapseSmartSnippet', async () => {
+        const built = client.makeCollapseSmartSnippet();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippet);
     });
 
     it('should send proper payload for #logOpenSmartSnippetFeedbackModal', async () => {
@@ -539,14 +995,41 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
     });
 
+    it('should send proper payload for #makeOpenSmartSnippetFeedbackModal', async () => {
+        const built = client.makeOpenSmartSnippetFeedbackModal();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetFeedbackModal);
+    });
+
     it('should send proper payload for #logCloseSmartSnippetFeedbackModal', async () => {
         await client.logCloseSmartSnippetFeedbackModal();
         expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
     });
 
+    it('should send proper payload for #makeCloseSmartSnippetFeedbackModal', async () => {
+        const built = client.makeCloseSmartSnippetFeedbackModal();
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
+        expectMatchDescription(built.description, SearchPageEvents.closeSmartSnippetFeedbackModal);
+    });
+
     it('should send proper payload for #logSmartSnippetFeedbackReason', async () => {
         await client.logSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
         expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
+            details: 'this is irrelevant',
+            reason: 'does_not_answer',
+        });
+    });
+
+    it('should send proper payload for #makeSmartSnippetFeedbackReason', async () => {
+        const built = client.makeSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
+            details: 'this is irrelevant',
+            reason: 'does_not_answer',
+        });
+        expectMatchDescription(built.description, SearchPageEvents.sendSmartSnippetReason, {
             details: 'this is irrelevant',
             reason: 'does_not_answer',
         });
@@ -559,6 +1042,25 @@ describe('SearchPageClient', () => {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeExpandSmartSnippetSuggestion', async () => {
+        const built = client.makeExpandSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
@@ -578,6 +1080,25 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #makeCollapseSmartSnippetSuggestion', async () => {
+        const built = client.makeCollapseSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
     it('should send proper payload for #logExpandSmartSnippetSuggestion when called with only the documentId', async () => {
         await client.logExpandSmartSnippetSuggestion({contentIdKey: 'permanentid', contentIdValue: 'foo'});
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
@@ -585,9 +1106,34 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #makeExpandSmartSnippetSuggestion when called with only the documentId', async () => {
+        const built = client.makeExpandSmartSnippetSuggestion({
+            contentIdKey: 'permanentid',
+            contentIdValue: 'foo',
+        });
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
     it('should send proper payload for #logCollapseSmartSnippetSuggestion when called with only the documentId', async () => {
         await client.logCollapseSmartSnippetSuggestion({contentIdKey: 'permanentid', contentIdValue: 'foo'});
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeCollapseSmartSnippetSuggestion when called with only the documentId', async () => {
+        const built = client.makeCollapseSmartSnippetSuggestion({contentIdKey: 'permanentid', contentIdValue: 'foo'});
+        await built.log();
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippetSuggestion, {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
     });
@@ -601,7 +1147,6 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.showMoreSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
-            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
     });
 
@@ -623,6 +1168,13 @@ describe('SearchPageClient', () => {
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
     });
 
+    it('should send proper payload for #makeOpenSmartSnippetSource', async () => {
+        const built = client.makeOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSource, {...fakeDocID});
+    });
+
     it('should send proper payload for #logOpenSmartSnippetSuggestionSource', async () => {
         const meta = {
             question: 'Abc',
@@ -637,6 +1189,18 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #makeOpenSmartSnippetSuggestionSource', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+        const built = client.makeOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionSource, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionSource, meta);
+    });
+
     it('should send proper payload for #logOpenSmartSnippetInlineLink', async () => {
         const meta = {
             ...fakeDocID,
@@ -645,6 +1209,18 @@ describe('SearchPageClient', () => {
         };
         await client.logOpenSmartSnippetInlineLink(fakeDocInfo, meta);
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetInlineLink', async () => {
+        const meta = {
+            ...fakeDocID,
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        const built = client.makeOpenSmartSnippetInlineLink(fakeDocInfo, meta);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetInlineLink, meta);
     });
 
     it('should send proper payload for #logOpenSmartSnippetSuggestionInlineLink', async () => {
@@ -663,14 +1239,44 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #makeOpenSmartSnippetSuggestionInlineLink', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        const built = client.makeOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
+        await built.log();
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionInlineLink, meta);
+    });
+
     it('should send proper payload for #logRecentQueryClick', async () => {
         await client.logRecentQueryClick();
         expectMatchPayload(SearchPageEvents.recentQueryClick);
     });
 
+    it('should send proper payload for #makeRecentQueryClick', async () => {
+        const built = client.makeRecentQueryClick();
+        await built.log();
+
+        expectMatchPayload(SearchPageEvents.recentQueryClick);
+        expectMatchDescription(built.description, SearchPageEvents.recentQueryClick);
+    });
+
     it('should send proper payload for #logClearRecentQueries', async () => {
         await client.logClearRecentQueries();
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
+    });
+
+    it('should send proper payload for #makeClearRecentQueries', async () => {
+        const built = client.makeClearRecentQueries();
+        await built.log();
+
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
+        expectMatchDescription(built.description, SearchPageEvents.clearRecentQueries);
     });
 
     it('should send proper payload for #logRecentResultClick', async () => {
@@ -681,9 +1287,32 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #makeRecentResultClick', async () => {
+        const built = client.makeRecentResultClick(fakeDocInfo, fakeDocID);
+        await built.log();
+
+        expectMatchCustomEventPayload(SearchPageEvents.recentResultClick, {
+            info: fakeDocInfo,
+            identifier: fakeDocID,
+        });
+
+        expectMatchDescription(built.description, SearchPageEvents.recentResultClick, {
+            info: fakeDocInfo,
+            identifier: fakeDocID,
+        });
+    });
+
     it('should send proper payload for #logNoResultsBack', async () => {
         await client.logNoResultsBack();
         expectMatchPayload(SearchPageEvents.noResultsBack);
+    });
+
+    it('should send proper payload for #makeNoResultsBack', async () => {
+        const built = client.makeNoResultsBack();
+        await built.log();
+
+        expectMatchPayload(SearchPageEvents.noResultsBack);
+        expectMatchDescription(built.description, SearchPageEvents.noResultsBack);
     });
 
     it('should send proper payload for #logClearRecentResults', async () => {
@@ -691,9 +1320,25 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
     });
 
+    it('should send proper payload for #makeClearRecentResults', async () => {
+        const built = client.makeClearRecentResults();
+        await built.log();
+
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
+        expectMatchDescription(built.description, SearchPageEvents.clearRecentResults);
+    });
+
     it('should send proper payload for #logCustomEventWithType', async () => {
         await client.logCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
         expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
+    });
+
+    it('should send proper payload for #makeCustomEventWithType', async () => {
+        const built = client.makeCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
+        await built.log();
+
+        expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
+        expectMatchDescription(built.description, 'foo' as SearchPageEvents, {buzz: 'bazz'});
     });
 
     it('should enable analytics tracking by default', () => {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -1,5 +1,13 @@
 import CoveoAnalyticsClient, {ClientOptions, AnalyticsClient} from '../client/analytics';
-import {SearchEventRequest, ClickEventRequest, CustomEventRequest} from '../events';
+import {
+    SearchEventRequest,
+    ClickEventRequest,
+    CustomEventRequest,
+    SearchEventResponse,
+    AnyEventResponse,
+    ClickEventResponse,
+    CustomEventResponse,
+} from '../events';
 import {
     SearchPageEvents,
     OmniboxSuggestionsMetadata,
@@ -52,6 +60,13 @@ export interface SearchPageClientOptions extends ClientOptions {
     enableAnalytics: boolean;
 }
 
+export type EventDescription = Pick<SearchEventRequest, 'actionCause' | 'customData'>;
+
+export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
+    description: EventDescription;
+    log: () => Promise<T | void>;
+}
+
 export class CoveoSearchPageClient {
     public coveoAnalyticsClient: AnalyticsClient;
 
@@ -64,6 +79,7 @@ export class CoveoSearchPageClient {
         if (this.coveoAnalyticsClient instanceof CoveoAnalyticsClient) {
             this.coveoAnalyticsClient.clear();
         }
+
         this.coveoAnalyticsClient = new NoopAnalytics();
     }
 
@@ -71,257 +87,515 @@ export class CoveoSearchPageClient {
         this.coveoAnalyticsClient = new CoveoAnalyticsClient(this.opts);
     }
 
+    public makeInterfaceLoad() {
+        return this.makeSearchEvent(SearchPageEvents.interfaceLoad);
+    }
+
     public logInterfaceLoad() {
-        return this.logSearchEvent(SearchPageEvents.interfaceLoad);
+        return this.makeInterfaceLoad().log();
+    }
+
+    public makeRecommendationInterfaceLoad() {
+        return this.makeSearchEvent(SearchPageEvents.recommendationInterfaceLoad);
     }
 
     public logRecommendationInterfaceLoad() {
-        return this.logSearchEvent(SearchPageEvents.recommendationInterfaceLoad);
+        return this.makeRecommendationInterfaceLoad().log();
+    }
+
+    public makeRecommendation() {
+        return this.makeCustomEvent(SearchPageEvents.recommendation);
     }
 
     public logRecommendation() {
-        return this.logCustomEvent(SearchPageEvents.recommendation);
+        return this.makeRecommendation().log();
+    }
+
+    public makeRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.recommendationOpen, info, identifier);
     }
 
     public logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.recommendationOpen, info, identifier);
+        return this.makeRecommendationOpen(info, identifier).log();
+    }
+
+    public makeStaticFilterClearAll(meta: StaticFilterMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterClearAll, meta);
     }
 
     public logStaticFilterClearAll(meta: StaticFilterMetadata) {
-        return this.logSearchEvent(SearchPageEvents.staticFilterClearAll, meta);
+        return this.makeStaticFilterClearAll(meta).log();
+    }
+
+    public makeStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterSelect, meta);
     }
 
     public logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
-        return this.logSearchEvent(SearchPageEvents.staticFilterSelect, meta);
+        return this.makeStaticFilterSelect(meta).log();
+    }
+
+    public makeStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterDeselect, meta);
     }
 
     public logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
-        return this.logSearchEvent(SearchPageEvents.staticFilterDeselect, meta);
+        return this.makeStaticFilterDeselect(meta).log();
+    }
+
+    public makeFetchMoreResults() {
+        return this.makeCustomEvent(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
     }
 
     public logFetchMoreResults() {
-        return this.logCustomEvent(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+        return this.makeFetchMoreResults().log();
+    }
+
+    public makeInterfaceChange(metadata: InterfaceChangeMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.interfaceChange, metadata);
     }
 
     public logInterfaceChange(metadata: InterfaceChangeMetadata) {
-        return this.logSearchEvent(SearchPageEvents.interfaceChange, metadata);
+        return this.makeInterfaceChange(metadata).log();
+    }
+
+    public makeDidYouMeanAutomatic() {
+        return this.makeSearchEvent(SearchPageEvents.didyoumeanAutomatic);
     }
 
     public logDidYouMeanAutomatic() {
-        return this.logSearchEvent(SearchPageEvents.didyoumeanAutomatic);
+        return this.makeDidYouMeanAutomatic().log();
+    }
+
+    public makeDidYouMeanClick() {
+        return this.makeSearchEvent(SearchPageEvents.didyoumeanClick);
     }
 
     public logDidYouMeanClick() {
-        return this.logSearchEvent(SearchPageEvents.didyoumeanClick);
+        return this.makeDidYouMeanClick().log();
+    }
+
+    public makeResultsSort(metadata: ResultsSortMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.resultsSort, metadata);
     }
 
     public logResultsSort(metadata: ResultsSortMetadata) {
-        return this.logSearchEvent(SearchPageEvents.resultsSort, metadata);
+        return this.makeResultsSort(metadata).log();
+    }
+
+    public makeSearchboxSubmit() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxSubmit);
     }
 
     public logSearchboxSubmit() {
-        return this.logSearchEvent(SearchPageEvents.searchboxSubmit);
+        return this.makeSearchboxSubmit().log();
+    }
+
+    public makeSearchboxClear() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxClear);
     }
 
     public logSearchboxClear() {
-        return this.logSearchEvent(SearchPageEvents.searchboxClear);
+        return this.makeSearchboxClear().log();
+    }
+
+    public makeSearchboxAsYouType() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxAsYouType);
     }
 
     public logSearchboxAsYouType() {
-        return this.logSearchEvent(SearchPageEvents.searchboxAsYouType);
+        return this.makeSearchboxAsYouType().log();
+    }
+
+    public makeBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
     }
 
     public logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
-        return this.logSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
+        return this.makeBreadcrumbFacet(metadata).log();
+    }
+
+    public makeBreadcrumbResetAll() {
+        return this.makeSearchEvent(SearchPageEvents.breadcrumbResetAll);
     }
 
     public logBreadcrumbResetAll() {
-        return this.logSearchEvent(SearchPageEvents.breadcrumbResetAll);
+        return this.makeBreadcrumbResetAll().log();
+    }
+
+    public makeDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.documentQuickview, info, identifier);
     }
 
     public logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.documentQuickview, info, identifier);
+        return this.makeDocumentQuickview(info, identifier).log();
+    }
+
+    public makeDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.documentOpen, info, identifier);
     }
 
     public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier);
+        return this.makeDocumentOpen(info, identifier).log();
+    }
+
+    public makeOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.omniboxAnalytics, formatOmniboxMetadata(meta));
     }
 
     public logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
-        return this.logSearchEvent(SearchPageEvents.omniboxAnalytics, formatOmniboxMetadata(meta));
+        return this.makeOmniboxAnalytics(meta).log();
+    }
+
+    public makeOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.omniboxFromLink, formatOmniboxMetadata(meta));
     }
 
     public logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
-        return this.logSearchEvent(SearchPageEvents.omniboxFromLink, formatOmniboxMetadata(meta));
+        return this.makeOmniboxFromLink(meta).log();
+    }
+
+    public makeSearchFromLink() {
+        return this.makeSearchEvent(SearchPageEvents.searchFromLink);
     }
 
     public logSearchFromLink() {
-        return this.logSearchEvent(SearchPageEvents.searchFromLink);
+        return this.makeSearchFromLink().log();
+    }
+
+    public makeTriggerNotify(meta: TriggerNotifyMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerNotify, meta);
     }
 
     public logTriggerNotify(meta: TriggerNotifyMetadata) {
-        return this.logCustomEvent(SearchPageEvents.triggerNotify, meta);
+        return this.makeTriggerNotify(meta).log();
+    }
+
+    public makeTriggerExecute(meta: TriggerExecuteMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerExecute, meta);
     }
 
     public logTriggerExecute(meta: TriggerExecuteMetadata) {
-        return this.logCustomEvent(SearchPageEvents.triggerExecute, meta);
+        return this.makeTriggerExecute(meta).log();
+    }
+
+    public makeTriggerQuery() {
+        return this.makeCustomEvent(
+            SearchPageEvents.triggerQuery,
+            {query: this.provider.getSearchEventRequestPayload().queryText},
+            'queryPipelineTriggers'
+        );
     }
 
     public logTriggerQuery() {
-        const meta = {query: this.provider.getSearchEventRequestPayload().queryText};
-        return this.logCustomEvent(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
+        return this.makeTriggerQuery().log();
+    }
+
+    public makeUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.undoTriggerQuery, meta);
     }
 
     public logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
-        return this.logSearchEvent(SearchPageEvents.undoTriggerQuery, meta);
+        return this.makeUndoTriggerQuery(meta).log();
+    }
+
+    public makeTriggerRedirect(meta: TriggerRedirectMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerRedirect, {
+            ...meta,
+            query: this.provider.getSearchEventRequestPayload().queryText,
+        });
     }
 
     public logTriggerRedirect(meta: TriggerRedirectMetadata) {
-        const allMeta = {...meta, query: this.provider.getSearchEventRequestPayload().queryText};
-        return this.logCustomEvent(SearchPageEvents.triggerRedirect, allMeta);
+        return this.makeTriggerRedirect(meta).log();
+    }
+
+    public makePagerResize(meta: PagerResizeMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerResize, meta);
     }
 
     public logPagerResize(meta: PagerResizeMetadata) {
-        return this.logCustomEvent(SearchPageEvents.pagerResize, meta);
+        return this.makePagerResize(meta).log();
+    }
+
+    public makePagerNumber(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerNumber, meta);
     }
 
     public logPagerNumber(meta: PagerMetadata) {
-        return this.logCustomEvent(SearchPageEvents.pagerNumber, meta);
+        return this.makePagerNumber(meta).log();
+    }
+
+    public makePagerNext(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerNext, meta);
     }
 
     public logPagerNext(meta: PagerMetadata) {
-        return this.logCustomEvent(SearchPageEvents.pagerNext, meta);
+        return this.makePagerNext(meta).log();
+    }
+
+    public makePagerPrevious(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerPrevious, meta);
     }
 
     public logPagerPrevious(meta: PagerMetadata) {
-        return this.logCustomEvent(SearchPageEvents.pagerPrevious, meta);
+        return this.makePagerPrevious(meta).log();
+    }
+
+    public makePagerScrolling() {
+        return this.makeCustomEvent(SearchPageEvents.pagerScrolling);
     }
 
     public logPagerScrolling() {
-        return this.logCustomEvent(SearchPageEvents.pagerScrolling);
+        return this.makePagerScrolling().log();
+    }
+
+    public makeFacetClearAll(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetClearAll, meta);
     }
 
     public logFacetClearAll(meta: FacetBaseMeta) {
-        return this.logSearchEvent(SearchPageEvents.facetClearAll, meta);
+        return this.makeFacetClearAll(meta).log();
+    }
+
+    public makeFacetSearch(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetSearch, meta);
     }
 
     public logFacetSearch(meta: FacetBaseMeta) {
-        return this.logSearchEvent(SearchPageEvents.facetSearch, meta);
+        return this.makeFacetSearch(meta).log();
+    }
+
+    public makeFacetSelect(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetSelect, meta);
     }
 
     public logFacetSelect(meta: FacetMetadata) {
-        return this.logSearchEvent(SearchPageEvents.facetSelect, meta);
+        return this.makeFacetSelect(meta).log();
+    }
+
+    public makeFacetDeselect(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetDeselect, meta);
     }
 
     public logFacetDeselect(meta: FacetMetadata) {
-        return this.logSearchEvent(SearchPageEvents.facetDeselect, meta);
+        return this.makeFacetDeselect(meta).log();
+    }
+
+    public makeFacetExclude(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetExclude, meta);
     }
 
     public logFacetExclude(meta: FacetMetadata) {
-        return this.logSearchEvent(SearchPageEvents.facetExclude, meta);
+        return this.makeFacetExclude(meta).log();
+    }
+
+    public makeFacetUnexclude(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetUnexclude, meta);
     }
 
     public logFacetUnexclude(meta: FacetMetadata) {
-        return this.logSearchEvent(SearchPageEvents.facetUnexclude, meta);
+        return this.makeFacetUnexclude(meta).log();
+    }
+
+    public makeFacetSelectAll(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetSelectAll, meta);
     }
 
     public logFacetSelectAll(meta: FacetBaseMeta) {
-        return this.logSearchEvent(SearchPageEvents.facetSelectAll, meta);
+        return this.makeFacetSelectAll(meta).log();
+    }
+
+    public makeFacetUpdateSort(meta: FacetSortMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetUpdateSort, meta);
     }
 
     public logFacetUpdateSort(meta: FacetSortMeta) {
-        return this.logSearchEvent(SearchPageEvents.facetUpdateSort, meta);
+        return this.makeFacetUpdateSort(meta).log();
+    }
+
+    public makeFacetShowMore(meta: FacetBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.facetShowMore, meta);
     }
 
     public logFacetShowMore(meta: FacetBaseMeta) {
-        return this.logCustomEvent(SearchPageEvents.facetShowMore, meta);
+        return this.makeFacetShowMore(meta).log();
+    }
+
+    public makeFacetShowLess(meta: FacetBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.facetShowLess, meta);
     }
 
     public logFacetShowLess(meta: FacetBaseMeta) {
-        return this.logCustomEvent(SearchPageEvents.facetShowLess, meta);
+        return this.makeFacetShowLess(meta).log();
+    }
+
+    public makeQueryError(meta: QueryErrorMeta) {
+        return this.makeCustomEvent(SearchPageEvents.queryError, meta);
     }
 
     public logQueryError(meta: QueryErrorMeta) {
-        return this.logCustomEvent(SearchPageEvents.queryError, meta);
+        return this.makeQueryError(meta).log();
     }
 
-    public async logQueryErrorBack() {
-        await this.logCustomEvent(SearchPageEvents.queryErrorBack);
-        return this.logSearchEvent(SearchPageEvents.queryErrorBack);
+    public makeQueryErrorBack(): EventBuilder<SearchEventResponse> {
+        return {
+            description: this.makeDescription(SearchPageEvents.queryErrorBack),
+            log: async () => {
+                await this.logCustomEvent(SearchPageEvents.queryErrorBack);
+                return this.logSearchEvent(SearchPageEvents.queryErrorBack);
+            },
+        };
     }
 
-    public async logQueryErrorRetry() {
-        await this.logCustomEvent(SearchPageEvents.queryErrorRetry);
-        return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
+    public logQueryErrorBack() {
+        return this.makeQueryErrorBack().log();
     }
 
-    public async logQueryErrorClear() {
-        await this.logCustomEvent(SearchPageEvents.queryErrorClear);
-        return this.logSearchEvent(SearchPageEvents.queryErrorClear);
+    public makeQueryErrorRetry(): EventBuilder<SearchEventResponse> {
+        return {
+            description: this.makeDescription(SearchPageEvents.queryErrorRetry),
+            log: async () => {
+                await this.logCustomEvent(SearchPageEvents.queryErrorRetry);
+                return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
+            },
+        };
+    }
+
+    public logQueryErrorRetry() {
+        return this.makeQueryErrorRetry().log();
+    }
+
+    public makeQueryErrorClear(): EventBuilder<SearchEventResponse> {
+        return {
+            description: this.makeDescription(SearchPageEvents.queryErrorClear),
+            log: async () => {
+                await this.logCustomEvent(SearchPageEvents.queryErrorClear);
+                return this.logSearchEvent(SearchPageEvents.queryErrorClear);
+            },
+        };
+    }
+
+    public logQueryErrorClear() {
+        return this.makeQueryErrorClear().log();
+    }
+
+    public makeLikeSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.likeSmartSnippet);
     }
 
     public logLikeSmartSnippet() {
-        return this.logCustomEvent(SearchPageEvents.likeSmartSnippet);
+        return this.makeLikeSmartSnippet().log();
+    }
+
+    public makeDislikeSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.dislikeSmartSnippet);
     }
 
     public logDislikeSmartSnippet() {
-        return this.logCustomEvent(SearchPageEvents.dislikeSmartSnippet);
+        return this.makeDislikeSmartSnippet().log();
+    }
+
+    public makeExpandSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.expandSmartSnippet);
     }
 
     public logExpandSmartSnippet() {
-        return this.logCustomEvent(SearchPageEvents.expandSmartSnippet);
+        return this.makeExpandSmartSnippet().log();
+    }
+
+    public makeCollapseSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.collapseSmartSnippet);
     }
 
     public logCollapseSmartSnippet() {
-        return this.logCustomEvent(SearchPageEvents.collapseSmartSnippet);
+        return this.makeCollapseSmartSnippet().log();
+    }
+
+    public makeOpenSmartSnippetFeedbackModal() {
+        return this.makeCustomEvent(SearchPageEvents.openSmartSnippetFeedbackModal);
     }
 
     public logOpenSmartSnippetFeedbackModal() {
-        return this.logCustomEvent(SearchPageEvents.openSmartSnippetFeedbackModal);
+        return this.makeOpenSmartSnippetFeedbackModal().log();
+    }
+
+    public makeCloseSmartSnippetFeedbackModal() {
+        return this.makeCustomEvent(SearchPageEvents.closeSmartSnippetFeedbackModal);
     }
 
     public logCloseSmartSnippetFeedbackModal() {
-        return this.logCustomEvent(SearchPageEvents.closeSmartSnippetFeedbackModal);
+        return this.makeCloseSmartSnippetFeedbackModal().log();
+    }
+
+    public makeSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
+        return this.makeCustomEvent(SearchPageEvents.sendSmartSnippetReason, {reason, details});
     }
 
     public logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
-        return this.logCustomEvent(SearchPageEvents.sendSmartSnippetReason, {reason, details});
+        return this.makeSmartSnippetFeedbackReason(reason, details).log();
     }
 
-    public logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return this.logCustomEvent(
+    public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeCustomEvent(
             SearchPageEvents.expandSmartSnippetSuggestion,
             'documentId' in snippet ? snippet : {documentId: snippet}
         );
     }
 
-    public logCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return this.logCustomEvent(
+    public logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeExpandSmartSnippetSuggestion(snippet).log();
+    }
+
+    public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeCustomEvent(
             SearchPageEvents.collapseSmartSnippetSuggestion,
             'documentId' in snippet ? snippet : {documentId: snippet}
         );
+    }
+
+    public logCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeCollapseSmartSnippetSuggestion(snippet).log();
+    }
+
+    /**
+     * @deprecated
+     */
+    private makeShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return this.makeCustomEvent(SearchPageEvents.showMoreSmartSnippetSuggestion, snippet);
     }
 
     /**
      * @deprecated
      */
     public logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return this.logCustomEvent(SearchPageEvents.showMoreSmartSnippetSuggestion, snippet);
+        return this.makeShowMoreSmartSnippetSuggestion(snippet).log();
+    }
+
+    /**
+     * @deprecated
+     */
+    private makeShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return this.makeCustomEvent(SearchPageEvents.showLessSmartSnippetSuggestion, snippet);
     }
 
     /**
      * @deprecated
      */
     public logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return this.logCustomEvent(SearchPageEvents.showLessSmartSnippetSuggestion, snippet);
+        return this.makeShowLessSmartSnippetSuggestion(snippet).log();
+    }
+
+    public makeOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.openSmartSnippetSource, info, identifier);
     }
 
     public logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.openSmartSnippetSource, info, identifier);
+        return this.makeOpenSmartSnippetSource(info, identifier).log();
     }
 
-    public logOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
-        return this.logClickEvent(
+    public makeOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
+        return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetSuggestionSource,
             info,
             {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
@@ -329,11 +603,15 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logOpenSmartSnippetInlineLink(
+    public logOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
+        return this.makeOpenSmartSnippetSuggestionSource(info, snippet).log();
+    }
+
+    public makeOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
         identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
-        return this.logClickEvent(
+        return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetInlineLink,
             info,
             {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
@@ -341,11 +619,18 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logOpenSmartSnippetSuggestionInlineLink(
+    public logOpenSmartSnippetInlineLink(
+        info: PartialDocumentInformation,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+    ) {
+        return this.makeOpenSmartSnippetInlineLink(info, identifierAndLink).log();
+    }
+
+    public makeOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
         snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
-        return this.logClickEvent(
+        return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetSuggestionInlineLink,
             info,
             {
@@ -356,32 +641,67 @@ export class CoveoSearchPageClient {
         );
     }
 
+    public logOpenSmartSnippetSuggestionInlineLink(
+        info: PartialDocumentInformation,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+    ) {
+        return this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink).log();
+    }
+
+    public makeRecentQueryClick() {
+        return this.makeSearchEvent(SearchPageEvents.recentQueryClick);
+    }
+
     public logRecentQueryClick() {
-        return this.logSearchEvent(SearchPageEvents.recentQueryClick);
+        return this.makeRecentQueryClick().log();
+    }
+
+    public makeClearRecentQueries() {
+        return this.makeCustomEvent(SearchPageEvents.clearRecentQueries);
     }
 
     public logClearRecentQueries() {
-        return this.logCustomEvent(SearchPageEvents.clearRecentQueries);
+        return this.makeClearRecentQueries().log();
+    }
+
+    public makeRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeCustomEvent(SearchPageEvents.recentResultClick, {info, identifier});
     }
 
     public logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logCustomEvent(SearchPageEvents.recentResultClick, {info, identifier});
+        return this.makeRecentResultClick(info, identifier).log();
+    }
+
+    public makeClearRecentResults() {
+        return this.makeCustomEvent(SearchPageEvents.clearRecentResults);
     }
 
     public logClearRecentResults() {
-        return this.logCustomEvent(SearchPageEvents.clearRecentResults);
+        return this.makeClearRecentResults().log();
+    }
+
+    public makeNoResultsBack() {
+        return this.makeSearchEvent(SearchPageEvents.noResultsBack);
     }
 
     public logNoResultsBack() {
-        return this.logSearchEvent(SearchPageEvents.noResultsBack);
+        return this.makeNoResultsBack().log();
+    }
+
+    public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
     }
 
     public logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
+        return this.makeShowMoreFoldedResults(info, identifier).log();
+    }
+
+    public makeShowLessFoldedResults() {
+        return this.makeCustomEvent(SearchPageEvents.showLessFoldedResults);
     }
 
     public logShowLessFoldedResults() {
-        return this.logCustomEvent(SearchPageEvents.showLessFoldedResults);
+        return this.makeShowLessFoldedResults().log();
     }
 
     public async logCustomEvent(
@@ -400,19 +720,49 @@ export class CoveoSearchPageClient {
         return this.coveoAnalyticsClient.sendCustomEvent(payload);
     }
 
-    public async logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
-        const customData = {...this.provider.getBaseMetadata(), ...metadata};
-
-        const payload: CustomEventRequest = {
-            ...(await this.getBaseCustomEventRequest(customData)),
-            eventType,
-            eventValue,
+    public makeCustomEvent(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>,
+        eventType: string = CustomEventsTypes[event]!
+    ): EventBuilder<CustomEventResponse> {
+        return {
+            description: this.makeDescription(event, metadata),
+            log: () => this.logCustomEvent(event, metadata, eventType),
         };
-        return this.coveoAnalyticsClient.sendCustomEvent(payload);
+    }
+
+    public makeCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        return {
+            description: <EventDescription>{actionCause: eventValue, customData},
+            log: async () => {
+                const payload: CustomEventRequest = {
+                    ...(await this.getBaseCustomEventRequest(customData)),
+                    eventType,
+                    eventValue,
+                };
+                return this.coveoAnalyticsClient.sendCustomEvent(payload);
+            },
+        };
+    }
+
+    public logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+        return this.makeCustomEventWithType(eventValue, eventType, metadata).log();
     }
 
     public async logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
         return this.coveoAnalyticsClient.sendSearchEvent(await this.getBaseSearchEventRequest(event, metadata));
+    }
+
+    private makeDescription(actionCause: SearchPageEvents, metadata?: Record<string, any>): EventDescription {
+        return {actionCause, customData: {...this.provider.getBaseMetadata(), ...metadata}};
+    }
+
+    public makeSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>): EventBuilder<SearchEventResponse> {
+        return {
+            description: this.makeDescription(event, metadata),
+            log: () => this.logSearchEvent(event, metadata),
+        };
     }
 
     public async logClickEvent(
@@ -430,6 +780,18 @@ export class CoveoSearchPageClient {
         };
 
         return this.coveoAnalyticsClient.sendClickEvent(payload);
+    }
+
+    public makeClickEvent(
+        event: SearchPageEvents,
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: Record<string, any>
+    ): EventBuilder<ClickEventResponse> {
+        return {
+            description: this.makeDescription(event, metadata),
+            log: () => this.logClickEvent(event, info, identifier, metadata),
+        };
     }
 
     private async getBaseSearchEventRequest(


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2058

This PR introduces a "make" function for every "log" search analytics function. In an upcoming PR, this enables Headless to get the actionCause and customData of an event without sending it.
