### PR TITLE
feat(insight): added user actions events

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -844,4 +844,31 @@ describe('InsightClient', () => {
         await client.logShowFollowingSessions(baseCaseMetadata);
         expectMatchCustomEventPayload(InsightEvents.showFollowingSessions, expectedBaseCaseMetadata);
     });
+
+    it('should send proper payload for #logViewedDocumentClick', async () => {
+        const document = {
+            title: 'Some Title',
+            uri: 'https://www.some-uri.com',
+            uriHash: 'Acp8NfEWi0DeðeZU',
+            permanentId: '8c88cd894t2767a96fa4f109041bb62bb54ca21ff31c1d760814b60cbcf2',
+        };
+        await client.logViewedDocumentClick(document, baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.clickViewedDocument, {
+            ...expectedBaseCaseMetadata,
+            document,
+        });
+    });
+
+    it('should send proper payload for #logPageViewClick', async () => {
+        const pageView = {
+            title: 'Some Title',
+            contentIdKey: 'someKey',
+            contentIdValue: 'some-content-id-value',
+        };
+        await client.logPageViewClick(pageView, baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.clickPageView, {
+            ...expectedBaseCaseMetadata,
+            pageView,
+        });
+    });
 });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -858,4 +858,17 @@ describe('InsightClient', () => {
             document,
         });
     });
+
+    it('should send proper payload for #logPageViewClick', async () => {
+        const pageView = {
+            title: 'Some Title',
+            contentIdKey: 'someKey',
+            contentIdValue: 'some-content-id-value',
+        };
+        await client.logPageViewClick(pageView, baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.clickPageView, {
+            ...expectedBaseCaseMetadata,
+            pageView,
+        });
+    });
 });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -858,17 +858,4 @@ describe('InsightClient', () => {
             document,
         });
     });
-
-    it('should send proper payload for #logPageViewClick', async () => {
-        const pageView = {
-            title: 'Some Title',
-            contentIdKey: 'someKey',
-            contentIdValue: 'some-content-id-value',
-        };
-        await client.logPageViewClick(pageView, baseCaseMetadata);
-        expectMatchCustomEventPayload(InsightEvents.clickPageView, {
-            ...expectedBaseCaseMetadata,
-            pageView,
-        });
-    });
 });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -829,4 +829,19 @@ describe('InsightClient', () => {
         await client.logExpandToFullUI(meta);
         expectMatchCustomEventPayload(InsightEvents.expandToFullUI, expectedMeta);
     });
