### PR TITLE
KIT-2071 made preparable analytics prepare everything

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -70,24 +70,24 @@ export interface PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse ext
 export interface AnalyticsClient {
     getPayload(eventType: string, ...payload: VariableArgumentsPayload): Promise<any>;
     getParameters(eventType: string, ...payload: VariableArgumentsPayload): Promise<any>;
-    prepareEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+    makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
         eventType: string,
         ...payload: VariableArgumentsPayload
     ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>>;
     sendEvent(eventType: string, ...payload: VariableArgumentsPayload): Promise<AnyEventResponse | void>;
-    prepareSearchEvent(
+    makeSearchEvent(
         request: PreparedSearchEventRequest
     ): Promise<PreparedEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>>;
     sendSearchEvent(request: SearchEventRequest): Promise<SearchEventResponse | void>;
-    prepareClickEvent(
+    makeClickEvent(
         request: PreparedClickEventRequest
     ): Promise<PreparedEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>>;
     sendClickEvent(request: ClickEventRequest): Promise<ClickEventResponse | void>;
-    prepareCustomEvent(
+    makeCustomEvent(
         request: PreparedCustomEventRequest
     ): Promise<PreparedEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>>;
     sendCustomEvent(request: CustomEventRequest): Promise<CustomEventResponse | void>;
-    prepareViewEvent(
+    makeViewEvent(
         request: PreparedViewEventRequest
     ): Promise<PreparedEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>>;
     sendViewEvent(request: ViewEventRequest): Promise<ViewEventResponse | void>;
@@ -310,7 +310,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         return payloadToSend;
     }
 
-    async prepareEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+    async makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
         eventType: EventType | string,
         ...payload: VariableArgumentsPayload
     ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>> {
@@ -337,7 +337,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     async sendEvent(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
-        return (await this.prepareEvent<any, any, AnyEventResponse>(eventType, ...payload)).log({});
+        return (await this.makeEvent<any, any, AnyEventResponse>(eventType, ...payload)).log({});
     }
 
     private deferExecution(): Promise<void> {
@@ -362,48 +362,45 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         this.runtime.client.deleteHttpCookieVisitorId();
     }
 
-    async prepareSearchEvent(request: PreparedSearchEventRequest) {
-        return this.prepareEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(
+    async makeSearchEvent(request: PreparedSearchEventRequest) {
+        return this.makeEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(
             EventType.search,
             request
         );
     }
 
     async sendSearchEvent({searchQueryUid, ...preparedRequest}: SearchEventRequest) {
-        return (await this.prepareSearchEvent(preparedRequest)).log({searchQueryUid});
+        return (await this.makeSearchEvent(preparedRequest)).log({searchQueryUid});
     }
 
-    async prepareClickEvent(request: PreparedClickEventRequest) {
-        return this.prepareEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(
+    async makeClickEvent(request: PreparedClickEventRequest) {
+        return this.makeEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(
             EventType.click,
             request
         );
     }
 
     async sendClickEvent({searchQueryUid, ...preparedRequest}: ClickEventRequest) {
-        return (await this.prepareClickEvent(preparedRequest)).log({searchQueryUid});
+        return (await this.makeClickEvent(preparedRequest)).log({searchQueryUid});
     }
 
-    async prepareCustomEvent(request: PreparedCustomEventRequest) {
-        return this.prepareEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(
+    async makeCustomEvent(request: PreparedCustomEventRequest) {
+        return this.makeEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(
             EventType.custom,
             request
         );
     }
 
     async sendCustomEvent({lastSearchQueryUid, ...preparedRequest}: CustomEventRequest) {
-        return (await this.prepareCustomEvent(preparedRequest)).log({lastSearchQueryUid});
+        return (await this.makeCustomEvent(preparedRequest)).log({lastSearchQueryUid});
     }
 
-    async prepareViewEvent(request: PreparedViewEventRequest) {
-        return this.prepareEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(
-            EventType.view,
-            request
-        );
+    async makeViewEvent(request: PreparedViewEventRequest) {
+        return this.makeEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view, request);
     }
 
     async sendViewEvent(request: ViewEventRequest): Promise<ViewEventResponse | void> {
-        return (await this.prepareViewEvent(request)).log({});
+        return (await this.makeViewEvent(request)).log({});
     }
 
     async getVisit(): Promise<VisitResponse> {

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -64,7 +64,7 @@ export type EventTypeConfig = {
 
 export interface PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>
     extends BufferedRequest {
-    log(missingPayload: Omit<TCompleteRequest, keyof TPreparedRequest>): Promise<TResponse | void>;
+    log(remainingPayload: Omit<TCompleteRequest, keyof TPreparedRequest>): Promise<TResponse | void>;
 }
 
 export interface AnalyticsClient {
@@ -322,13 +322,13 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         return {
             eventType: eventTypeToSend,
             payload: payloadToSend,
-            log: async (missingPayload) => {
+            log: async (remainingPayload) => {
                 this.bufferedRequests.push(<BufferedRequest>{
                     eventType: eventTypeToSend,
-                    payload: {...payloadToSend, ...missingPayload},
+                    payload: {...payloadToSend, ...remainingPayload},
                 });
                 await Promise.all(
-                    this.afterSendHooks.map((hook) => hook(eventType, {...parametersToSend, ...missingPayload}))
+                    this.afterSendHooks.map((hook) => hook(eventType, {...parametersToSend, ...remainingPayload}))
                 );
                 await this.deferExecution();
                 return (await this.sendFromBufferWithFetch()) as TResponse | void;

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -1,4 +1,4 @@
-import {AnalyticsClient} from './analytics';
+import {AnalyticsClient, PreparedEvent} from './analytics';
 import {
     AnyEventResponse,
     SearchEventResponse,
@@ -7,6 +7,7 @@ import {
     VisitResponse,
     HealthResponse,
     ViewEventResponse,
+    EventType,
 } from '../events';
 import {NoopRuntime} from './runtimeEnvironment';
 
@@ -17,17 +18,32 @@ export class NoopAnalytics implements AnalyticsClient {
     getParameters(): Promise<any> {
         return Promise.resolve();
     }
+    prepareEvent<T extends AnyEventResponse>(eventType: EventType | string): Promise<PreparedEvent<T>> {
+        return Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
+    }
     sendEvent(): Promise<AnyEventResponse | void> {
         return Promise.resolve();
+    }
+    prepareSearchEvent(): Promise<PreparedEvent<SearchEventResponse>> {
+        return this.prepareEvent(EventType.search);
     }
     sendSearchEvent(): Promise<SearchEventResponse | void> {
         return Promise.resolve();
     }
+    prepareClickEvent(): Promise<PreparedEvent<ClickEventResponse>> {
+        return this.prepareEvent(EventType.click);
+    }
     sendClickEvent(): Promise<ClickEventResponse | void> {
         return Promise.resolve();
     }
+    prepareCustomEvent(): Promise<PreparedEvent<CustomEventResponse>> {
+        return this.prepareEvent(EventType.custom);
+    }
     sendCustomEvent(): Promise<CustomEventResponse | void> {
         return Promise.resolve();
+    }
+    prepareViewEvent(): Promise<PreparedEvent<ViewEventResponse>> {
+        return this.prepareEvent(EventType.view);
     }
     sendViewEvent(): Promise<ViewEventResponse | void> {
         return Promise.resolve();

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -26,7 +26,7 @@ export class NoopAnalytics implements AnalyticsClient {
     getParameters(): Promise<any> {
         return Promise.resolve();
     }
-    prepareEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+    makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
         eventType: EventType | string
     ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>> {
         return Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
@@ -34,26 +34,26 @@ export class NoopAnalytics implements AnalyticsClient {
     sendEvent(): Promise<AnyEventResponse | void> {
         return Promise.resolve();
     }
-    prepareSearchEvent() {
-        return this.prepareEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(EventType.search);
+    makeSearchEvent() {
+        return this.makeEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(EventType.search);
     }
     sendSearchEvent(): Promise<SearchEventResponse | void> {
         return Promise.resolve();
     }
-    prepareClickEvent() {
-        return this.prepareEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(EventType.click);
+    makeClickEvent() {
+        return this.makeEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(EventType.click);
     }
     sendClickEvent(): Promise<ClickEventResponse | void> {
         return Promise.resolve();
     }
-    prepareCustomEvent() {
-        return this.prepareEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(EventType.custom);
+    makeCustomEvent() {
+        return this.makeEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(EventType.custom);
     }
     sendCustomEvent(): Promise<CustomEventResponse | void> {
         return Promise.resolve();
     }
-    prepareViewEvent() {
-        return this.prepareEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view);
+    makeViewEvent() {
+        return this.makeEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view);
     }
     sendViewEvent(): Promise<ViewEventResponse | void> {
         return Promise.resolve();

--- a/src/client/noopAnalytics.ts
+++ b/src/client/noopAnalytics.ts
@@ -8,6 +8,14 @@ import {
     HealthResponse,
     ViewEventResponse,
     EventType,
+    PreparedSearchEventRequest,
+    SearchEventRequest,
+    ClickEventRequest,
+    CustomEventRequest,
+    PreparedClickEventRequest,
+    PreparedCustomEventRequest,
+    PreparedViewEventRequest,
+    ViewEventRequest,
 } from '../events';
 import {NoopRuntime} from './runtimeEnvironment';
 
@@ -18,32 +26,34 @@ export class NoopAnalytics implements AnalyticsClient {
     getParameters(): Promise<any> {
         return Promise.resolve();
     }
-    prepareEvent<T extends AnyEventResponse>(eventType: EventType | string): Promise<PreparedEvent<T>> {
+    prepareEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+        eventType: EventType | string
+    ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>> {
         return Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
     }
     sendEvent(): Promise<AnyEventResponse | void> {
         return Promise.resolve();
     }
-    prepareSearchEvent(): Promise<PreparedEvent<SearchEventResponse>> {
-        return this.prepareEvent(EventType.search);
+    prepareSearchEvent() {
+        return this.prepareEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(EventType.search);
     }
     sendSearchEvent(): Promise<SearchEventResponse | void> {
         return Promise.resolve();
     }
-    prepareClickEvent(): Promise<PreparedEvent<ClickEventResponse>> {
-        return this.prepareEvent(EventType.click);
+    prepareClickEvent() {
+        return this.prepareEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(EventType.click);
     }
     sendClickEvent(): Promise<ClickEventResponse | void> {
         return Promise.resolve();
     }
-    prepareCustomEvent(): Promise<PreparedEvent<CustomEventResponse>> {
-        return this.prepareEvent(EventType.custom);
+    prepareCustomEvent() {
+        return this.prepareEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(EventType.custom);
     }
     sendCustomEvent(): Promise<CustomEventResponse | void> {
         return Promise.resolve();
     }
-    prepareViewEvent(): Promise<PreparedEvent<ViewEventResponse>> {
-        return this.prepareEvent(EventType.view);
+    prepareViewEvent() {
+        return this.prepareEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view);
     }
     sendViewEvent(): Promise<ViewEventResponse | void> {
         return Promise.resolve();

--- a/src/events.ts
+++ b/src/events.ts
@@ -68,6 +68,8 @@ export interface SearchEventRequest extends EventBaseRequest {
     facetState?: FacetStateRequest[];
 }
 
+export interface PreparedSearchEventRequest extends Omit<SearchEventRequest, 'searchQueryUid'> {}
+
 export interface DocumentInformation {
     documentUri: string;
     documentUriHash: string;
@@ -86,11 +88,15 @@ export interface DocumentInformation {
 
 export interface ClickEventRequest extends EventBaseRequest, DocumentInformation {}
 
+export interface PreparedClickEventRequest extends Omit<ClickEventRequest, 'searchQueryUid'> {}
+
 export interface CustomEventRequest extends EventBaseRequest {
     eventType: string;
     eventValue: string;
     lastSearchQueryUid?: string;
 }
+
+export interface PreparedCustomEventRequest extends Omit<CustomEventRequest, 'lastSearchQueryUid'> {}
 
 export interface ViewEventRequest extends EventBaseRequest {
     location?: string;
@@ -100,6 +106,8 @@ export interface ViewEventRequest extends EventBaseRequest {
     contentIdValue: string;
     contentType?: string;
 }
+
+export interface PreparedViewEventRequest extends ViewEventRequest {}
 
 export interface DefaultEventResponse {
     visitId: string;

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -207,7 +207,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeInterfaceLoad', async () => {
         const built = await client.makeInterfaceLoad();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.interfaceLoad);
         expectMatchDescription(built.description, SearchPageEvents.interfaceLoad);
     });
@@ -221,7 +221,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeInterfaceChange', async () => {
         const built = await client.makeInterfaceChange({interfaceChangeTo: 'bob'});
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
         expectMatchDescription(built.description, SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
     });
@@ -233,7 +233,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDidyoumeanAutomatic', async () => {
         const built = await client.makeDidYouMeanAutomatic();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
         expectMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
     });
@@ -245,7 +245,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDidyoumeanClick', async () => {
         const built = await client.makeDidYouMeanClick();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.didyoumeanClick);
         expectMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
     });
@@ -257,7 +257,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeResultsSort', async () => {
         const built = await client.makeResultsSort({resultsSortBy: 'date ascending'});
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
         expectMatchDescription(built.description, SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
     });
@@ -269,7 +269,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxSubmit', async () => {
         const built = await client.makeSearchboxSubmit();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxSubmit);
         expectMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
     });
@@ -281,7 +281,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxClear', async () => {
         const built = await client.makeSearchboxClear();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxClear);
         expectMatchDescription(built.description, SearchPageEvents.searchboxClear);
     });
@@ -293,7 +293,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxAsYouType', async () => {
         const built = await client.makeSearchboxAsYouType();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxAsYouType);
         expectMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
     });
@@ -305,7 +305,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDocumentQuickview', async () => {
         const built = await client.makeDocumentQuickview(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.documentQuickview, {...fakeDocID});
     });
@@ -317,7 +317,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDocumentOpen', async () => {
         const built = await client.makeDocumentOpen(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.documentOpen, {...fakeDocID});
     });
@@ -329,7 +329,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeShowMoreFoldedResults', async () => {
         const built = await client.makeShowMoreFoldedResults(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.showMoreFoldedResults, fakeDocID);
     });
@@ -341,7 +341,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeShowLessFoldedResults', async () => {
         const built = await client.makeShowLessFoldedResults();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
         expectMatchDescription(built.description, SearchPageEvents.showLessFoldedResults);
     });
@@ -367,7 +367,7 @@ describe('SearchPageClient', () => {
             querySuggestResponseId: '1',
         };
         const built = await client.makeOmniboxAnalytics(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
         expectMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
     });
@@ -393,7 +393,7 @@ describe('SearchPageClient', () => {
             querySuggestResponseId: '1',
         };
         const built = await client.makeOmniboxFromLink(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
         expectMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
     });
@@ -405,7 +405,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchFromLink', async () => {
         const built = await client.makeSearchFromLink();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchFromLink);
         expectMatchDescription(built.description, SearchPageEvents.searchFromLink);
     });
@@ -423,7 +423,7 @@ describe('SearchPageClient', () => {
             notifications: ['foo', 'bar'],
         };
         const built = await client.makeTriggerNotify(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerNotify, meta);
     });
@@ -447,7 +447,7 @@ describe('SearchPageClient', () => {
             ],
         };
         const built = await client.makeTriggerExecute(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerExecute, meta);
     });
@@ -465,7 +465,7 @@ describe('SearchPageClient', () => {
             query: 'queryText',
         };
         const built = await client.makeTriggerQuery();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
         expectMatchDescription(built.description, SearchPageEvents.triggerQuery, meta);
     });
@@ -483,7 +483,7 @@ describe('SearchPageClient', () => {
             undoneQuery: 'foo',
         };
         const built = await client.makeUndoTriggerQuery(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
         expectMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
     });
@@ -503,7 +503,7 @@ describe('SearchPageClient', () => {
             query: provider.getSearchEventRequestPayload().queryText,
         };
         const built = await client.makeTriggerRedirect(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerRedirect, meta);
     });
@@ -521,7 +521,7 @@ describe('SearchPageClient', () => {
             currentResultsPerPage: 123,
         };
         const built = await client.makePagerResize(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerResize, meta);
     });
