### PR TITLE
SFINT-4675  location replaced by window.location

### DIFF
--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -18,7 +18,7 @@ export class Cookie {
             expires = '';
         }
 
-        host = location.hostname ?? window.location.hostname;
+        host = window.location.hostname;
         if (host.indexOf('.') === -1) {
             // no "." in a domain - it's localhost or something similar
             document.cookie = name + '=' + value + expires + '; path=/';

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -18,7 +18,7 @@ export class Cookie {
             expires = '';
         }
 
-        host = location.hostname;
+        host = location.hostname ?? window.location.hostname;
         if (host.indexOf('.') === -1) {
             // no "." in a domain - it's localhost or something similar
             document.cookie = name + '=' + value + expires + '; path=/';


### PR DESCRIPTION
[SFINT-4675](https://coveord.atlassian.net/browse/SFINT-4675)

#### In a Salesforce Winter 23 org, Quantic interfaces in the Salesforce console fail to send analytics events causing the following error:

<img width="600" alt="ErrorQuantic" src="https://user-images.githubusercontent.com/86681870/199550622-135ddded-2917-4e74-a8ae-c68b1cc83be7.png">
<img width="600" alt="Quantic-issue" src="https://user-images.githubusercontent.com/86681870/199550629-dc76a654-758d-4772-80b6-2079ba4c9371.png">


#### The reason behind this problem has been identified, apparently the `location` JS global object is returning undefined when being used from the Salesforce console.

#### In the other hand `window.location`  which contains the exact same information as `location` is working just fine, thus the change I added in this PR.