+
+    it('should send proper payload for #logOpenUserActions', async () => {
+        await client.logOpenUserActions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.openUserActions, expectedBaseCaseMetadata);
+    });
+
+    it('should send proper payload for #logShowPrecedingSession', async () => {
+        await client.logShowPrecedingSessions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.showPrecedingSessions, expectedBaseCaseMetadata);
+    });
+
+    it('should send proper payload for #logShowFollowingSession', async () => {
+        await client.logShowFollowingSessions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.showFollowingSessions, expectedBaseCaseMetadata);
+    });
 });

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -24,7 +24,6 @@ import {
     InsightPagerMetadata,
     InsightResultsSortMetadata,
     UserActionsDocumentMetadata,
-    UserActionsPageViewMetadata,
 } from './insightEvents';
 
 export interface InsightClientProvider {
@@ -240,13 +239,6 @@ export class CoveoInsightClient {
         return this.logCustomEvent(InsightEvents.clickViewedDocument, {
             ...generateMetadataToSend(metadata, false),
             document,
-        });
-    }
-
-    public logPageViewClick(pageView: UserActionsPageViewMetadata, metadata: CaseMetadata) {
-        return this.logCustomEvent(InsightEvents.clickPageView, {
-            ...generateMetadataToSend(metadata, false),
-            pageView,
         });
     }
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -23,6 +23,8 @@ import {
     InsightQueryErrorMeta,
     InsightPagerMetadata,
     InsightResultsSortMetadata,
+    UserActionsDocumentMetadata,
+    UserActionsPageViewMetadata,
 } from './insightEvents';
 
 export interface InsightClientProvider {
@@ -220,18 +222,32 @@ export class CoveoInsightClient {
     }
 
     public logOpenUserActions(metadata: CaseMetadata) {
-        const metadataToSend = generateMetadataToSend(metadata);
+        const metadataToSend = generateMetadataToSend(metadata, false);
         return this.logCustomEvent(InsightEvents.openUserActions, metadataToSend);
     }
 
     public logShowPrecedingSessions(metadata: CaseMetadata) {
-        const metadataToSend = generateMetadataToSend(metadata);
+        const metadataToSend = generateMetadataToSend(metadata, false);
         return this.logCustomEvent(InsightEvents.showPrecedingSessions, metadataToSend);
     }
 
     public logShowFollowingSessions(metadata: CaseMetadata) {
-        const metadataToSend = generateMetadataToSend(metadata);
+        const metadataToSend = generateMetadataToSend(metadata, false);
         return this.logCustomEvent(InsightEvents.showFollowingSessions, metadataToSend);
+    }
+
+    public logViewedDocumentClick(document: UserActionsDocumentMetadata, metadata: CaseMetadata) {
+        return this.logCustomEvent(InsightEvents.clickViewedDocument, {
+            ...generateMetadataToSend(metadata, false),
+            document,
+        });
+    }
+
+    public logPageViewClick(pageView: UserActionsPageViewMetadata, metadata: CaseMetadata) {
+        return this.logCustomEvent(InsightEvents.clickPageView, {
+            ...generateMetadataToSend(metadata, false),
+            pageView,
+        });
     }
 
     public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -24,6 +24,7 @@ import {
     InsightPagerMetadata,
     InsightResultsSortMetadata,
     UserActionsDocumentMetadata,
+    UserActionsPageViewMetadata,
 } from './insightEvents';
 
 export interface InsightClientProvider {
@@ -239,6 +240,13 @@ export class CoveoInsightClient {
         return this.logCustomEvent(InsightEvents.clickViewedDocument, {
             ...generateMetadataToSend(metadata, false),
             document,
+        });
+    }
+
+    public logPageViewClick(pageView: UserActionsPageViewMetadata, metadata: CaseMetadata) {
+        return this.logCustomEvent(InsightEvents.clickPageView, {
+            ...generateMetadataToSend(metadata, false),
+            pageView,
         });
     }
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -219,6 +219,21 @@ export class CoveoInsightClient {
         return this.logCustomEvent(InsightEvents.expandToFullUI, metadataToSend);
     }
 
+    public logOpenUserActions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logCustomEvent(InsightEvents.openUserActions, metadataToSend);
+    }
+
+    public logShowPrecedingSessions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logCustomEvent(InsightEvents.showPrecedingSessions, metadataToSend);
+    }
+
+    public logShowFollowingSessions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logCustomEvent(InsightEvents.showFollowingSessions, metadataToSend);
+    }
+
     public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
         return this.logClickEvent(
             SearchPageEvents.documentOpen,

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -33,13 +33,9 @@ export enum InsightEvents {
      */
     showFollowingSessions = 'showFollowingSessions',
     /**
-     * Identified the event that gets logged when the user clicks a viewed document.
+     * Identifies the event that gets logged when the user clicks a viewed document.
      */
     clickViewedDocument = 'clickViewedDocument',
-    /**
-     * Identified the event that gets logged when the user clicks a viewed page.
-     */
-    clickPageView = 'clickPageView',
 }
 
 export interface CaseMetadata {
@@ -56,14 +52,8 @@ export interface ExpandToFullUIMetadata extends CaseMetadata {
 export interface UserActionsDocumentMetadata {
     title: string;
     uri: string;
-    uriHash: string;
+    uriHash?: string;
     permanentId?: string;
-}
-
-export interface UserActionsPageViewMetadata {
-    title: string;
-    contentIdKey: string;
-    contentIdValue: string;
 }
 
 export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -32,6 +32,14 @@ export enum InsightEvents {
      * Identifies the event that gets logged when the user clicks to view user action sessions following the ticket creation.
      */
     showFollowingSessions = 'showFollowingSessions',
+    /**
+     * Identified the event that gets logged when the user clicks a viewed document.
+     */
+    clickViewedDocument = 'clickViewedDocument',
+    /**
+     * Identified the event that gets logged when the user clicks a viewed page.
+     */
+    clickPageView = 'clickPageView',
 }
 
 export interface CaseMetadata {
@@ -43,6 +51,19 @@ export interface CaseMetadata {
 export interface ExpandToFullUIMetadata extends CaseMetadata {
     fullSearchComponentName: string;
     triggeredBy: string;
+}
+
+export interface UserActionsDocumentMetadata {
+    title: string;
+    uri: string;
+    uriHash: string;
+    permanentId?: string;
+}
+
+export interface UserActionsPageViewMetadata {
+    title: string;
+    contentIdKey: string;
+    contentIdValue: string;
 }
 
 export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -36,6 +36,10 @@ export enum InsightEvents {
      * Identifies the event that gets logged when the user clicks a viewed document.
      */
     clickViewedDocument = 'clickViewedDocument',
+    /**
+     * Identifies the event that gets logged when the user clicks a viewed page.
+     */
+    clickPageView = 'clickPageView',
 }
 
 export interface CaseMetadata {
@@ -54,6 +58,12 @@ export interface UserActionsDocumentMetadata {
     uri: string;
     uriHash?: string;
     permanentId?: string;
+}
+
+export interface UserActionsPageViewMetadata {
+    title: string;
+    contentIdKey: string;
+    contentIdValue: string;
 }
 
 export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -33,11 +33,11 @@ export enum InsightEvents {
      */
     showFollowingSessions = 'showFollowingSessions',
     /**
-     * Identifies the event that gets logged when the user clicks a viewed document.
+     * Identifies the event that gets logged when the user clicks a viewed document link on the user actions timeline.
      */
     clickViewedDocument = 'clickViewedDocument',
     /**
-     * Identifies the event that gets logged when the user clicks a viewed page.
+     * Identifies the event that gets logged when the user clicks a viewed page link on the user actions timeline.
      */
     clickPageView = 'clickPageView',
 }

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -20,6 +20,18 @@ export enum InsightEvents {
      * Identifies the event that gets logged when the user opens the full search page from the insight panel.
      */
     expandToFullUI = 'expandToFullUI',
+    /**
+     * Identifies the event that gets logged when the user opens the user actions section.
+     */
+    openUserActions = 'openUserActions',
+    /**
+     * Identifies the event that gets logged when the user clicks to view user action sessions preceding the ticket creation.
+     */
+    showPrecedingSessions = 'showPrecedingSessions',
+    /**
+     * Identifies the event that gets logged when the user clicks to view user action sessions following the ticket creation.
+     */
+    showFollowingSessions = 'showFollowingSessions',
 }
 
 export interface CaseMetadata {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -325,6 +325,8 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [InsightEvents.openUserActions]: 'User Actions',
     [InsightEvents.showPrecedingSessions]: 'User Actions',
     [InsightEvents.showFollowingSessions]: 'User Actions',
+    [InsightEvents.clickViewedDocument]: 'User Actions',
+    [InsightEvents.clickPageView]: 'User Actions',
     [SearchPageEvents.caseDetach]: 'case',
 };
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -326,6 +326,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [InsightEvents.showPrecedingSessions]: 'User Actions',
     [InsightEvents.showFollowingSessions]: 'User Actions',
     [InsightEvents.clickViewedDocument]: 'User Actions',
+    [InsightEvents.clickPageView]: 'User Actions',
     [SearchPageEvents.caseDetach]: 'case',
 };
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -326,7 +326,6 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [InsightEvents.showPrecedingSessions]: 'User Actions',
     [InsightEvents.showFollowingSessions]: 'User Actions',
     [InsightEvents.clickViewedDocument]: 'User Actions',
-    [InsightEvents.clickPageView]: 'User Actions',
     [SearchPageEvents.caseDetach]: 'case',
 };
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -322,6 +322,9 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.clearRecentResults]: 'recentlyClickedDocuments',
     [SearchPageEvents.showLessFoldedResults]: 'folding',
     [InsightEvents.expandToFullUI]: 'interface',
+    [InsightEvents.openUserActions]: 'User Actions',
+    [InsightEvents.showPrecedingSessions]: 'User Actions',
+    [InsightEvents.showFollowingSessions]: 'User Actions',
     [SearchPageEvents.caseDetach]: 'case',
 };
 


### PR DESCRIPTION
Added the following event logging methods related to the Quantic Insight Panel:
- openUserActions
- showPrecedingSessions
- showFollowingSessions
- logViewedDocumentClick
- logPageViewClick