@@ -535,7 +535,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerNumber', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerNumber(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerNumber, meta);
     });
@@ -549,7 +549,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerNext', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerNext(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerNext, meta);
     });
@@ -563,7 +563,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerPrevious', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerPrevious(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerPrevious, meta);
     });
@@ -575,7 +575,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makePagerScrolling', async () => {
         const built = await client.makePagerScrolling();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
         expectMatchDescription(built.description, SearchPageEvents.pagerScrolling);
     });
@@ -590,7 +590,7 @@ describe('SearchPageClient', () => {
     it('should send the proper payload for #makeStaticFilterClearAll', async () => {
         const staticFilterId = 'filetypes';
         const built = await client.makeStaticFilterClearAll({staticFilterId});
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
         expectMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
     });
@@ -617,7 +617,7 @@ describe('SearchPageClient', () => {
             },
         };
         const built = await client.makeStaticFilterSelect(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
         expectMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
@@ -645,7 +645,7 @@ describe('SearchPageClient', () => {
             },
         };
         const built = await client.makeStaticFilterDeselect(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
         expectMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
     });
@@ -667,7 +667,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetSearch(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSearch, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
     });
@@ -692,7 +692,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         const built = await client.makeFacetSelect(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSelect, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
     });
@@ -718,7 +718,7 @@ describe('SearchPageClient', () => {
         };
 
         const built = await client.makeFacetDeselect(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetDeselect, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
     });
@@ -742,7 +742,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         const built = await client.makeFacetExclude(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetExclude, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
     });
@@ -766,7 +766,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         const built = await client.makeFacetUnexclude(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
     });
@@ -788,7 +788,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetSelectAll(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
     });
@@ -812,7 +812,7 @@ describe('SearchPageClient', () => {
             criteria: 'bazz',
         };
         const built = await client.makeFacetUpdateSort(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
     });
@@ -834,7 +834,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetShowMore(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetShowMore, meta);
     });
@@ -856,7 +856,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetShowLess(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetShowLess, meta);
     });
@@ -884,7 +884,7 @@ describe('SearchPageClient', () => {
             errorType: 'a bad one',
         };
         const built = await client.makeQueryError(meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
         expectMatchDescription(built.description, SearchPageEvents.queryError, meta);
     });
@@ -896,7 +896,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorBack', async () => {
         const built = await client.makeQueryErrorBack();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.queryErrorBack);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorBack);
@@ -909,7 +909,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorRetry', async () => {
         const built = await client.makeQueryErrorRetry();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.queryErrorRetry);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorRetry);
     });
@@ -921,7 +921,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorClear', async () => {
         const built = await client.makeQueryErrorClear();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.queryErrorClear);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorClear);
     });
@@ -933,7 +933,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendationInterfaceLoad', async () => {
         const built = await client.makeRecommendationInterfaceLoad();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
         expectMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
     });
@@ -945,7 +945,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendation', async () => {
         const built = await client.makeRecommendation();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.recommendation);
     });
 
@@ -956,7 +956,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendationOpen', async () => {
         const built = await client.makeRecommendationOpen(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.recommendationOpen, {...fakeDocID});
     });
@@ -968,7 +968,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeFetchMoreResults', async () => {
         const built = await client.makeFetchMoreResults();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
         expectMatchDescription(built.description, SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
     });
@@ -980,7 +980,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeLikeSmartSnippet', async () => {
         const built = await client.makeLikeSmartSnippet();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.likeSmartSnippet);
     });
@@ -992,7 +992,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDislikeSmartSnippet', async () => {
         const built = await client.makeDislikeSmartSnippet();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.dislikeSmartSnippet);
     });
@@ -1004,7 +1004,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeExpandSmartSnippet', async () => {
         const built = await client.makeExpandSmartSnippet();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippet);
     });
@@ -1016,7 +1016,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCollapseSmartSnippet', async () => {
         const built = await client.makeCollapseSmartSnippet();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippet);
     });
@@ -1028,7 +1028,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeOpenSmartSnippetFeedbackModal', async () => {
         const built = await client.makeOpenSmartSnippetFeedbackModal();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetFeedbackModal);
     });
@@ -1040,7 +1040,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCloseSmartSnippetFeedbackModal', async () => {
         const built = await client.makeCloseSmartSnippetFeedbackModal();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
         expectMatchDescription(built.description, SearchPageEvents.closeSmartSnippetFeedbackModal);
     });
@@ -1055,7 +1055,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSmartSnippetFeedbackReason', async () => {
         const built = await client.makeSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
             details: 'this is irrelevant',
             reason: 'does_not_answer',
@@ -1085,7 +1085,7 @@ describe('SearchPageClient', () => {
             answerSnippet: 'Def',
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
@@ -1117,7 +1117,7 @@ describe('SearchPageClient', () => {
             answerSnippet: 'Def',
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
@@ -1142,7 +1142,7 @@ describe('SearchPageClient', () => {
             contentIdKey: 'permanentid',
             contentIdValue: 'foo',
         });
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
@@ -1163,7 +1163,7 @@ describe('SearchPageClient', () => {
             contentIdKey: 'permanentid',
             contentIdValue: 'foo',
         });
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
@@ -1210,7 +1210,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeOpenSmartSnippetSource', async () => {
         const built = await client.makeOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSource, {...fakeDocID});
     });
@@ -1238,7 +1238,7 @@ describe('SearchPageClient', () => {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         };
         const built = await client.makeOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionSource, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionSource, meta);
     });
@@ -1260,7 +1260,7 @@ describe('SearchPageClient', () => {
             linkURL: 'https://invalid.com',
         };
         const built = await client.makeOpenSmartSnippetInlineLink(fakeDocInfo, meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetInlineLink, meta);
     });
@@ -1292,7 +1292,7 @@ describe('SearchPageClient', () => {
             linkURL: 'https://invalid.com',
         };
         const built = await client.makeOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionInlineLink, meta);
     });
@@ -1304,7 +1304,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecentQueryClick', async () => {
         const built = await client.makeRecentQueryClick();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.recentQueryClick);
         expectMatchDescription(built.description, SearchPageEvents.recentQueryClick);
@@ -1317,7 +1317,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeClearRecentQueries', async () => {
         const built = await client.makeClearRecentQueries();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
         expectMatchDescription(built.description, SearchPageEvents.clearRecentQueries);
@@ -1333,7 +1333,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecentResultClick', async () => {
         const built = await client.makeRecentResultClick(fakeDocInfo, fakeDocID);
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchCustomEventPayload(SearchPageEvents.recentResultClick, {
             info: fakeDocInfo,
@@ -1353,7 +1353,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeNoResultsBack', async () => {
         const built = await client.makeNoResultsBack();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.noResultsBack);
         expectMatchDescription(built.description, SearchPageEvents.noResultsBack);
@@ -1366,7 +1366,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeClearRecentResults', async () => {
         const built = await client.makeClearRecentResults();
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
         expectMatchDescription(built.description, SearchPageEvents.clearRecentResults);
@@ -1379,7 +1379,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCustomEventWithType', async () => {
         const built = await client.makeCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
-        await built.log(provider.getSearchUID());
+        await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
         expectMatchDescription(built.description, 'foo' as SearchPageEvents, {buzz: 'bazz'});

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -207,7 +207,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeInterfaceLoad', async () => {
         const built = await client.makeInterfaceLoad();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.interfaceLoad);
         expectMatchDescription(built.description, SearchPageEvents.interfaceLoad);
     });
@@ -221,7 +221,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeInterfaceChange', async () => {
         const built = await client.makeInterfaceChange({interfaceChangeTo: 'bob'});
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
         expectMatchDescription(built.description, SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
     });
@@ -233,7 +233,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDidyoumeanAutomatic', async () => {
         const built = await client.makeDidYouMeanAutomatic();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
         expectMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
     });
@@ -245,7 +245,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDidyoumeanClick', async () => {
         const built = await client.makeDidYouMeanClick();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.didyoumeanClick);
         expectMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
     });
@@ -257,7 +257,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeResultsSort', async () => {
         const built = await client.makeResultsSort({resultsSortBy: 'date ascending'});
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
         expectMatchDescription(built.description, SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
     });
@@ -269,7 +269,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxSubmit', async () => {
         const built = await client.makeSearchboxSubmit();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.searchboxSubmit);
         expectMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
     });
@@ -281,7 +281,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxClear', async () => {
         const built = await client.makeSearchboxClear();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.searchboxClear);
         expectMatchDescription(built.description, SearchPageEvents.searchboxClear);
     });
@@ -293,7 +293,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchboxAsYouType', async () => {
         const built = await client.makeSearchboxAsYouType();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.searchboxAsYouType);
         expectMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
     });
@@ -305,7 +305,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDocumentQuickview', async () => {
         const built = await client.makeDocumentQuickview(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.documentQuickview, {...fakeDocID});
     });
@@ -317,7 +317,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDocumentOpen', async () => {
         const built = await client.makeDocumentOpen(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.documentOpen, {...fakeDocID});
     });
@@ -329,7 +329,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeShowMoreFoldedResults', async () => {
         const built = await client.makeShowMoreFoldedResults(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.showMoreFoldedResults, fakeDocID);
     });
@@ -341,7 +341,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeShowLessFoldedResults', async () => {
         const built = await client.makeShowLessFoldedResults();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
         expectMatchDescription(built.description, SearchPageEvents.showLessFoldedResults);
     });
@@ -367,7 +367,7 @@ describe('SearchPageClient', () => {
             querySuggestResponseId: '1',
         };
         const built = await client.makeOmniboxAnalytics(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
         expectMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
     });
@@ -393,7 +393,7 @@ describe('SearchPageClient', () => {
             querySuggestResponseId: '1',
         };
         const built = await client.makeOmniboxFromLink(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
         expectMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
     });
@@ -405,7 +405,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSearchFromLink', async () => {
         const built = await client.makeSearchFromLink();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.searchFromLink);
         expectMatchDescription(built.description, SearchPageEvents.searchFromLink);
     });
@@ -423,7 +423,7 @@ describe('SearchPageClient', () => {
             notifications: ['foo', 'bar'],
         };
         const built = await client.makeTriggerNotify(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerNotify, meta);
     });
@@ -447,7 +447,7 @@ describe('SearchPageClient', () => {
             ],
         };
         const built = await client.makeTriggerExecute(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerExecute, meta);
     });
@@ -465,7 +465,7 @@ describe('SearchPageClient', () => {
             query: 'queryText',
         };
         const built = await client.makeTriggerQuery();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
         expectMatchDescription(built.description, SearchPageEvents.triggerQuery, meta);
     });
@@ -483,7 +483,7 @@ describe('SearchPageClient', () => {
             undoneQuery: 'foo',
         };
         const built = await client.makeUndoTriggerQuery(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
         expectMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
     });
@@ -503,7 +503,7 @@ describe('SearchPageClient', () => {
             query: provider.getSearchEventRequestPayload().queryText,
         };
         const built = await client.makeTriggerRedirect(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
         expectMatchDescription(built.description, SearchPageEvents.triggerRedirect, meta);
     });
@@ -521,7 +521,7 @@ describe('SearchPageClient', () => {
             currentResultsPerPage: 123,
         };
         const built = await client.makePagerResize(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerResize, meta);
     });
@@ -535,7 +535,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerNumber', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerNumber(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerNumber, meta);
     });
@@ -549,7 +549,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerNext', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerNext(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerNext, meta);
     });
@@ -563,7 +563,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makePagerPrevious', async () => {
         const meta = {pagerNumber: 123};
         const built = await client.makePagerPrevious(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
         expectMatchDescription(built.description, SearchPageEvents.pagerPrevious, meta);
     });
@@ -575,7 +575,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makePagerScrolling', async () => {
         const built = await client.makePagerScrolling();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
         expectMatchDescription(built.description, SearchPageEvents.pagerScrolling);
     });
