### PR TITLE
SFINT-4661 logDocumentOpen added to the insight analytics client

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -671,8 +671,6 @@ describe('InsightClient', () => {
             const expectedMetadata = {
                 ...fakeDocID,
                 ...expectedBaseCaseMetadata,
-                context_Case_Subject: 'test subject',
-                context_Case_Description: 'test description',
             };
             await client.logDocumentOpen(fakeDocInfo, fakeDocID, metadata);
             expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, expectedMetadata);

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -221,7 +221,7 @@ export class CoveoInsightClient {
 
     public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
         if (metadata) {
-            const metadataToSend = generateMetadataToSend(metadata);
+            const metadataToSend = generateMetadataToSend(metadata, false);
             return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier, metadataToSend);
         }
         return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier);

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -220,11 +220,11 @@ export class CoveoInsightClient {
     }
 
     public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
-        if (metadata) {
-            const metadataToSend = generateMetadataToSend(metadata, false);
-            return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier, metadataToSend);
-        }
-        return this.logClickEvent(SearchPageEvents.documentOpen, info, identifier);
+        return this.logClickEvent(
+          SearchPageEvents.documentOpen,
+          info,
+          identifier,
+          metadata ? generateMetadataToSend(metadata, false) : undefined);
     }
 
     public async logCustomEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {


### PR DESCRIPTION
[SFINT-4661](https://coveord.atlassian.net/browse/SFINT-4661)

### logDocumentOpen method added to the Insight Client in order to log click events in the insight use case with the proper payload including the data about the case(`CaseId`, `CaseNumber`, `CaseSubject`).

### Example:
<img width="1050" alt="HeadlessClickEvent" src="https://user-images.githubusercontent.com/86681870/199011788-eb2292a4-9d26-4e46-b76e-c7543d0f6584.png">
