### PR TITLE
Generate debug version

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
-            "url": "localhost:9001",
+            "url": "http://localhost:9001",
             "webRoot": "${workspaceFolder}/src",
             "preLaunchTask": "dev",
             "sourceMapPathOverrides": {

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
         a='coveoua';c[a]=c[a]||function(){(c[a].q=c[a].q|| []).push(arguments)};
         c[a].t=Date.now();u=o.createElement(v);u.async=1;u.src=e;
         O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
-        })(window,document,'script','coveoua.js')
+        })(window,document,'script','coveoua.debug.js')
 
         // Replace YOUR-TOKEN with your real token
         // (eg: an API key which has the rights to write into Coveo UsageAnalytics)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,10 +30,18 @@ const browserUMD = {
             format: 'umd',
             name: 'coveoua',
             sourcemap: true,
+            plugins: [terser({format: {comments: false}})],
         },
         {
             file: './dist/coveoua.browser.js',
             format: 'iife',
+            name: 'coveoua',
+            sourcemap: true,
+            plugins: [terser({format: {comments: false}})],
+        },
+        {
+            file: './dist/coveoua.debug.js',
+            format: 'umd',
             name: 'coveoua',
             sourcemap: true,
         },
@@ -41,7 +49,6 @@ const browserUMD = {
     plugins: [
         browserFetch(),
         tsPlugin(),
-        terser({format: {comments: false}}),
         process.env.SERVE
             ? serve({
                   contentBase: ['dist', 'public'],


### PR DESCRIPTION
Understand coveo.analytics.js is harder than it needs be (partly) because there is no non-minified version available. This makes it impossible to step through the much more readable .ts code and see the internals. There are source maps created, but they don't really work on minified js code.

This change adds a new build `coveoua.debug.js` which contains non-minified code. I took the liberty to hook the index.html page to the minified build as well. 