@@ -590,7 +590,7 @@ describe('SearchPageClient', () => {
     it('should send the proper payload for #makeStaticFilterClearAll', async () => {
         const staticFilterId = 'filetypes';
         const built = await client.makeStaticFilterClearAll({staticFilterId});
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
         expectMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
     });
@@ -617,7 +617,7 @@ describe('SearchPageClient', () => {
             },
         };
         const built = await client.makeStaticFilterSelect(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
         expectMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
@@ -645,7 +645,7 @@ describe('SearchPageClient', () => {
             },
         };
         const built = await client.makeStaticFilterDeselect(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
         expectMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
     });
@@ -667,7 +667,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetSearch(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetSearch, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
     });
@@ -691,8 +691,8 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
             facetValue: 'qwerty',
         };
-        const built = await await client.makeFacetSelect(meta);
-        await built.log();
+        const built = await client.makeFacetSelect(meta);
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetSelect, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
     });
@@ -718,7 +718,7 @@ describe('SearchPageClient', () => {
         };
 
         const built = await client.makeFacetDeselect(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetDeselect, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
     });
@@ -742,7 +742,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         const built = await client.makeFacetExclude(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetExclude, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
     });
@@ -766,7 +766,7 @@ describe('SearchPageClient', () => {
             facetValue: 'qwerty',
         };
         const built = await client.makeFacetUnexclude(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
     });
@@ -788,7 +788,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetSelectAll(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
     });
@@ -812,7 +812,7 @@ describe('SearchPageClient', () => {
             criteria: 'bazz',
         };
         const built = await client.makeFacetUpdateSort(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
     });
@@ -834,7 +834,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetShowMore(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetShowMore, meta);
     });
@@ -856,7 +856,7 @@ describe('SearchPageClient', () => {
             facetTitle: 'title',
         };
         const built = await client.makeFacetShowLess(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
         expectMatchDescription(built.description, SearchPageEvents.facetShowLess, meta);
     });
@@ -884,7 +884,7 @@ describe('SearchPageClient', () => {
             errorType: 'a bad one',
         };
         const built = await client.makeQueryError(meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
         expectMatchDescription(built.description, SearchPageEvents.queryError, meta);
     });
@@ -896,7 +896,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorBack', async () => {
         const built = await client.makeQueryErrorBack();
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchPayload(SearchPageEvents.queryErrorBack);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorBack);
@@ -909,7 +909,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorRetry', async () => {
         const built = await client.makeQueryErrorRetry();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.queryErrorRetry);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorRetry);
     });
@@ -921,7 +921,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeQueryErrorClear', async () => {
         const built = await client.makeQueryErrorClear();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.queryErrorClear);
         expectMatchDescription(built.description, SearchPageEvents.queryErrorClear);
     });
@@ -933,7 +933,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendationInterfaceLoad', async () => {
         const built = await client.makeRecommendationInterfaceLoad();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
         expectMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
     });
@@ -945,7 +945,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendation', async () => {
         const built = await client.makeRecommendation();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.recommendation);
     });
 
@@ -956,7 +956,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecommendationOpen', async () => {
         const built = await client.makeRecommendationOpen(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.recommendationOpen, {...fakeDocID});
     });
@@ -968,7 +968,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeFetchMoreResults', async () => {
         const built = await client.makeFetchMoreResults();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
         expectMatchDescription(built.description, SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
     });
@@ -980,7 +980,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeLikeSmartSnippet', async () => {
         const built = await client.makeLikeSmartSnippet();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.likeSmartSnippet);
     });
@@ -992,7 +992,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeDislikeSmartSnippet', async () => {
         const built = await client.makeDislikeSmartSnippet();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.dislikeSmartSnippet);
     });
@@ -1004,7 +1004,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeExpandSmartSnippet', async () => {
         const built = await client.makeExpandSmartSnippet();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippet);
     });
@@ -1016,7 +1016,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCollapseSmartSnippet', async () => {
         const built = await client.makeCollapseSmartSnippet();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
         expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippet);
     });
@@ -1028,7 +1028,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeOpenSmartSnippetFeedbackModal', async () => {
         const built = await client.makeOpenSmartSnippetFeedbackModal();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetFeedbackModal);
     });
@@ -1040,7 +1040,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCloseSmartSnippetFeedbackModal', async () => {
         const built = await client.makeCloseSmartSnippetFeedbackModal();
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
         expectMatchDescription(built.description, SearchPageEvents.closeSmartSnippetFeedbackModal);
     });
@@ -1055,7 +1055,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeSmartSnippetFeedbackReason', async () => {
         const built = await client.makeSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
             details: 'this is irrelevant',
             reason: 'does_not_answer',
@@ -1085,7 +1085,7 @@ describe('SearchPageClient', () => {
             answerSnippet: 'Def',
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
@@ -1117,7 +1117,7 @@ describe('SearchPageClient', () => {
             answerSnippet: 'Def',
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
             question: 'Abc',
             answerSnippet: 'Def',
@@ -1142,7 +1142,7 @@ describe('SearchPageClient', () => {
             contentIdKey: 'permanentid',
             contentIdValue: 'foo',
         });
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
@@ -1163,7 +1163,7 @@ describe('SearchPageClient', () => {
             contentIdKey: 'permanentid',
             contentIdValue: 'foo',
         });
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         });
@@ -1210,7 +1210,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeOpenSmartSnippetSource', async () => {
         const built = await client.makeOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSource, {...fakeDocID});
     });
@@ -1238,7 +1238,7 @@ describe('SearchPageClient', () => {
             documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
         };
         const built = await client.makeOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionSource, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionSource, meta);
     });
@@ -1260,7 +1260,7 @@ describe('SearchPageClient', () => {
             linkURL: 'https://invalid.com',
         };
         const built = await client.makeOpenSmartSnippetInlineLink(fakeDocInfo, meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetInlineLink, meta);
     });
@@ -1292,7 +1292,7 @@ describe('SearchPageClient', () => {
             linkURL: 'https://invalid.com',
         };
         const built = await client.makeOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
-        await built.log();
+        await built.log(provider.getSearchUID());
         expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, meta);
         expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionInlineLink, meta);
     });
@@ -1304,7 +1304,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecentQueryClick', async () => {
         const built = await client.makeRecentQueryClick();
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchPayload(SearchPageEvents.recentQueryClick);
         expectMatchDescription(built.description, SearchPageEvents.recentQueryClick);
@@ -1317,7 +1317,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeClearRecentQueries', async () => {
         const built = await client.makeClearRecentQueries();
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
         expectMatchDescription(built.description, SearchPageEvents.clearRecentQueries);
