### PR TITLE
SFINT-4717 logCaseAttach and logCaseDetach added to insight analytics client

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -333,6 +333,25 @@ describe('InsightClient', () => {
             await client.logDocumentQuickview(fakeDocInfo, fakeDocID);
             expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, expectedMetadata);
         });
+
+        it('should send proper payload for #caseAttach', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseAttach(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.caseAttach, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseDetach', async () => {
+            const expectedMetadata = {
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseDetach(fakeDocInfo.documentUriHash);
+            expectMatchCustomEventPayload(SearchPageEvents.caseDetach, expectedMetadata);
+        });
     });
 
     describe('when the case metadata is included', () => {
@@ -713,6 +732,31 @@ describe('InsightClient', () => {
             };
             await client.logDocumentQuickview(fakeDocInfo, fakeDocID, metadata);
             expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseAttach', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseAttach(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.caseAttach, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseDetach', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseDetach(fakeDocInfo.documentUriHash, metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.caseDetach, expectedMetadata);
         });
     });
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -258,6 +258,32 @@ export class CoveoInsightClient {
         );
     }
 
+    public logCaseAttach(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        caseMetadata?: CaseMetadata
+    ) {
+        const metadata = {
+            documentTitle: info.documentTitle,
+            documentURL: info.documentUrl,
+            resultUriHash: info.documentUriHash,
+        };
+
+        return this.logClickEvent(
+            SearchPageEvents.caseAttach,
+            info,
+            identifier,
+            caseMetadata ? {...generateMetadataToSend(caseMetadata, false), ...metadata} : metadata
+        );
+    }
+
+    public logCaseDetach(resultUriHash: string, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.caseDetach,
+            metadata ? {...generateMetadataToSend(metadata, false), resultUriHash} : {resultUriHash}
+        );
+    }
+
     public async logCustomEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -278,6 +278,14 @@ export enum SearchPageEvents {
      * Identifies the click event that gets logged when a user clicks the Copy To Clipboard result action.
      */
     copyToClipboard = 'copyToClipboard',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Attach To Case result action.
+     */
+    caseAttach = 'caseAttach',
+    /**
+     * Identifies the custom event that gets logged when a user clicks the Detach From Case result action.
+     */
+    caseDetach = 'caseDetach',
 }
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
@@ -314,6 +322,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.clearRecentResults]: 'recentlyClickedDocuments',
     [SearchPageEvents.showLessFoldedResults]: 'folding',
     [InsightEvents.expandToFullUI]: 'interface',
+    [SearchPageEvents.caseDetach]: 'case',
 };
 
 export interface StaticFilterMetadata {


### PR DESCRIPTION
[SFINT-4717](https://coveord.atlassian.net/browse/SFINT-4717)

## New methods added to the Insight Analytics client:

- ### logCaseAttach: this method will log the following click event:
<img width="546" alt="AttachToCase" src="https://user-images.githubusercontent.com/86681870/206741657-c42ff156-55cb-47e0-8a6e-8232d79a7596.png">

- ### logCaseDetach: this method will log the following custom event:
<img width="277" alt="CaseDetach" src="https://user-images.githubusercontent.com/86681870/206741692-6d9d6cf8-18e5-4a9b-a0c8-2483042f3f23.png">
