### PR TITLE
Fixing currency symbol not being stripped when sending price [COM-1824]

### DIFF
--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -228,6 +228,36 @@ export class CoveoInsightClient {
         );
     }
 
+    public logCopyToClipboard(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.copyToClipboard,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logDocumentQuickview(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        caseMetadata?: CaseMetadata
+    ) {
+        const metadata = {
+            documentTitle: info.documentTitle,
+            documentURL: info.documentUrl,
+        };
+        return this.logClickEvent(
+            SearchPageEvents.documentQuickview,
+            info,
+            identifier,
+            caseMetadata ? {...generateMetadataToSend(caseMetadata, false), ...metadata} : metadata
+        );
+    }
+
     public async logCustomEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -228,36 +228,6 @@ export class CoveoInsightClient {
         );
     }
 
-    public logCopyToClipboard(
-        info: PartialDocumentInformation,
-        identifier: DocumentIdentifier,
-        metadata?: CaseMetadata
-    ) {
-        return this.logClickEvent(
-            SearchPageEvents.copyToClipboard,
-            info,
-            identifier,
-            metadata ? generateMetadataToSend(metadata, false) : undefined
-        );
-    }
-
-    public logDocumentQuickview(
-        info: PartialDocumentInformation,
-        identifier: DocumentIdentifier,
-        caseMetadata?: CaseMetadata
-    ) {
-        const metadata = {
-            documentTitle: info.documentTitle,
-            documentURL: info.documentUrl,
-        };
-        return this.logClickEvent(
-            SearchPageEvents.documentQuickview,
-            info,
-            identifier,
-            caseMetadata ? {...generateMetadataToSend(caseMetadata, false), ...metadata} : metadata
-        );
-    }
-
     public async logCustomEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -67,7 +67,7 @@ export abstract class BasePlugin {
     public getDefaultContextInformation(eventType: string) {
         const documentContext = {
             title: hasDocument() ? document.title : '',
-            encoding: hasDocument() ? document.characterSet :'UTF-8',
+            encoding: hasDocument() ? document.characterSet : 'UTF-8',
         };
         const screenContext = {
             screenResolution: `${screen.width}x${screen.height}`,

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -85,6 +85,7 @@ describe('EC plugin', () => {
             ec.addProduct({name: '🐭', price: '€ -20.99'});
             ec.addProduct({name: '🐈', price: '1.99 $'});
             ec.addProduct({name: '🦊', price: 'anything goes'});
+            ec.addProduct({name: '🐓', price: '£ 0'});
 
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
@@ -98,6 +99,8 @@ describe('EC plugin', () => {
                 pr3pr: 1.99,
                 pr4nm: '🦊',
                 pr4pr: 'anything goes',
+                pr5nm: '🐓',
+                pr5pr: 0,
             });
         });
 
@@ -297,6 +300,7 @@ describe('EC plugin', () => {
             ec.addImpression({name: '🐭', price: '€ -20.99'});
             ec.addImpression({name: '🐈', price: '1.99 $'});
             ec.addImpression({name: '🦊', price: 'anything goes'});
+            ec.addImpression({name: '🐓', price: '£ 0'});
 
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
@@ -310,6 +314,8 @@ describe('EC plugin', () => {
                 il1pi3pr: 1.99,
                 il1pi4nm: '🦊',
                 il1pi4pr: 'anything goes',
+                il1pi5nm: '🐓',
+                il1pi5pr: 0,
             });
         });
 

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -80,6 +80,27 @@ describe('EC plugin', () => {
             expect(result).toEqual({...defaultResult, pr1nm: '🧀', pr1pr: 5.99});
         });
 
+        it('should convert currency product keys into numerical values', () => {
+            ec.addProduct({name: '🧀', price: '£ 5.99'});
+            ec.addProduct({name: '🐭', price: '€ -20.99'});
+            ec.addProduct({name: '🐈', price: '1.99 $'});
+            ec.addProduct({name: '🦊', price: 'anything goes'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                pr1nm: '🧀',
+                pr1pr: 5.99,
+                pr2nm: '🐭',
+                pr2pr: -20.99,
+                pr3nm: '🐈',
+                pr3pr: 1.99,
+                pr4nm: '🦊',
+                pr4pr: 'anything goes',
+            });
+        });
+
         it('should keep custom metadata in the product', () => {
             ec.addProduct({name: '🧀', price: 5.99, custom: {verycustom: 'value'}});
 
@@ -268,6 +289,27 @@ describe('EC plugin', () => {
                 ...defaultResult,
                 il1pi1nm: '🧀',
                 il1pi1group: 'mahgroup',
+            });
+        });
+
+        it('should convert currency impression keys into numerical values', () => {
+            ec.addImpression({name: '🧀', price: '£ 5.99'});
+            ec.addImpression({name: '🐭', price: '€ -20.99'});
+            ec.addImpression({name: '🐈', price: '1.99 $'});
+            ec.addImpression({name: '🦊', price: 'anything goes'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1pi1nm: '🧀',
+                il1pi1pr: 5.99,
+                il1pi2nm: '🐭',
+                il1pi2pr: -20.99,
+                il1pi3nm: '🐈',
+                il1pi3pr: 1.99,
+                il1pi4nm: '🦊',
+                il1pi4pr: 'anything goes',
             });
         });
 

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -34,7 +34,7 @@ export interface ProductProperties extends CoveoExtensionProperties {
     brand?: string;
     category?: string;
     variant?: string;
-    price?: Number | string;
+    price?: number | string;
     quantity?: number;
     coupon?: string;
     position?: number;
@@ -51,7 +51,7 @@ export interface ImpressionProperties extends CoveoExtensionProperties {
     category?: string;
     variant?: string;
     position?: number;
-    price?: any;
+    price?: number | string;
     custom?: CustomValues;
 }
 
@@ -189,15 +189,12 @@ export class ECPlugin extends BasePlugin {
         return impression;
     }
 
-    private tryConvertStringPriceToNumber(price: Number | string): Number | string {
-        if (typeof price === 'string') {
-            let parsedPrice = Number(price.replace(/[^0-9\.-]/g, ''));
-            if (parsedPrice) {
-                return parsedPrice;
-            }
+    private tryConvertStringPriceToNumber(price: number | string): number | string {
+        if (typeof price === 'number') {
+            return price;
         }
 
-        return price;
+        return Number(price.replace(/[^0-9\.-]/g, '')) || price;
     }
 
     private assureProductValidity(product: Product) {

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -194,7 +194,7 @@ export class ECPlugin extends BasePlugin {
             return price;
         }
 
-        let parsedPrice = parseFloat(price.replace(/[^0-9\.-]/g, ''));
+        const parsedPrice = parseFloat(price.replace(/[^0-9\.-]/g, ''));
 
         return isNaN(parsedPrice) ? price : parsedPrice;
     }

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -194,7 +194,9 @@ export class ECPlugin extends BasePlugin {
             return price;
         }
 
-        return Number(price.replace(/[^0-9\.-]/g, '')) || price;
+        let parsedPrice = parseFloat(price.replace(/[^0-9\.-]/g, ''));
+
+        return isNaN(parsedPrice) ? price : parsedPrice;
     }
 
     private assureProductValidity(product: Product) {


### PR DESCRIPTION
Following [this discuss post](https://discuss.coveo.com/t/product-price-symbol-is-not-removed/8800) we saw that the code was not following the behaviour we described in the documentation:

>Any text surrounding the value, such as a currency symbol, will be removed before it’s sent to [Coveo Usage Analytics (Coveo UA)](https://docs.coveo.com/en/182/). For example, when €-20.00 is entered, only -20.00 is sent.

This PR aims at correcting that.

**Added the test first:**
![image](https://user-images.githubusercontent.com/33292327/204049939-f93bac4f-444c-4f7c-8144-1a50636274f9.png)

🎩
**After the fix:**
![image](https://user-images.githubusercontent.com/33292327/204049982-9466f94a-f929-4e67-a6f6-1587ec289fc2.png)

Also ran the lintfix.