@@ -1333,7 +1333,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeRecentResultClick', async () => {
         const built = await client.makeRecentResultClick(fakeDocInfo, fakeDocID);
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchCustomEventPayload(SearchPageEvents.recentResultClick, {
             info: fakeDocInfo,
@@ -1353,7 +1353,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeNoResultsBack', async () => {
         const built = await client.makeNoResultsBack();
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchPayload(SearchPageEvents.noResultsBack);
         expectMatchDescription(built.description, SearchPageEvents.noResultsBack);
@@ -1366,7 +1366,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeClearRecentResults', async () => {
         const built = await client.makeClearRecentResults();
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
         expectMatchDescription(built.description, SearchPageEvents.clearRecentResults);
@@ -1379,7 +1379,7 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #makeCustomEventWithType', async () => {
         const built = await client.makeCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
-        await built.log();
+        await built.log(provider.getSearchUID());
 
         expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
         expectMatchDescription(built.description, 'foo' as SearchPageEvents, {buzz: 'bazz'});

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -742,7 +742,7 @@ export class CoveoSearchPageClient {
             eventType,
             eventValue: event,
         };
-        const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(request);
+        const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
             log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
@@ -768,7 +768,7 @@ export class CoveoSearchPageClient {
             eventType,
             eventValue,
         };
-        const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(payload);
+        const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(payload);
         return {
             description: this.makeEventDescription(preparedEvent, eventValue as SearchPageEvents),
             log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
@@ -788,7 +788,7 @@ export class CoveoSearchPageClient {
         metadata?: Record<string, any>
     ): Promise<EventBuilder<SearchEventResponse>> {
         const request = await this.getBaseSearchEventRequest(event, metadata);
-        const preparedEvent = await this.coveoAnalyticsClient.prepareSearchEvent(request);
+        const preparedEvent = await this.coveoAnalyticsClient.makeSearchEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
             log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),
@@ -807,7 +807,7 @@ export class CoveoSearchPageClient {
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,
         };
-        const preparedEvent = await this.coveoAnalyticsClient.prepareClickEvent(request);
+        const preparedEvent = await this.coveoAnalyticsClient.makeClickEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
             log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -65,7 +65,7 @@ export type EventDescription = Pick<SearchEventRequest, 'actionCause' | 'customD
 
 export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
     description: EventDescription;
-    log: (searchUID: string) => Promise<T | void>;
+    log(metadata: {searchUID: string}): Promise<T | void>;
 }
 
 export class CoveoSearchPageClient {
@@ -93,7 +93,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logInterfaceLoad() {
-        return (await this.makeInterfaceLoad()).log(this.provider.getSearchUID());
+        return (await this.makeInterfaceLoad()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeRecommendationInterfaceLoad() {
@@ -101,7 +101,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendationInterfaceLoad() {
-        return (await this.makeRecommendationInterfaceLoad()).log(this.provider.getSearchUID());
+        return (await this.makeRecommendationInterfaceLoad()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeRecommendation() {
@@ -109,7 +109,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendation() {
-        return (await this.makeRecommendation()).log(this.provider.getSearchUID());
+        return (await this.makeRecommendation()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -117,7 +117,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeRecommendationOpen(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeRecommendationOpen(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeStaticFilterClearAll(meta: StaticFilterMetadata) {
@@ -125,7 +125,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterClearAll(meta: StaticFilterMetadata) {
-        return (await this.makeStaticFilterClearAll(meta)).log(this.provider.getSearchUID());
+        return (await this.makeStaticFilterClearAll(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
@@ -133,7 +133,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
-        return (await this.makeStaticFilterSelect(meta)).log(this.provider.getSearchUID());
+        return (await this.makeStaticFilterSelect(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
@@ -141,7 +141,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
-        return (await this.makeStaticFilterDeselect(meta)).log(this.provider.getSearchUID());
+        return (await this.makeStaticFilterDeselect(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFetchMoreResults() {
@@ -149,7 +149,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFetchMoreResults() {
-        return (await this.makeFetchMoreResults()).log(this.provider.getSearchUID());
+        return (await this.makeFetchMoreResults()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeInterfaceChange(metadata: InterfaceChangeMetadata) {
@@ -157,7 +157,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logInterfaceChange(metadata: InterfaceChangeMetadata) {
-        return (await this.makeInterfaceChange(metadata)).log(this.provider.getSearchUID());
+        return (await this.makeInterfaceChange(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeDidYouMeanAutomatic() {
@@ -165,7 +165,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDidYouMeanAutomatic() {
-        return (await this.makeDidYouMeanAutomatic()).log(this.provider.getSearchUID());
+        return (await this.makeDidYouMeanAutomatic()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeDidYouMeanClick() {
@@ -173,7 +173,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDidYouMeanClick() {
-        return (await this.makeDidYouMeanClick()).log(this.provider.getSearchUID());
+        return (await this.makeDidYouMeanClick()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeResultsSort(metadata: ResultsSortMetadata) {
@@ -181,7 +181,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logResultsSort(metadata: ResultsSortMetadata) {
-        return (await this.makeResultsSort(metadata)).log(this.provider.getSearchUID());
+        return (await this.makeResultsSort(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeSearchboxSubmit() {
@@ -189,7 +189,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxSubmit() {
-        return (await this.makeSearchboxSubmit()).log(this.provider.getSearchUID());
+        return (await this.makeSearchboxSubmit()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeSearchboxClear() {
@@ -197,7 +197,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxClear() {
-        return (await this.makeSearchboxClear()).log(this.provider.getSearchUID());
+        return (await this.makeSearchboxClear()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeSearchboxAsYouType() {
@@ -205,7 +205,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxAsYouType() {
-        return (await this.makeSearchboxAsYouType()).log(this.provider.getSearchUID());
+        return (await this.makeSearchboxAsYouType()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
@@ -213,7 +213,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
-        return (await this.makeBreadcrumbFacet(metadata)).log(this.provider.getSearchUID());
+        return (await this.makeBreadcrumbFacet(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeBreadcrumbResetAll() {
@@ -221,7 +221,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logBreadcrumbResetAll() {
-        return (await this.makeBreadcrumbResetAll()).log(this.provider.getSearchUID());
+        return (await this.makeBreadcrumbResetAll()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -229,7 +229,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeDocumentQuickview(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeDocumentQuickview(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -237,7 +237,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeDocumentOpen(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeDocumentOpen(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
@@ -245,7 +245,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
-        return (await this.makeOmniboxAnalytics(meta)).log(this.provider.getSearchUID());
+        return (await this.makeOmniboxAnalytics(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
@@ -253,7 +253,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
-        return (await this.makeOmniboxFromLink(meta)).log(this.provider.getSearchUID());
+        return (await this.makeOmniboxFromLink(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeSearchFromLink() {
@@ -261,7 +261,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchFromLink() {
-        return (await this.makeSearchFromLink()).log(this.provider.getSearchUID());
+        return (await this.makeSearchFromLink()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeTriggerNotify(meta: TriggerNotifyMetadata) {
@@ -269,7 +269,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerNotify(meta: TriggerNotifyMetadata) {
-        return (await this.makeTriggerNotify(meta)).log(this.provider.getSearchUID());
+        return (await this.makeTriggerNotify(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeTriggerExecute(meta: TriggerExecuteMetadata) {
@@ -277,7 +277,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerExecute(meta: TriggerExecuteMetadata) {
-        return (await this.makeTriggerExecute(meta)).log(this.provider.getSearchUID());
+        return (await this.makeTriggerExecute(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeTriggerQuery() {
@@ -289,7 +289,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerQuery() {
-        return (await this.makeTriggerQuery()).log(this.provider.getSearchUID());
+        return (await this.makeTriggerQuery()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
@@ -297,7 +297,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
-        return (await this.makeUndoTriggerQuery(meta)).log(this.provider.getSearchUID());
+        return (await this.makeUndoTriggerQuery(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeTriggerRedirect(meta: TriggerRedirectMetadata) {
@@ -308,7 +308,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerRedirect(meta: TriggerRedirectMetadata) {
-        return (await this.makeTriggerRedirect(meta)).log(this.provider.getSearchUID());
+        return (await this.makeTriggerRedirect(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makePagerResize(meta: PagerResizeMetadata) {
@@ -316,7 +316,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerResize(meta: PagerResizeMetadata) {
-        return (await this.makePagerResize(meta)).log(this.provider.getSearchUID());
+        return (await this.makePagerResize(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makePagerNumber(meta: PagerMetadata) {
@@ -324,7 +324,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerNumber(meta: PagerMetadata) {
-        return (await this.makePagerNumber(meta)).log(this.provider.getSearchUID());
+        return (await this.makePagerNumber(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makePagerNext(meta: PagerMetadata) {
@@ -332,7 +332,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerNext(meta: PagerMetadata) {
-        return (await this.makePagerNext(meta)).log(this.provider.getSearchUID());
+        return (await this.makePagerNext(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makePagerPrevious(meta: PagerMetadata) {
@@ -340,7 +340,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerPrevious(meta: PagerMetadata) {
-        return (await this.makePagerPrevious(meta)).log(this.provider.getSearchUID());
+        return (await this.makePagerPrevious(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makePagerScrolling() {
@@ -348,7 +348,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerScrolling() {
-        return (await this.makePagerScrolling()).log(this.provider.getSearchUID());
+        return (await this.makePagerScrolling()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetClearAll(meta: FacetBaseMeta) {
@@ -356,7 +356,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetClearAll(meta: FacetBaseMeta) {
-        return (await this.makeFacetClearAll(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetClearAll(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetSearch(meta: FacetBaseMeta) {
@@ -364,7 +364,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSearch(meta: FacetBaseMeta) {
-        return (await this.makeFacetSearch(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetSearch(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetSelect(meta: FacetMetadata) {
@@ -372,7 +372,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSelect(meta: FacetMetadata) {
-        return (await this.makeFacetSelect(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetSelect(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetDeselect(meta: FacetMetadata) {
@@ -380,7 +380,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetDeselect(meta: FacetMetadata) {
-        return (await this.makeFacetDeselect(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetDeselect(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetExclude(meta: FacetMetadata) {
@@ -388,7 +388,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetExclude(meta: FacetMetadata) {
-        return (await this.makeFacetExclude(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetExclude(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetUnexclude(meta: FacetMetadata) {
@@ -396,7 +396,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetUnexclude(meta: FacetMetadata) {
-        return (await this.makeFacetUnexclude(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetUnexclude(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetSelectAll(meta: FacetBaseMeta) {
@@ -404,7 +404,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSelectAll(meta: FacetBaseMeta) {
-        return (await this.makeFacetSelectAll(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetSelectAll(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetUpdateSort(meta: FacetSortMeta) {
@@ -412,7 +412,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetUpdateSort(meta: FacetSortMeta) {
-        return (await this.makeFacetUpdateSort(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetUpdateSort(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetShowMore(meta: FacetBaseMeta) {
@@ -420,7 +420,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetShowMore(meta: FacetBaseMeta) {
-        return (await this.makeFacetShowMore(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetShowMore(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeFacetShowLess(meta: FacetBaseMeta) {
@@ -428,7 +428,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetShowLess(meta: FacetBaseMeta) {
-        return (await this.makeFacetShowLess(meta)).log(this.provider.getSearchUID());
+        return (await this.makeFacetShowLess(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeQueryError(meta: QueryErrorMeta) {
@@ -436,7 +436,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logQueryError(meta: QueryErrorMeta) {
-        return (await this.makeQueryError(meta)).log(this.provider.getSearchUID());
+        return (await this.makeQueryError(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async makeQueryErrorBack(): Promise<EventBuilder<SearchEventResponse>> {
@@ -444,14 +444,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log(this.provider.getSearchUID());
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
                 return this.logSearchEvent(SearchPageEvents.queryErrorBack);
             },
         };
     }
 
     public async logQueryErrorBack() {
-        return (await this.makeQueryErrorBack()).log(this.provider.getSearchUID());
+        return (await this.makeQueryErrorBack()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async makeQueryErrorRetry(): Promise<EventBuilder<SearchEventResponse>> {
@@ -459,14 +459,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log(this.provider.getSearchUID());
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
                 return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
             },
         };
     }
 
     public async logQueryErrorRetry() {
-        return (await this.makeQueryErrorRetry()).log(this.provider.getSearchUID());
+        return (await this.makeQueryErrorRetry()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async makeQueryErrorClear(): Promise<EventBuilder<SearchEventResponse>> {
@@ -474,14 +474,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log(this.provider.getSearchUID());
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
                 return this.logSearchEvent(SearchPageEvents.queryErrorClear);
             },
         };
     }
 
     public async logQueryErrorClear() {
-        return (await this.makeQueryErrorClear()).log(this.provider.getSearchUID());
+        return (await this.makeQueryErrorClear()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeLikeSmartSnippet() {
@@ -489,7 +489,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logLikeSmartSnippet() {
-        return (await this.makeLikeSmartSnippet()).log(this.provider.getSearchUID());
+        return (await this.makeLikeSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeDislikeSmartSnippet() {
@@ -497,7 +497,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDislikeSmartSnippet() {
-        return (await this.makeDislikeSmartSnippet()).log(this.provider.getSearchUID());
+        return (await this.makeDislikeSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeExpandSmartSnippet() {
@@ -505,7 +505,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logExpandSmartSnippet() {
-        return (await this.makeExpandSmartSnippet()).log(this.provider.getSearchUID());
+        return (await this.makeExpandSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeCollapseSmartSnippet() {
@@ -513,7 +513,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logCollapseSmartSnippet() {
-        return (await this.makeCollapseSmartSnippet()).log(this.provider.getSearchUID());
+        return (await this.makeCollapseSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeOpenSmartSnippetFeedbackModal() {
@@ -521,7 +521,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOpenSmartSnippetFeedbackModal() {
-        return (await this.makeOpenSmartSnippetFeedbackModal()).log(this.provider.getSearchUID());
+        return (await this.makeOpenSmartSnippetFeedbackModal()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeCloseSmartSnippetFeedbackModal() {
@@ -529,7 +529,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logCloseSmartSnippetFeedbackModal() {
-        return (await this.makeCloseSmartSnippetFeedbackModal()).log(this.provider.getSearchUID());
+        return (await this.makeCloseSmartSnippetFeedbackModal()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
@@ -537,7 +537,9 @@ export class CoveoSearchPageClient {
     }
 
     public async logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
-        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log(this.provider.getSearchUID());
+        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -548,7 +550,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
+        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -561,7 +563,7 @@ export class CoveoSearchPageClient {
     public async logCollapseSmartSnippetSuggestion(
         snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
     ) {
-        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
+        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
 
     /**
@@ -575,7 +577,7 @@ export class CoveoSearchPageClient {
      * @deprecated
      */
     public async logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
+        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
 
     /**
@@ -589,7 +591,7 @@ export class CoveoSearchPageClient {
      * @deprecated
      */
     public async logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
+        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -597,7 +599,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeOpenSmartSnippetSource(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeOpenSmartSnippetSource(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
@@ -614,14 +616,16 @@ export class CoveoSearchPageClient {
     }
 
     public async logCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeCopyToClipboard(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeCopyToClipboard(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async logOpenSmartSnippetSuggestionSource(
         info: PartialDocumentInformation,
         snippet: SmartSnippetSuggestionMeta
     ) {
-        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log(this.provider.getSearchUID());
+        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     public makeOpenSmartSnippetInlineLink(
@@ -640,7 +644,9 @@ export class CoveoSearchPageClient {
         info: PartialDocumentInformation,
         identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
-        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log(this.provider.getSearchUID());
+        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     public makeOpenSmartSnippetSuggestionInlineLink(
@@ -662,9 +668,9 @@ export class CoveoSearchPageClient {
         info: PartialDocumentInformation,
         snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
-        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log(
-            this.provider.getSearchUID()
-        );
+        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     public makeRecentQueryClick() {
@@ -672,7 +678,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecentQueryClick() {
-        return (await this.makeRecentQueryClick()).log(this.provider.getSearchUID());
+        return (await this.makeRecentQueryClick()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeClearRecentQueries() {
@@ -680,7 +686,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logClearRecentQueries() {
-        return (await this.makeClearRecentQueries()).log(this.provider.getSearchUID());
+        return (await this.makeClearRecentQueries()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -688,7 +694,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeRecentResultClick(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeRecentResultClick(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeClearRecentResults() {
@@ -696,7 +702,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logClearRecentResults() {
-        return (await this.makeClearRecentResults()).log(this.provider.getSearchUID());
+        return (await this.makeClearRecentResults()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeNoResultsBack() {
@@ -704,7 +710,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logNoResultsBack() {
-        return (await this.makeNoResultsBack()).log(this.provider.getSearchUID());
+        return (await this.makeNoResultsBack()).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -712,7 +718,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeShowMoreFoldedResults(info, identifier)).log(this.provider.getSearchUID());
+        return (await this.makeShowMoreFoldedResults(info, identifier)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeShowLessFoldedResults() {
@@ -720,7 +726,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logShowLessFoldedResults() {
-        return (await this.makeShowLessFoldedResults()).log(this.provider.getSearchUID());
+        return (await this.makeShowLessFoldedResults()).log({searchUID: this.provider.getSearchUID()});
     }
 
     private makeEventDescription(
@@ -745,7 +751,7 @@ export class CoveoSearchPageClient {
         const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
-            log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+            log: ({searchUID}) => preparedEvent.log({lastSearchQueryUid: searchUID}),
         };
     }
 
@@ -754,7 +760,7 @@ export class CoveoSearchPageClient {
         metadata?: Record<string, any>,
         eventType: string = CustomEventsTypes[event]!
     ) {
-        return (await this.makeCustomEvent(event, metadata, eventType)).log(this.provider.getSearchUID());
+        return (await this.makeCustomEvent(event, metadata, eventType)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async makeCustomEventWithType(
@@ -771,16 +777,18 @@ export class CoveoSearchPageClient {
         const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(payload);
         return {
             description: this.makeEventDescription(preparedEvent, eventValue as SearchPageEvents),
-            log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+            log: ({searchUID}) => preparedEvent.log({lastSearchQueryUid: searchUID}),
         };
     }
 
     public async logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
-        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log(this.provider.getSearchUID());
+        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     public async logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
-        return (await this.makeSearchEvent(event, metadata)).log(this.provider.getSearchUID());
+        return (await this.makeSearchEvent(event, metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public async makeSearchEvent(
@@ -791,7 +799,7 @@ export class CoveoSearchPageClient {
         const preparedEvent = await this.coveoAnalyticsClient.makeSearchEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
-            log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),
+            log: ({searchUID}) => preparedEvent.log({searchQueryUid: searchUID}),
         };
     }
 
@@ -810,7 +818,7 @@ export class CoveoSearchPageClient {
         const preparedEvent = await this.coveoAnalyticsClient.makeClickEvent(request);
         return {
             description: this.makeEventDescription(preparedEvent, event),
-            log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),
+            log: ({searchUID}) => preparedEvent.log({searchQueryUid: searchUID}),
         };
     }
 
@@ -820,7 +828,9 @@ export class CoveoSearchPageClient {
         identifier: DocumentIdentifier,
         metadata?: Record<string, any>
     ) {
-        return (await this.makeClickEvent(event, info, identifier, metadata)).log(this.provider.getSearchUID());
+        return (await this.makeClickEvent(event, info, identifier, metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
     }
 
     private async getBaseSearchEventRequest(

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -1,12 +1,13 @@
 import CoveoAnalyticsClient, {ClientOptions, AnalyticsClient, PreparedEvent} from '../client/analytics';
 import {
     SearchEventRequest,
-    ClickEventRequest,
     CustomEventRequest,
     SearchEventResponse,
     AnyEventResponse,
     ClickEventResponse,
     CustomEventResponse,
+    PreparedClickEventRequest,
+    PreparedSearchEventRequest,
 } from '../events';
 import {
     SearchPageEvents,
@@ -64,7 +65,7 @@ export type EventDescription = Pick<SearchEventRequest, 'actionCause' | 'customD
 
 export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
     description: EventDescription;
-    log: () => Promise<T | void>;
+    log: (searchUID: string) => Promise<T | void>;
 }
 
 export class CoveoSearchPageClient {
@@ -92,7 +93,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logInterfaceLoad() {
-        return (await this.makeInterfaceLoad()).log();
+        return (await this.makeInterfaceLoad()).log(this.provider.getSearchUID());
     }
 
     public makeRecommendationInterfaceLoad() {
@@ -100,7 +101,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendationInterfaceLoad() {
-        return (await this.makeRecommendationInterfaceLoad()).log();
+        return (await this.makeRecommendationInterfaceLoad()).log(this.provider.getSearchUID());
     }
 
     public makeRecommendation() {
@@ -108,7 +109,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendation() {
-        return (await this.makeRecommendation()).log();
+        return (await this.makeRecommendation()).log(this.provider.getSearchUID());
     }
 
     public makeRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -116,7 +117,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeRecommendationOpen(info, identifier)).log();
+        return (await this.makeRecommendationOpen(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeStaticFilterClearAll(meta: StaticFilterMetadata) {
@@ -124,7 +125,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterClearAll(meta: StaticFilterMetadata) {
-        return (await this.makeStaticFilterClearAll(meta)).log();
+        return (await this.makeStaticFilterClearAll(meta)).log(this.provider.getSearchUID());
     }
 
     public makeStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
@@ -132,7 +133,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
-        return (await this.makeStaticFilterSelect(meta)).log();
+        return (await this.makeStaticFilterSelect(meta)).log(this.provider.getSearchUID());
     }
 
     public makeStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
@@ -140,7 +141,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
-        return (await this.makeStaticFilterDeselect(meta)).log();
+        return (await this.makeStaticFilterDeselect(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFetchMoreResults() {
@@ -148,7 +149,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFetchMoreResults() {
-        return (await this.makeFetchMoreResults()).log();
+        return (await this.makeFetchMoreResults()).log(this.provider.getSearchUID());
     }
 
     public makeInterfaceChange(metadata: InterfaceChangeMetadata) {
@@ -156,7 +157,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logInterfaceChange(metadata: InterfaceChangeMetadata) {
-        return (await this.makeInterfaceChange(metadata)).log();
+        return (await this.makeInterfaceChange(metadata)).log(this.provider.getSearchUID());
     }
 
     public makeDidYouMeanAutomatic() {
@@ -164,7 +165,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDidYouMeanAutomatic() {
-        return (await this.makeDidYouMeanAutomatic()).log();
+        return (await this.makeDidYouMeanAutomatic()).log(this.provider.getSearchUID());
     }
 
     public makeDidYouMeanClick() {
@@ -172,7 +173,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDidYouMeanClick() {
-        return (await this.makeDidYouMeanClick()).log();
+        return (await this.makeDidYouMeanClick()).log(this.provider.getSearchUID());
     }
 
     public makeResultsSort(metadata: ResultsSortMetadata) {
@@ -180,7 +181,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logResultsSort(metadata: ResultsSortMetadata) {
-        return (await this.makeResultsSort(metadata)).log();
+        return (await this.makeResultsSort(metadata)).log(this.provider.getSearchUID());
     }
 
     public makeSearchboxSubmit() {
@@ -188,7 +189,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxSubmit() {
-        return (await this.makeSearchboxSubmit()).log();
+        return (await this.makeSearchboxSubmit()).log(this.provider.getSearchUID());
     }
 
     public makeSearchboxClear() {
@@ -196,7 +197,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxClear() {
-        return (await this.makeSearchboxClear()).log();
+        return (await this.makeSearchboxClear()).log(this.provider.getSearchUID());
     }
 
     public makeSearchboxAsYouType() {
@@ -204,7 +205,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchboxAsYouType() {
-        return (await this.makeSearchboxAsYouType()).log();
+        return (await this.makeSearchboxAsYouType()).log(this.provider.getSearchUID());
     }
 
     public makeBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
@@ -212,7 +213,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
-        return (await this.makeBreadcrumbFacet(metadata)).log();
+        return (await this.makeBreadcrumbFacet(metadata)).log(this.provider.getSearchUID());
     }
 
     public makeBreadcrumbResetAll() {
@@ -220,7 +221,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logBreadcrumbResetAll() {
-        return (await this.makeBreadcrumbResetAll()).log();
+        return (await this.makeBreadcrumbResetAll()).log(this.provider.getSearchUID());
     }
 
     public makeDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -228,7 +229,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeDocumentQuickview(info, identifier)).log();
+        return (await this.makeDocumentQuickview(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -236,7 +237,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeDocumentOpen(info, identifier)).log();
+        return (await this.makeDocumentOpen(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
@@ -244,7 +245,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
-        return (await this.makeOmniboxAnalytics(meta)).log();
+        return (await this.makeOmniboxAnalytics(meta)).log(this.provider.getSearchUID());
     }
 
     public makeOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
@@ -252,7 +253,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
-        return (await this.makeOmniboxFromLink(meta)).log();
+        return (await this.makeOmniboxFromLink(meta)).log(this.provider.getSearchUID());
     }
 
     public makeSearchFromLink() {
@@ -260,7 +261,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSearchFromLink() {
-        return (await this.makeSearchFromLink()).log();
+        return (await this.makeSearchFromLink()).log(this.provider.getSearchUID());
     }
 
     public makeTriggerNotify(meta: TriggerNotifyMetadata) {
@@ -268,7 +269,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerNotify(meta: TriggerNotifyMetadata) {
-        return (await this.makeTriggerNotify(meta)).log();
+        return (await this.makeTriggerNotify(meta)).log(this.provider.getSearchUID());
     }
 
     public makeTriggerExecute(meta: TriggerExecuteMetadata) {
@@ -276,7 +277,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerExecute(meta: TriggerExecuteMetadata) {
-        return (await this.makeTriggerExecute(meta)).log();
+        return (await this.makeTriggerExecute(meta)).log(this.provider.getSearchUID());
     }
 
     public makeTriggerQuery() {
@@ -288,7 +289,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerQuery() {
-        return (await this.makeTriggerQuery()).log();
+        return (await this.makeTriggerQuery()).log(this.provider.getSearchUID());
     }
 
     public makeUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
@@ -296,7 +297,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
-        return (await this.makeUndoTriggerQuery(meta)).log();
+        return (await this.makeUndoTriggerQuery(meta)).log(this.provider.getSearchUID());
     }
 
     public makeTriggerRedirect(meta: TriggerRedirectMetadata) {
@@ -307,7 +308,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logTriggerRedirect(meta: TriggerRedirectMetadata) {
-        return (await this.makeTriggerRedirect(meta)).log();
+        return (await this.makeTriggerRedirect(meta)).log(this.provider.getSearchUID());
     }
 
     public makePagerResize(meta: PagerResizeMetadata) {
@@ -315,7 +316,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerResize(meta: PagerResizeMetadata) {
-        return (await this.makePagerResize(meta)).log();
+        return (await this.makePagerResize(meta)).log(this.provider.getSearchUID());
     }
 
     public makePagerNumber(meta: PagerMetadata) {
@@ -323,7 +324,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerNumber(meta: PagerMetadata) {
-        return (await this.makePagerNumber(meta)).log();
+        return (await this.makePagerNumber(meta)).log(this.provider.getSearchUID());
     }
 
     public makePagerNext(meta: PagerMetadata) {
@@ -331,7 +332,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerNext(meta: PagerMetadata) {
-        return (await this.makePagerNext(meta)).log();
+        return (await this.makePagerNext(meta)).log(this.provider.getSearchUID());
     }
 
     public makePagerPrevious(meta: PagerMetadata) {
@@ -339,7 +340,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerPrevious(meta: PagerMetadata) {
-        return (await this.makePagerPrevious(meta)).log();
+        return (await this.makePagerPrevious(meta)).log(this.provider.getSearchUID());
     }
 
     public makePagerScrolling() {
@@ -347,7 +348,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logPagerScrolling() {
-        return (await this.makePagerScrolling()).log();
+        return (await this.makePagerScrolling()).log(this.provider.getSearchUID());
     }
 
     public makeFacetClearAll(meta: FacetBaseMeta) {
@@ -355,7 +356,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetClearAll(meta: FacetBaseMeta) {
-        return (await this.makeFacetClearAll(meta)).log();
+        return (await this.makeFacetClearAll(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetSearch(meta: FacetBaseMeta) {
@@ -363,7 +364,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSearch(meta: FacetBaseMeta) {
-        return (await this.makeFacetSearch(meta)).log();
+        return (await this.makeFacetSearch(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetSelect(meta: FacetMetadata) {
@@ -371,7 +372,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSelect(meta: FacetMetadata) {
-        return (await this.makeFacetSelect(meta)).log();
+        return (await this.makeFacetSelect(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetDeselect(meta: FacetMetadata) {
@@ -379,7 +380,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetDeselect(meta: FacetMetadata) {
-        return (await this.makeFacetDeselect(meta)).log();
+        return (await this.makeFacetDeselect(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetExclude(meta: FacetMetadata) {
@@ -387,7 +388,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetExclude(meta: FacetMetadata) {
-        return (await this.makeFacetExclude(meta)).log();
+        return (await this.makeFacetExclude(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetUnexclude(meta: FacetMetadata) {
@@ -395,7 +396,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetUnexclude(meta: FacetMetadata) {
-        return (await this.makeFacetUnexclude(meta)).log();
+        return (await this.makeFacetUnexclude(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetSelectAll(meta: FacetBaseMeta) {
@@ -403,7 +404,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetSelectAll(meta: FacetBaseMeta) {
-        return (await this.makeFacetSelectAll(meta)).log();
+        return (await this.makeFacetSelectAll(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetUpdateSort(meta: FacetSortMeta) {
@@ -411,7 +412,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetUpdateSort(meta: FacetSortMeta) {
-        return (await this.makeFacetUpdateSort(meta)).log();
+        return (await this.makeFacetUpdateSort(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetShowMore(meta: FacetBaseMeta) {
@@ -419,7 +420,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetShowMore(meta: FacetBaseMeta) {
-        return (await this.makeFacetShowMore(meta)).log();
+        return (await this.makeFacetShowMore(meta)).log(this.provider.getSearchUID());
     }
 
     public makeFacetShowLess(meta: FacetBaseMeta) {
@@ -427,7 +428,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logFacetShowLess(meta: FacetBaseMeta) {
-        return (await this.makeFacetShowLess(meta)).log();
+        return (await this.makeFacetShowLess(meta)).log(this.provider.getSearchUID());
     }
 
     public makeQueryError(meta: QueryErrorMeta) {
@@ -435,7 +436,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logQueryError(meta: QueryErrorMeta) {
-        return (await this.makeQueryError(meta)).log();
+        return (await this.makeQueryError(meta)).log(this.provider.getSearchUID());
     }
 
     public async makeQueryErrorBack(): Promise<EventBuilder<SearchEventResponse>> {
@@ -443,14 +444,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log();
+                await customEventBuilder.log(this.provider.getSearchUID());
                 return this.logSearchEvent(SearchPageEvents.queryErrorBack);
             },
         };
     }
 
     public async logQueryErrorBack() {
-        return (await this.makeQueryErrorBack()).log();
+        return (await this.makeQueryErrorBack()).log(this.provider.getSearchUID());
     }
 
     public async makeQueryErrorRetry(): Promise<EventBuilder<SearchEventResponse>> {
@@ -458,14 +459,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log();
+                await customEventBuilder.log(this.provider.getSearchUID());
                 return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
             },
         };
     }
 
     public async logQueryErrorRetry() {
-        return (await this.makeQueryErrorRetry()).log();
+        return (await this.makeQueryErrorRetry()).log(this.provider.getSearchUID());
     }
 
     public async makeQueryErrorClear(): Promise<EventBuilder<SearchEventResponse>> {
@@ -473,14 +474,14 @@ export class CoveoSearchPageClient {
         return {
             description: customEventBuilder.description,
             log: async () => {
-                await customEventBuilder.log();
+                await customEventBuilder.log(this.provider.getSearchUID());
                 return this.logSearchEvent(SearchPageEvents.queryErrorClear);
             },
         };
     }
 
     public async logQueryErrorClear() {
-        return (await this.makeQueryErrorClear()).log();
+        return (await this.makeQueryErrorClear()).log(this.provider.getSearchUID());
     }
 
     public makeLikeSmartSnippet() {
@@ -488,7 +489,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logLikeSmartSnippet() {
-        return (await this.makeLikeSmartSnippet()).log();
+        return (await this.makeLikeSmartSnippet()).log(this.provider.getSearchUID());
     }
 
     public makeDislikeSmartSnippet() {
@@ -496,7 +497,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logDislikeSmartSnippet() {
-        return (await this.makeDislikeSmartSnippet()).log();
+        return (await this.makeDislikeSmartSnippet()).log(this.provider.getSearchUID());
     }
 
     public makeExpandSmartSnippet() {
@@ -504,7 +505,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logExpandSmartSnippet() {
-        return (await this.makeExpandSmartSnippet()).log();
+        return (await this.makeExpandSmartSnippet()).log(this.provider.getSearchUID());
     }
 
     public makeCollapseSmartSnippet() {
@@ -512,7 +513,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logCollapseSmartSnippet() {
-        return (await this.makeCollapseSmartSnippet()).log();
+        return (await this.makeCollapseSmartSnippet()).log(this.provider.getSearchUID());
     }
 
     public makeOpenSmartSnippetFeedbackModal() {
@@ -520,7 +521,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOpenSmartSnippetFeedbackModal() {
-        return (await this.makeOpenSmartSnippetFeedbackModal()).log();
+        return (await this.makeOpenSmartSnippetFeedbackModal()).log(this.provider.getSearchUID());
     }
 
     public makeCloseSmartSnippetFeedbackModal() {
@@ -528,7 +529,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logCloseSmartSnippetFeedbackModal() {
-        return (await this.makeCloseSmartSnippetFeedbackModal()).log();
+        return (await this.makeCloseSmartSnippetFeedbackModal()).log(this.provider.getSearchUID());
     }
 
     public makeSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
@@ -536,7 +537,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
-        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log();
+        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log(this.provider.getSearchUID());
     }
 
     public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -547,7 +548,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log();
+        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
     }
 
     public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -560,7 +561,7 @@ export class CoveoSearchPageClient {
     public async logCollapseSmartSnippetSuggestion(
         snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
     ) {
-        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log();
+        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
     }
 
     /**
@@ -574,7 +575,7 @@ export class CoveoSearchPageClient {
      * @deprecated
      */
     public async logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log();
+        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
     }
 
     /**
@@ -588,7 +589,7 @@ export class CoveoSearchPageClient {
      * @deprecated
      */
     public async logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log();
+        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log(this.provider.getSearchUID());
     }
 
     public makeOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -596,7 +597,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeOpenSmartSnippetSource(info, identifier)).log();
+        return (await this.makeOpenSmartSnippetSource(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
@@ -613,14 +614,14 @@ export class CoveoSearchPageClient {
     }
 
     public async logCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeCopyToClipboard(info, identifier)).log();
+        return (await this.makeCopyToClipboard(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public async logOpenSmartSnippetSuggestionSource(
         info: PartialDocumentInformation,
         snippet: SmartSnippetSuggestionMeta
     ) {
-        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log();
+        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log(this.provider.getSearchUID());
     }
 
     public makeOpenSmartSnippetInlineLink(
@@ -639,7 +640,7 @@ export class CoveoSearchPageClient {
         info: PartialDocumentInformation,
         identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
-        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log();
+        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log(this.provider.getSearchUID());
     }
 
     public makeOpenSmartSnippetSuggestionInlineLink(
@@ -661,7 +662,9 @@ export class CoveoSearchPageClient {
         info: PartialDocumentInformation,
         snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
-        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log();
+        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log(
+            this.provider.getSearchUID()
+        );
     }
 
     public makeRecentQueryClick() {
@@ -669,7 +672,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecentQueryClick() {
-        return (await this.makeRecentQueryClick()).log();
+        return (await this.makeRecentQueryClick()).log(this.provider.getSearchUID());
     }
 
     public makeClearRecentQueries() {
@@ -677,7 +680,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logClearRecentQueries() {
-        return (await this.makeClearRecentQueries()).log();
+        return (await this.makeClearRecentQueries()).log(this.provider.getSearchUID());
     }
 
     public makeRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -685,7 +688,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeRecentResultClick(info, identifier)).log();
+        return (await this.makeRecentResultClick(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeClearRecentResults() {
@@ -693,7 +696,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logClearRecentResults() {
-        return (await this.makeClearRecentResults()).log();
+        return (await this.makeClearRecentResults()).log(this.provider.getSearchUID());
     }
 
     public makeNoResultsBack() {
@@ -701,7 +704,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logNoResultsBack() {
-        return (await this.makeNoResultsBack()).log();
+        return (await this.makeNoResultsBack()).log(this.provider.getSearchUID());
     }
 
     public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
@@ -709,7 +712,7 @@ export class CoveoSearchPageClient {
     }
 
     public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return (await this.makeShowMoreFoldedResults(info, identifier)).log();
+        return (await this.makeShowMoreFoldedResults(info, identifier)).log(this.provider.getSearchUID());
     }
 
     public makeShowLessFoldedResults() {
@@ -717,15 +720,14 @@ export class CoveoSearchPageClient {
     }
 
     public async logShowLessFoldedResults() {
-        return (await this.makeShowLessFoldedResults()).log();
+        return (await this.makeShowLessFoldedResults()).log(this.provider.getSearchUID());
     }
 
-    private makeEventBuilder<T extends AnyEventResponse>(
-        actionCause: SearchPageEvents,
-        preparedEvent: PreparedEvent<T>
-    ): EventBuilder<T> {
-        const description: EventDescription = {actionCause, customData: preparedEvent.payload?.customData};
-        return {description, log: () => preparedEvent.log()};
+    private makeEventDescription(
+        preparedEvent: PreparedEvent<unknown, unknown, AnyEventResponse>,
+        actionCause: SearchPageEvents
+    ): EventDescription {
+        return {actionCause, customData: preparedEvent.payload?.customData};
     }
 
     public async makeCustomEvent(
@@ -736,12 +738,15 @@ export class CoveoSearchPageClient {
         this.coveoAnalyticsClient.getParameters;
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
         const request: CustomEventRequest = {
-            ...(await this.getBaseCustomEventRequest(customData)),
+            ...(await this.getBaseEventRequest(customData)),
             eventType,
             eventValue: event,
         };
         const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(request);
-        return this.makeEventBuilder(event, preparedEvent);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+        };
     }
 
     public async logCustomEvent(
@@ -749,26 +754,33 @@ export class CoveoSearchPageClient {
         metadata?: Record<string, any>,
         eventType: string = CustomEventsTypes[event]!
     ) {
-        return (await this.makeCustomEvent(event, metadata, eventType)).log();
+        return (await this.makeCustomEvent(event, metadata, eventType)).log(this.provider.getSearchUID());
     }
 
-    public async makeCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+    public async makeCustomEventWithType(
+        eventValue: string,
+        eventType: string,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<CustomEventResponse>> {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
         const payload: CustomEventRequest = {
-            ...(await this.getBaseCustomEventRequest(customData)),
+            ...(await this.getBaseEventRequest(customData)),
             eventType,
             eventValue,
         };
         const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(payload);
-        return this.makeEventBuilder(eventValue as SearchPageEvents, preparedEvent);
+        return {
+            description: this.makeEventDescription(preparedEvent, eventValue as SearchPageEvents),
+            log: (searchUID) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+        };
     }
 
     public async logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
-        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log();
+        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log(this.provider.getSearchUID());
     }
 
     public async logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
-        return (await this.makeSearchEvent(event, metadata)).log();
+        return (await this.makeSearchEvent(event, metadata)).log(this.provider.getSearchUID());
     }
 
     public async makeSearchEvent(
@@ -777,7 +789,10 @@ export class CoveoSearchPageClient {
     ): Promise<EventBuilder<SearchEventResponse>> {
         const request = await this.getBaseSearchEventRequest(event, metadata);
         const preparedEvent = await this.coveoAnalyticsClient.prepareSearchEvent(request);
-        return this.makeEventBuilder(event, preparedEvent);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),
+        };
     }
 
     public async makeClickEvent(
@@ -786,15 +801,17 @@ export class CoveoSearchPageClient {
         identifier: DocumentIdentifier,
         metadata?: Record<string, any>
     ): Promise<EventBuilder<ClickEventResponse>> {
-        const request: ClickEventRequest = {
+        const request: PreparedClickEventRequest = {
             ...info,
             ...(await this.getBaseEventRequest({...identifier, ...metadata})),
-            searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,
         };
         const preparedEvent = await this.coveoAnalyticsClient.prepareClickEvent(request);
-        return this.makeEventBuilder(event, preparedEvent);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: (searchUID) => preparedEvent.log({searchQueryUid: searchUID}),
+        };
     }
 
     public async logClickEvent(
@@ -803,26 +820,18 @@ export class CoveoSearchPageClient {
         identifier: DocumentIdentifier,
         metadata?: Record<string, any>
     ) {
-        return (await this.makeClickEvent(event, info, identifier, metadata)).log();
+        return (await this.makeClickEvent(event, info, identifier, metadata)).log(this.provider.getSearchUID());
     }
 
     private async getBaseSearchEventRequest(
         event: SearchPageEvents,
         metadata?: Record<string, any>
-    ): Promise<SearchEventRequest> {
+    ): Promise<PreparedSearchEventRequest> {
         return {
             ...(await this.getBaseEventRequest(metadata)),
             ...this.provider.getSearchEventRequestPayload(),
-            searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,
-        };
-    }
-
-    private async getBaseCustomEventRequest(metadata?: Record<string, any>) {
-        return {
-            ...(await this.getBaseEventRequest(metadata)),
-            lastSearchQueryUid: this.provider.getSearchUID(),
         };
     }
 

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -1,4 +1,4 @@
-import CoveoAnalyticsClient, {ClientOptions, AnalyticsClient} from '../client/analytics';
+import CoveoAnalyticsClient, {ClientOptions, AnalyticsClient, PreparedEvent} from '../client/analytics';
 import {
     SearchEventRequest,
     ClickEventRequest,
@@ -91,192 +91,192 @@ export class CoveoSearchPageClient {
         return this.makeSearchEvent(SearchPageEvents.interfaceLoad);
     }
 
-    public logInterfaceLoad() {
-        return this.makeInterfaceLoad().log();
+    public async logInterfaceLoad() {
+        return (await this.makeInterfaceLoad()).log();
     }
 
     public makeRecommendationInterfaceLoad() {
         return this.makeSearchEvent(SearchPageEvents.recommendationInterfaceLoad);
     }
 
-    public logRecommendationInterfaceLoad() {
-        return this.makeRecommendationInterfaceLoad().log();
+    public async logRecommendationInterfaceLoad() {
+        return (await this.makeRecommendationInterfaceLoad()).log();
     }
 
     public makeRecommendation() {
         return this.makeCustomEvent(SearchPageEvents.recommendation);
     }
 
-    public logRecommendation() {
-        return this.makeRecommendation().log();
+    public async logRecommendation() {
+        return (await this.makeRecommendation()).log();
     }
 
     public makeRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeClickEvent(SearchPageEvents.recommendationOpen, info, identifier);
     }
 
-    public logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeRecommendationOpen(info, identifier).log();
+    public async logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeRecommendationOpen(info, identifier)).log();
     }
 
     public makeStaticFilterClearAll(meta: StaticFilterMetadata) {
         return this.makeSearchEvent(SearchPageEvents.staticFilterClearAll, meta);
     }
 
-    public logStaticFilterClearAll(meta: StaticFilterMetadata) {
-        return this.makeStaticFilterClearAll(meta).log();
+    public async logStaticFilterClearAll(meta: StaticFilterMetadata) {
+        return (await this.makeStaticFilterClearAll(meta)).log();
     }
 
     public makeStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
         return this.makeSearchEvent(SearchPageEvents.staticFilterSelect, meta);
     }
 
-    public logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
-        return this.makeStaticFilterSelect(meta).log();
+    public async logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
+        return (await this.makeStaticFilterSelect(meta)).log();
     }
 
     public makeStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
         return this.makeSearchEvent(SearchPageEvents.staticFilterDeselect, meta);
     }
 
-    public logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
-        return this.makeStaticFilterDeselect(meta).log();
+    public async logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
+        return (await this.makeStaticFilterDeselect(meta)).log();
     }
 
     public makeFetchMoreResults() {
         return this.makeCustomEvent(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
     }
 
-    public logFetchMoreResults() {
-        return this.makeFetchMoreResults().log();
+    public async logFetchMoreResults() {
+        return (await this.makeFetchMoreResults()).log();
     }
 
     public makeInterfaceChange(metadata: InterfaceChangeMetadata) {
         return this.makeSearchEvent(SearchPageEvents.interfaceChange, metadata);
     }
 
-    public logInterfaceChange(metadata: InterfaceChangeMetadata) {
-        return this.makeInterfaceChange(metadata).log();
+    public async logInterfaceChange(metadata: InterfaceChangeMetadata) {
+        return (await this.makeInterfaceChange(metadata)).log();
     }
 
     public makeDidYouMeanAutomatic() {
         return this.makeSearchEvent(SearchPageEvents.didyoumeanAutomatic);
     }
 
-    public logDidYouMeanAutomatic() {
-        return this.makeDidYouMeanAutomatic().log();
+    public async logDidYouMeanAutomatic() {
+        return (await this.makeDidYouMeanAutomatic()).log();
     }
 
     public makeDidYouMeanClick() {
         return this.makeSearchEvent(SearchPageEvents.didyoumeanClick);
     }
 
-    public logDidYouMeanClick() {
-        return this.makeDidYouMeanClick().log();
+    public async logDidYouMeanClick() {
+        return (await this.makeDidYouMeanClick()).log();
     }
 
     public makeResultsSort(metadata: ResultsSortMetadata) {
         return this.makeSearchEvent(SearchPageEvents.resultsSort, metadata);
     }
 
-    public logResultsSort(metadata: ResultsSortMetadata) {
-        return this.makeResultsSort(metadata).log();
+    public async logResultsSort(metadata: ResultsSortMetadata) {
+        return (await this.makeResultsSort(metadata)).log();
     }
 
     public makeSearchboxSubmit() {
         return this.makeSearchEvent(SearchPageEvents.searchboxSubmit);
     }
 
-    public logSearchboxSubmit() {
-        return this.makeSearchboxSubmit().log();
+    public async logSearchboxSubmit() {
+        return (await this.makeSearchboxSubmit()).log();
     }
 
     public makeSearchboxClear() {
         return this.makeSearchEvent(SearchPageEvents.searchboxClear);
     }
 
-    public logSearchboxClear() {
-        return this.makeSearchboxClear().log();
+    public async logSearchboxClear() {
+        return (await this.makeSearchboxClear()).log();
     }
 
     public makeSearchboxAsYouType() {
         return this.makeSearchEvent(SearchPageEvents.searchboxAsYouType);
     }
 
-    public logSearchboxAsYouType() {
-        return this.makeSearchboxAsYouType().log();
+    public async logSearchboxAsYouType() {
+        return (await this.makeSearchboxAsYouType()).log();
     }
 
     public makeBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
         return this.makeSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
     }
 
-    public logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
-        return this.makeBreadcrumbFacet(metadata).log();
+    public async logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
+        return (await this.makeBreadcrumbFacet(metadata)).log();
     }
 
     public makeBreadcrumbResetAll() {
         return this.makeSearchEvent(SearchPageEvents.breadcrumbResetAll);
     }
 
-    public logBreadcrumbResetAll() {
-        return this.makeBreadcrumbResetAll().log();
+    public async logBreadcrumbResetAll() {
+        return (await this.makeBreadcrumbResetAll()).log();
     }
 
     public makeDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeClickEvent(SearchPageEvents.documentQuickview, info, identifier);
     }
 
-    public logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeDocumentQuickview(info, identifier).log();
+    public async logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeDocumentQuickview(info, identifier)).log();
     }
 
     public makeDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeClickEvent(SearchPageEvents.documentOpen, info, identifier);
     }
 
-    public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeDocumentOpen(info, identifier).log();
+    public async logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeDocumentOpen(info, identifier)).log();
     }
 
     public makeOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
         return this.makeSearchEvent(SearchPageEvents.omniboxAnalytics, formatOmniboxMetadata(meta));
     }
 
-    public logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
-        return this.makeOmniboxAnalytics(meta).log();
+    public async logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
+        return (await this.makeOmniboxAnalytics(meta)).log();
     }
 
     public makeOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
         return this.makeSearchEvent(SearchPageEvents.omniboxFromLink, formatOmniboxMetadata(meta));
     }
 
-    public logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
-        return this.makeOmniboxFromLink(meta).log();
+    public async logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
+        return (await this.makeOmniboxFromLink(meta)).log();
     }
 
     public makeSearchFromLink() {
         return this.makeSearchEvent(SearchPageEvents.searchFromLink);
     }
 
-    public logSearchFromLink() {
-        return this.makeSearchFromLink().log();
+    public async logSearchFromLink() {
+        return (await this.makeSearchFromLink()).log();
     }
 
     public makeTriggerNotify(meta: TriggerNotifyMetadata) {
         return this.makeCustomEvent(SearchPageEvents.triggerNotify, meta);
     }
 
-    public logTriggerNotify(meta: TriggerNotifyMetadata) {
-        return this.makeTriggerNotify(meta).log();
+    public async logTriggerNotify(meta: TriggerNotifyMetadata) {
+        return (await this.makeTriggerNotify(meta)).log();
     }
 
     public makeTriggerExecute(meta: TriggerExecuteMetadata) {
         return this.makeCustomEvent(SearchPageEvents.triggerExecute, meta);
     }
 
-    public logTriggerExecute(meta: TriggerExecuteMetadata) {
-        return this.makeTriggerExecute(meta).log();
+    public async logTriggerExecute(meta: TriggerExecuteMetadata) {
+        return (await this.makeTriggerExecute(meta)).log();
     }
 
     public makeTriggerQuery() {
@@ -287,16 +287,16 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logTriggerQuery() {
-        return this.makeTriggerQuery().log();
+    public async logTriggerQuery() {
+        return (await this.makeTriggerQuery()).log();
     }
 
     public makeUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
         return this.makeSearchEvent(SearchPageEvents.undoTriggerQuery, meta);
     }
 
-    public logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
-        return this.makeUndoTriggerQuery(meta).log();
+    public async logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
+        return (await this.makeUndoTriggerQuery(meta)).log();
     }
 
     public makeTriggerRedirect(meta: TriggerRedirectMetadata) {
@@ -306,234 +306,237 @@ export class CoveoSearchPageClient {
         });
     }
 
-    public logTriggerRedirect(meta: TriggerRedirectMetadata) {
-        return this.makeTriggerRedirect(meta).log();
+    public async logTriggerRedirect(meta: TriggerRedirectMetadata) {
+        return (await this.makeTriggerRedirect(meta)).log();
     }
 
     public makePagerResize(meta: PagerResizeMetadata) {
         return this.makeCustomEvent(SearchPageEvents.pagerResize, meta);
     }
 
-    public logPagerResize(meta: PagerResizeMetadata) {
-        return this.makePagerResize(meta).log();
+    public async logPagerResize(meta: PagerResizeMetadata) {
+        return (await this.makePagerResize(meta)).log();
     }
 
     public makePagerNumber(meta: PagerMetadata) {
         return this.makeCustomEvent(SearchPageEvents.pagerNumber, meta);
     }
 
-    public logPagerNumber(meta: PagerMetadata) {
-        return this.makePagerNumber(meta).log();
+    public async logPagerNumber(meta: PagerMetadata) {
+        return (await this.makePagerNumber(meta)).log();
     }
 
     public makePagerNext(meta: PagerMetadata) {
         return this.makeCustomEvent(SearchPageEvents.pagerNext, meta);
     }
 
-    public logPagerNext(meta: PagerMetadata) {
-        return this.makePagerNext(meta).log();
+    public async logPagerNext(meta: PagerMetadata) {
+        return (await this.makePagerNext(meta)).log();
     }
 
     public makePagerPrevious(meta: PagerMetadata) {
         return this.makeCustomEvent(SearchPageEvents.pagerPrevious, meta);
     }
 
-    public logPagerPrevious(meta: PagerMetadata) {
-        return this.makePagerPrevious(meta).log();
+    public async logPagerPrevious(meta: PagerMetadata) {
+        return (await this.makePagerPrevious(meta)).log();
     }
 
     public makePagerScrolling() {
         return this.makeCustomEvent(SearchPageEvents.pagerScrolling);
     }
 
-    public logPagerScrolling() {
-        return this.makePagerScrolling().log();
+    public async logPagerScrolling() {
+        return (await this.makePagerScrolling()).log();
     }
 
     public makeFacetClearAll(meta: FacetBaseMeta) {
         return this.makeSearchEvent(SearchPageEvents.facetClearAll, meta);
     }
 
-    public logFacetClearAll(meta: FacetBaseMeta) {
-        return this.makeFacetClearAll(meta).log();
+    public async logFacetClearAll(meta: FacetBaseMeta) {
+        return (await this.makeFacetClearAll(meta)).log();
     }
 
     public makeFacetSearch(meta: FacetBaseMeta) {
         return this.makeSearchEvent(SearchPageEvents.facetSearch, meta);
     }
 
-    public logFacetSearch(meta: FacetBaseMeta) {
-        return this.makeFacetSearch(meta).log();
+    public async logFacetSearch(meta: FacetBaseMeta) {
+        return (await this.makeFacetSearch(meta)).log();
     }
 
     public makeFacetSelect(meta: FacetMetadata) {
         return this.makeSearchEvent(SearchPageEvents.facetSelect, meta);
     }
 
-    public logFacetSelect(meta: FacetMetadata) {
-        return this.makeFacetSelect(meta).log();
+    public async logFacetSelect(meta: FacetMetadata) {
+        return (await this.makeFacetSelect(meta)).log();
     }
 
     public makeFacetDeselect(meta: FacetMetadata) {
         return this.makeSearchEvent(SearchPageEvents.facetDeselect, meta);
     }
 
-    public logFacetDeselect(meta: FacetMetadata) {
-        return this.makeFacetDeselect(meta).log();
+    public async logFacetDeselect(meta: FacetMetadata) {
+        return (await this.makeFacetDeselect(meta)).log();
     }
 
     public makeFacetExclude(meta: FacetMetadata) {
         return this.makeSearchEvent(SearchPageEvents.facetExclude, meta);
     }
 
-    public logFacetExclude(meta: FacetMetadata) {
-        return this.makeFacetExclude(meta).log();
+    public async logFacetExclude(meta: FacetMetadata) {
+        return (await this.makeFacetExclude(meta)).log();
     }
 
     public makeFacetUnexclude(meta: FacetMetadata) {
         return this.makeSearchEvent(SearchPageEvents.facetUnexclude, meta);
     }
 
-    public logFacetUnexclude(meta: FacetMetadata) {
-        return this.makeFacetUnexclude(meta).log();
+    public async logFacetUnexclude(meta: FacetMetadata) {
+        return (await this.makeFacetUnexclude(meta)).log();
     }
 
     public makeFacetSelectAll(meta: FacetBaseMeta) {
         return this.makeSearchEvent(SearchPageEvents.facetSelectAll, meta);
     }
 
-    public logFacetSelectAll(meta: FacetBaseMeta) {
-        return this.makeFacetSelectAll(meta).log();
+    public async logFacetSelectAll(meta: FacetBaseMeta) {
+        return (await this.makeFacetSelectAll(meta)).log();
     }
 
     public makeFacetUpdateSort(meta: FacetSortMeta) {
         return this.makeSearchEvent(SearchPageEvents.facetUpdateSort, meta);
     }
 
-    public logFacetUpdateSort(meta: FacetSortMeta) {
-        return this.makeFacetUpdateSort(meta).log();
+    public async logFacetUpdateSort(meta: FacetSortMeta) {
+        return (await this.makeFacetUpdateSort(meta)).log();
     }
 
     public makeFacetShowMore(meta: FacetBaseMeta) {
         return this.makeCustomEvent(SearchPageEvents.facetShowMore, meta);
     }
 
-    public logFacetShowMore(meta: FacetBaseMeta) {
-        return this.makeFacetShowMore(meta).log();
+    public async logFacetShowMore(meta: FacetBaseMeta) {
+        return (await this.makeFacetShowMore(meta)).log();
     }
 
     public makeFacetShowLess(meta: FacetBaseMeta) {
         return this.makeCustomEvent(SearchPageEvents.facetShowLess, meta);
     }
 
-    public logFacetShowLess(meta: FacetBaseMeta) {
-        return this.makeFacetShowLess(meta).log();
+    public async logFacetShowLess(meta: FacetBaseMeta) {
+        return (await this.makeFacetShowLess(meta)).log();
     }
 
     public makeQueryError(meta: QueryErrorMeta) {
         return this.makeCustomEvent(SearchPageEvents.queryError, meta);
     }
 
-    public logQueryError(meta: QueryErrorMeta) {
-        return this.makeQueryError(meta).log();
+    public async logQueryError(meta: QueryErrorMeta) {
+        return (await this.makeQueryError(meta)).log();
     }
 
-    public makeQueryErrorBack(): EventBuilder<SearchEventResponse> {
+    public async makeQueryErrorBack(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorBack);
         return {
-            description: this.makeDescription(SearchPageEvents.queryErrorBack),
+            description: customEventBuilder.description,
             log: async () => {
-                await this.logCustomEvent(SearchPageEvents.queryErrorBack);
+                await customEventBuilder.log();
                 return this.logSearchEvent(SearchPageEvents.queryErrorBack);
             },
         };
     }
 
-    public logQueryErrorBack() {
-        return this.makeQueryErrorBack().log();
+    public async logQueryErrorBack() {
+        return (await this.makeQueryErrorBack()).log();
     }
 
-    public makeQueryErrorRetry(): EventBuilder<SearchEventResponse> {
+    public async makeQueryErrorRetry(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorRetry);
         return {
-            description: this.makeDescription(SearchPageEvents.queryErrorRetry),
+            description: customEventBuilder.description,
             log: async () => {
-                await this.logCustomEvent(SearchPageEvents.queryErrorRetry);
+                await customEventBuilder.log();
                 return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
             },
         };
     }
 
-    public logQueryErrorRetry() {
-        return this.makeQueryErrorRetry().log();
+    public async logQueryErrorRetry() {
+        return (await this.makeQueryErrorRetry()).log();
     }
 
-    public makeQueryErrorClear(): EventBuilder<SearchEventResponse> {
+    public async makeQueryErrorClear(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorClear);
         return {
-            description: this.makeDescription(SearchPageEvents.queryErrorClear),
+            description: customEventBuilder.description,
             log: async () => {
-                await this.logCustomEvent(SearchPageEvents.queryErrorClear);
+                await customEventBuilder.log();
                 return this.logSearchEvent(SearchPageEvents.queryErrorClear);
             },
         };
     }
 
-    public logQueryErrorClear() {
-        return this.makeQueryErrorClear().log();
+    public async logQueryErrorClear() {
+        return (await this.makeQueryErrorClear()).log();
     }
 
     public makeLikeSmartSnippet() {
         return this.makeCustomEvent(SearchPageEvents.likeSmartSnippet);
     }
 
-    public logLikeSmartSnippet() {
-        return this.makeLikeSmartSnippet().log();
+    public async logLikeSmartSnippet() {
+        return (await this.makeLikeSmartSnippet()).log();
     }
 
     public makeDislikeSmartSnippet() {
         return this.makeCustomEvent(SearchPageEvents.dislikeSmartSnippet);
     }
 
-    public logDislikeSmartSnippet() {
-        return this.makeDislikeSmartSnippet().log();
+    public async logDislikeSmartSnippet() {
+        return (await this.makeDislikeSmartSnippet()).log();
     }
 
     public makeExpandSmartSnippet() {
         return this.makeCustomEvent(SearchPageEvents.expandSmartSnippet);
     }
 
-    public logExpandSmartSnippet() {
-        return this.makeExpandSmartSnippet().log();
+    public async logExpandSmartSnippet() {
+        return (await this.makeExpandSmartSnippet()).log();
     }
 
     public makeCollapseSmartSnippet() {
         return this.makeCustomEvent(SearchPageEvents.collapseSmartSnippet);
     }
 
-    public logCollapseSmartSnippet() {
-        return this.makeCollapseSmartSnippet().log();
+    public async logCollapseSmartSnippet() {
+        return (await this.makeCollapseSmartSnippet()).log();
     }
 
     public makeOpenSmartSnippetFeedbackModal() {
         return this.makeCustomEvent(SearchPageEvents.openSmartSnippetFeedbackModal);
     }
 
-    public logOpenSmartSnippetFeedbackModal() {
-        return this.makeOpenSmartSnippetFeedbackModal().log();
+    public async logOpenSmartSnippetFeedbackModal() {
+        return (await this.makeOpenSmartSnippetFeedbackModal()).log();
     }
 
     public makeCloseSmartSnippetFeedbackModal() {
         return this.makeCustomEvent(SearchPageEvents.closeSmartSnippetFeedbackModal);
     }
 
-    public logCloseSmartSnippetFeedbackModal() {
-        return this.makeCloseSmartSnippetFeedbackModal().log();
+    public async logCloseSmartSnippetFeedbackModal() {
+        return (await this.makeCloseSmartSnippetFeedbackModal()).log();
     }
 
     public makeSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
         return this.makeCustomEvent(SearchPageEvents.sendSmartSnippetReason, {reason, details});
     }
 
-    public logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
-        return this.makeSmartSnippetFeedbackReason(reason, details).log();
+    public async logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
+        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log();
     }
 
     public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -543,8 +546,8 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return this.makeExpandSmartSnippetSuggestion(snippet).log();
+    public async logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log();
     }
 
     public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
@@ -554,8 +557,10 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
-        return this.makeCollapseSmartSnippetSuggestion(snippet).log();
+    public async logCollapseSmartSnippetSuggestion(
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
+    ) {
+        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log();
     }
 
     /**
@@ -568,8 +573,8 @@ export class CoveoSearchPageClient {
     /**
      * @deprecated
      */
-    public logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return this.makeShowMoreSmartSnippetSuggestion(snippet).log();
+    public async logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log();
     }
 
     /**
@@ -582,16 +587,16 @@ export class CoveoSearchPageClient {
     /**
      * @deprecated
      */
-    public logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
-        return this.makeShowLessSmartSnippetSuggestion(snippet).log();
+    public async logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log();
     }
 
     public makeOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeClickEvent(SearchPageEvents.openSmartSnippetSource, info, identifier);
     }
 
-    public logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeOpenSmartSnippetSource(info, identifier).log();
+    public async logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeOpenSmartSnippetSource(info, identifier)).log();
     }
 
     public makeOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
@@ -607,12 +612,15 @@ export class CoveoSearchPageClient {
         return this.makeClickEvent(SearchPageEvents.copyToClipboard, info, identifier);
     }
 
-    public logCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeCopyToClipboard(info, identifier).log();
+    public async logCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeCopyToClipboard(info, identifier)).log();
     }
 
-    public logOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
-        return this.makeOpenSmartSnippetSuggestionSource(info, snippet).log();
+    public async logOpenSmartSnippetSuggestionSource(
+        info: PartialDocumentInformation,
+        snippet: SmartSnippetSuggestionMeta
+    ) {
+        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log();
     }
 
     public makeOpenSmartSnippetInlineLink(
@@ -627,11 +635,11 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logOpenSmartSnippetInlineLink(
+    public async logOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
         identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
-        return this.makeOpenSmartSnippetInlineLink(info, identifierAndLink).log();
+        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log();
     }
 
     public makeOpenSmartSnippetSuggestionInlineLink(
@@ -649,129 +657,144 @@ export class CoveoSearchPageClient {
         );
     }
 
-    public logOpenSmartSnippetSuggestionInlineLink(
+    public async logOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
         snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
-        return this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink).log();
+        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log();
     }
 
     public makeRecentQueryClick() {
         return this.makeSearchEvent(SearchPageEvents.recentQueryClick);
     }
 
-    public logRecentQueryClick() {
-        return this.makeRecentQueryClick().log();
+    public async logRecentQueryClick() {
+        return (await this.makeRecentQueryClick()).log();
     }
 
     public makeClearRecentQueries() {
         return this.makeCustomEvent(SearchPageEvents.clearRecentQueries);
     }
 
-    public logClearRecentQueries() {
-        return this.makeClearRecentQueries().log();
+    public async logClearRecentQueries() {
+        return (await this.makeClearRecentQueries()).log();
     }
 
     public makeRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeCustomEvent(SearchPageEvents.recentResultClick, {info, identifier});
     }
 
-    public logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeRecentResultClick(info, identifier).log();
+    public async logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeRecentResultClick(info, identifier)).log();
     }
 
     public makeClearRecentResults() {
         return this.makeCustomEvent(SearchPageEvents.clearRecentResults);
     }
 
-    public logClearRecentResults() {
-        return this.makeClearRecentResults().log();
+    public async logClearRecentResults() {
+        return (await this.makeClearRecentResults()).log();
     }
 
     public makeNoResultsBack() {
         return this.makeSearchEvent(SearchPageEvents.noResultsBack);
     }
 
-    public logNoResultsBack() {
-        return this.makeNoResultsBack().log();
+    public async logNoResultsBack() {
+        return (await this.makeNoResultsBack()).log();
     }
 
     public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
         return this.makeClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
     }
 
-    public logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.makeShowMoreFoldedResults(info, identifier).log();
+    public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeShowMoreFoldedResults(info, identifier)).log();
     }
 
     public makeShowLessFoldedResults() {
         return this.makeCustomEvent(SearchPageEvents.showLessFoldedResults);
     }
 
-    public logShowLessFoldedResults() {
-        return this.makeShowLessFoldedResults().log();
+    public async logShowLessFoldedResults() {
+        return (await this.makeShowLessFoldedResults()).log();
     }
 
-    public makeCustomEvent(
+    private makeEventBuilder<T extends AnyEventResponse>(
+        actionCause: SearchPageEvents,
+        preparedEvent: PreparedEvent<T>
+    ): EventBuilder<T> {
+        const description: EventDescription = {actionCause, customData: preparedEvent.payload?.customData};
+        return {description, log: () => preparedEvent.log()};
+    }
+
+    public async makeCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
         eventType: string = CustomEventsTypes[event]!
-    ): EventBuilder<CustomEventResponse> {
+    ): Promise<EventBuilder<CustomEventResponse>> {
+        this.coveoAnalyticsClient.getParameters;
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
-        return {
-            description: this.makeDescription(event, metadata),
-            log: async () => {
-                const payload: CustomEventRequest = {
-                    ...(await this.getBaseCustomEventRequest(customData)),
-                    eventType,
-                    eventValue: event,
-                };
-
-                return this.coveoAnalyticsClient.sendCustomEvent(payload);
-            },
+        const request: CustomEventRequest = {
+            ...(await this.getBaseCustomEventRequest(customData)),
+            eventType,
+            eventValue: event,
         };
+        const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(request);
+        return this.makeEventBuilder(event, preparedEvent);
     }
 
-    public logCustomEvent(
+    public async logCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
         eventType: string = CustomEventsTypes[event]!
     ) {
-        return this.makeCustomEvent(event, metadata, eventType).log();
+        return (await this.makeCustomEvent(event, metadata, eventType)).log();
     }
 
-    public makeCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+    public async makeCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
-        return {
-            description: <EventDescription>{actionCause: eventValue, customData},
-            log: async () => {
-                const payload: CustomEventRequest = {
-                    ...(await this.getBaseCustomEventRequest(customData)),
-                    eventType,
-                    eventValue,
-                };
-                return this.coveoAnalyticsClient.sendCustomEvent(payload);
-            },
+        const payload: CustomEventRequest = {
+            ...(await this.getBaseCustomEventRequest(customData)),
+            eventType,
+            eventValue,
         };
+        const preparedEvent = await this.coveoAnalyticsClient.prepareCustomEvent(payload);
+        return this.makeEventBuilder(eventValue as SearchPageEvents, preparedEvent);
     }
 
-    public logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
-        return this.makeCustomEventWithType(eventValue, eventType, metadata).log();
+    public async logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log();
     }
 
     public async logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
-        return this.coveoAnalyticsClient.sendSearchEvent(await this.getBaseSearchEventRequest(event, metadata));
+        return (await this.makeSearchEvent(event, metadata)).log();
     }
 
-    private makeDescription(actionCause: SearchPageEvents, metadata?: Record<string, any>): EventDescription {
-        return {actionCause, customData: {...this.provider.getBaseMetadata(), ...metadata}};
+    public async makeSearchEvent(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<SearchEventResponse>> {
+        const request = await this.getBaseSearchEventRequest(event, metadata);
+        const preparedEvent = await this.coveoAnalyticsClient.prepareSearchEvent(request);
+        return this.makeEventBuilder(event, preparedEvent);
     }
 
-    public makeSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>): EventBuilder<SearchEventResponse> {
-        return {
-            description: this.makeDescription(event, metadata),
-            log: () => this.logSearchEvent(event, metadata),
+    public async makeClickEvent(
+        event: SearchPageEvents,
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<ClickEventResponse>> {
+        const request: ClickEventRequest = {
+            ...info,
+            ...(await this.getBaseEventRequest({...identifier, ...metadata})),
+            searchQueryUid: this.provider.getSearchUID(),
+            queryPipeline: this.provider.getPipeline(),
+            actionCause: event,
         };
+        const preparedEvent = await this.coveoAnalyticsClient.prepareClickEvent(request);
+        return this.makeEventBuilder(event, preparedEvent);
     }
 
     public async logClickEvent(
@@ -780,27 +803,7 @@ export class CoveoSearchPageClient {
         identifier: DocumentIdentifier,
         metadata?: Record<string, any>
     ) {
-        const payload: ClickEventRequest = {
-            ...info,
-            ...(await this.getBaseEventRequest({...identifier, ...metadata})),
-            searchQueryUid: this.provider.getSearchUID(),
-            queryPipeline: this.provider.getPipeline(),
-            actionCause: event,
-        };
-
-        return this.coveoAnalyticsClient.sendClickEvent(payload);
-    }
-
-    public makeClickEvent(
-        event: SearchPageEvents,
-        info: PartialDocumentInformation,
-        identifier: DocumentIdentifier,
-        metadata?: Record<string, any>
-    ): EventBuilder<ClickEventResponse> {
-        return {
-            description: this.makeDescription(event, {...identifier, ...metadata}),
-            log: () => this.logClickEvent(event, info, identifier, metadata),
-        };
+        return (await this.makeClickEvent(event, info, identifier, metadata)).log();
     }
 
     private async getBaseSearchEventRequest(

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -1,15 +1,25 @@
-import {AnalyticsClient} from '../src/client/analytics';
+import {AnalyticsClient, PreparedEvent} from '../src/client/analytics';
+import {NoopAnalytics} from '../src/client/noopAnalytics';
 import {NoopRuntime} from '../src/client/runtimeEnvironment';
+import {AnyEventResponse, EventType} from '../src/events';
 
 export const visitorIdMock = 'mockvisitorid';
+
+const prepareEvent = (eventType: EventType | string) =>
+    Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
 
 export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     getPayload: jest.fn((eventType, ...payload) => Promise.resolve()),
     getParameters: jest.fn((eventType, ...payload) => Promise.resolve()),
+    prepareEvent: jest.fn(prepareEvent),
     sendEvent: jest.fn((eventType, payload) => Promise.resolve()),
+    prepareClickEvent: jest.fn((request) => prepareEvent(EventType.click)),
     sendClickEvent: jest.fn((request) => Promise.resolve()),
+    prepareCustomEvent: jest.fn((request) => prepareEvent(EventType.custom)),
     sendCustomEvent: jest.fn((request) => Promise.resolve()),
+    prepareSearchEvent: jest.fn((request) => prepareEvent(EventType.search)),
     sendSearchEvent: jest.fn((request) => Promise.resolve()),
+    prepareViewEvent: jest.fn((request) => prepareEvent(EventType.view)),
     sendViewEvent: jest.fn((request) => Promise.resolve()),
     getHealth: jest.fn(() => Promise.resolve({status: 'ok'})),
     getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),

--- a/tests/analyticsClientMock.ts
+++ b/tests/analyticsClientMock.ts
@@ -5,21 +5,21 @@ import {AnyEventResponse, EventType} from '../src/events';
 
 export const visitorIdMock = 'mockvisitorid';
 
-const prepareEvent = (eventType: EventType | string) =>
+const makeEvent = (eventType: EventType | string) =>
     Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
 
 export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
     getPayload: jest.fn((eventType, ...payload) => Promise.resolve()),
     getParameters: jest.fn((eventType, ...payload) => Promise.resolve()),
-    prepareEvent: jest.fn(prepareEvent),
+    makeEvent: jest.fn(makeEvent),
     sendEvent: jest.fn((eventType, payload) => Promise.resolve()),
-    prepareClickEvent: jest.fn((request) => prepareEvent(EventType.click)),
+    makeClickEvent: jest.fn((request) => makeEvent(EventType.click)),
     sendClickEvent: jest.fn((request) => Promise.resolve()),
-    prepareCustomEvent: jest.fn((request) => prepareEvent(EventType.custom)),
+    makeCustomEvent: jest.fn((request) => makeEvent(EventType.custom)),
     sendCustomEvent: jest.fn((request) => Promise.resolve()),
-    prepareSearchEvent: jest.fn((request) => prepareEvent(EventType.search)),
+    makeSearchEvent: jest.fn((request) => makeEvent(EventType.search)),
     sendSearchEvent: jest.fn((request) => Promise.resolve()),
-    prepareViewEvent: jest.fn((request) => prepareEvent(EventType.view)),
+    makeViewEvent: jest.fn((request) => makeEvent(EventType.view)),
     sendViewEvent: jest.fn((request) => Promise.resolve()),
     getHealth: jest.fn(() => Promise.resolve({status: 'ok'})),
     getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2071

# The old problem
In Atomic, we wish to include the `actionCause` and `customData` of analytics events in their corresponding search (`/v2`) call. This problem was solved in an old PR by making events "preparable". Events were made "preparable" by making a copy of each `log*` function in `coveo.analytics`'s `searchPageClient.ts`, respectively named `make*`, which returns the needed metadata and a function to log them.

# The new problem
In Atomic, analytics middleware (which are passed as `beforeSendHooks` in `coveo.analytics`) weren't applied to prepared events. This meant that the `customData` we sent in search calls could be different from the one in analytics calls. One way this manifested was that `coveoAtomicVersion` was missing in search calls.

# The solution
Since `beforeSendHooks` live at a lower level than `searchPageClient.ts` (they live in `analytics.ts`), and since there's a lot of other things that seem to modify events at that level, I decided to make events preparable in `analytics.ts`.

This had two side-effects:
1. Preparing analytics is now asynchronous, since various processes affecting the payload in `analytics.ts` are asynchronous.
2. The entire analytics payload is now "prepared", not just the "customData".

# The second new problem
With the above changes, since the entire analytics payload is now prepared, the `searchQueryUid` was also prepared. Unfortunately, that's not something we can do, since we intend to prepare analytics before their corresponding search call.

# The solution to the second new problem
I allowed prepared events in `analytics.ts` to take two different payloads:
* the prepared payload (e.g., `PreparedClickEventRequest`)
* the full payload (e.g., `ClickEventRequest`)

Only the prepared payload is required to prepare an event. To call a prepared event, the remaining payload is required.

In addition to this, I made all `make*` functions in `searchPageClient.ts` require the `searchUID` when logging them.

# Conclusion / tl;dr
Prior to this PR, the signature of `make` functions (which only exist in `searchPageClient.ts`, so no case assist nor insight events) looked like the following:
```typescript
export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
    description: {
      actionCause: string;
      customData?: Record<string, any>;
    };
    log: () => Promise<T | void>;
}

makeCollapseSmartSnippetSuggestion(...someParams): EventBuilder;
```

After this PR, the signature of `make` functions in the same file looks like the following:
```typescript
export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
    description: {
      actionCause: string;
      customData?: Record<string, any>;
    };
    log: (searchUID: string) => Promise<T | void>; // Now takes the `searchUID` as a parameter.
}

makeCollapseSmartSnippetSuggestion(...someParams): Promise<EventBuilder>; // Now returns a `Promise`.
```

This change is breaking, but in theory we don't really expect any of the affected functions to have been used anywhere but in Headless v2.