### PR TITLE
[UA-7290] Fix tracking issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "2.23.9",
             "license": "MIT",
             "dependencies": {
-                "cross-fetch": "^3.1.5"
+                "cross-fetch": "^3.1.5",
+                "uuid": "^9.0.0"
             },
             "devDependencies": {
                 "@rollup/plugin-alias": "^3.1.2",
@@ -21,6 +22,7 @@
                 "@types/jsdom": "^12.2.4",
                 "@types/mime": "0.0.29",
                 "@types/node": "^6.0.45",
+                "@types/uuid": "^9.0.0",
                 "babel-core": "^6.17.0",
                 "babel-loader": "^7.1.4",
                 "babel-preset-es2015": "^6.16.0",
@@ -1903,6 +1905,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+            "dev": true
+        },
+        "node_modules/@types/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
             "dev": true
         },
         "node_modules/@types/vfile": {
@@ -13825,6 +13833,16 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/request/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "dev": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -18018,13 +18036,11 @@
             "peer": true
         },
         "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-            "dev": true,
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
             "bin": {
-                "uuid": "bin/uuid"
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache": {
@@ -20566,6 +20582,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+            "dev": true
+        },
+        "@types/uuid": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==",
             "dev": true
         },
         "@types/vfile": {
@@ -29970,6 +29992,12 @@
                         "psl": "^1.1.28",
                         "punycode": "^2.1.1"
                     }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+                    "dev": true
                 }
             }
         },
@@ -33345,10 +33373,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "dev": true
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.23.9",
+    "version": "2.24.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "cross-fetch": "^3.1.5"
+        "cross-fetch": "^3.1.5",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-alias": "^3.1.2",
@@ -35,6 +36,7 @@
         "@types/jsdom": "^12.2.4",
         "@types/mime": "0.0.29",
         "@types/node": "^6.0.45",
+        "@types/uuid": "^9.0.0",
         "babel-core": "^6.17.0",
         "babel-loader": "^7.1.4",
         "babel-preset-es2015": "^6.16.0",

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,6 @@
         O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
         })(window,document,'script','coveoua.debug.js')
 
-        // setting a consistent clientId
-        coveoua('onLoad', function (args) {
-            coveoanalytics.getCurrentClient().setClientId('myclientid', 'mynamespace');
-        });
-
         // Replace YOUR-TOKEN with your real token
         // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
         coveoua('init', 'YOUR-TOKEN');

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,11 @@
         O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
         })(window,document,'script','coveoua.debug.js')
 
+        // setting a consistent clientId
+        coveoua('onLoad', function (args) {
+            coveoanalytics.getCurrentClient().setClientId('myclientid', 'mynamespace');
+        });
+
         // Replace YOUR-TOKEN with your real token
         // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
         coveoua('init', 'YOUR-TOKEN');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,12 +22,6 @@ const tsPlugin = () =>
         useTsconfigDeclarationDir: true,
     });
 
-const nodeResolvePlugin = () =>
-    nodeResolve({
-        preferBuiltins: true,
-        only: ['cross-fetch', 'uuid'],
-    });
-
 const browserUMD = {
     input: './src/coveoua/browser.ts',
     output: [
@@ -54,7 +48,7 @@ const browserUMD = {
     ],
     plugins: [
         browserFetch(),
-        nodeResolvePlugin(),
+        nodeResolve({preferBuiltins: true, only: ['uuid']}),
         tsPlugin(),
         process.env.SERVE
             ? serve({
@@ -75,7 +69,12 @@ const nodeCJS = {
         file: './dist/library.js',
         format: 'cjs',
     },
-    plugins: [nodeResolve({mainFields: ['main'], preferBuiltins: true}), commonjs(), tsPlugin(), json()],
+    plugins: [
+        nodeResolve({mainFields: ['main'], preferBuiltins: true, only: ['uuid']}),
+        commonjs(),
+        tsPlugin(),
+        json(),
+    ],
 };
 
 const browserESM = {
@@ -86,7 +85,7 @@ const browserESM = {
     },
     plugins: [
         browserFetch(),
-        nodeResolvePlugin(),
+        nodeResolve({preferBuiltins: true, only: ['uuid']}),
         typescript({
             useTsconfigDeclarationDir: true,
             tsconfigOverride: {compilerOptions: {target: 'es6'}},
@@ -101,7 +100,7 @@ const libRN = {
         format: 'es',
     },
     plugins: [
-        nodeResolvePlugin(),
+        nodeResolve({preferBuiltins: true, only: ['uuid']}),
         commonjs(),
         json(),
         typescript({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,12 @@ const tsPlugin = () =>
         useTsconfigDeclarationDir: true,
     });
 
+const nodeResolvePlugin = () =>
+    nodeResolve({
+        preferBuiltins: true,
+        only: ['cross-fetch', 'uuid'],
+    });
+
 const browserUMD = {
     input: './src/coveoua/browser.ts',
     output: [
@@ -48,6 +54,7 @@ const browserUMD = {
     ],
     plugins: [
         browserFetch(),
+        nodeResolvePlugin(),
         tsPlugin(),
         process.env.SERVE
             ? serve({
@@ -68,7 +75,7 @@ const nodeCJS = {
         file: './dist/library.js',
         format: 'cjs',
     },
-    plugins: [nodeResolve({mainFields: ['main']}), commonjs(), tsPlugin(), json()],
+    plugins: [nodeResolve({mainFields: ['main'], preferBuiltins: true}), commonjs(), tsPlugin(), json()],
 };
 
 const browserESM = {
@@ -79,6 +86,7 @@ const browserESM = {
     },
     plugins: [
         browserFetch(),
+        nodeResolvePlugin(),
         typescript({
             useTsconfigDeclarationDir: true,
             tsconfigOverride: {compilerOptions: {target: 'es6'}},
@@ -93,6 +101,9 @@ const libRN = {
         format: 'es',
     },
     plugins: [
+        nodeResolvePlugin(),
+        commonjs(),
+        json(),
         typescript({
             useTsconfigDeclarationDir: true,
             tsconfigOverride: {compilerOptions: {target: 'es6'}},

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -453,3 +453,34 @@ describe('doNotTrack', () => {
         expect(Cookie.get('coveo_visitorId')).not.toBe(aVisitorId);
     });
 });
+
+describe('custom clientId', () => {
+    it('allows setting of a custom clientId', async () => {
+        let client = new CoveoAnalyticsClient({});
+        client.setClientId('c7d57b22-4aa8-487a-a106-be5243885f0a');
+        expect(await client.getCurrentVisitorId()).toBe('c7d57b22-4aa8-487a-a106-be5243885f0a');
+    });
+
+    it('allows setting a custom consistent clientId given a string', async () => {
+        let client = new CoveoAnalyticsClient({});
+        client.setClientId('somestring', 'testNameSpace');
+        //uuid v5 specific uuid generation
+        expect(await client.getCurrentVisitorId()).toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        //check for consistent ids
+        client.setClientId('somestring', 'testNameSpace');
+        expect(await client.getCurrentVisitorId()).toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        client.setClientId('otherstring', 'testNameSpace');
+        expect(await client.getCurrentVisitorId()).not.toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        client.setClientId('somestring', 'otherNameSpace');
+        expect(await client.getCurrentVisitorId()).not.toBe('2c356915-8223-5773-acb8-e2a34404a559');
+    });
+
+    it('errors when not providing a namespace', async () => {
+        let client = new CoveoAnalyticsClient({});
+        expect.assertions(1);
+        await expect(client.setClientId('somestring')).rejects.toEqual(
+            Error('Cannot generate uuid client id without a specific namespace string.')
+        );
+        //uuid v5 specific uuid generation
+    });
+});

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -23,6 +23,7 @@ import {hasWindow, hasDocument} from '../detector';
 import {addDefaultValues} from '../hook/addDefaultValues';
 import {enhanceViewEvent} from '../hook/enhanceViewEvent';
 import {uuidv4} from './crypto';
+import {v5 as uuidv5, validate as uuidValidate} from 'uuid';
 import {
     convertKeysToMeasurementProtocol,
     isMeasurementProtocolKey,
@@ -118,6 +119,8 @@ export function buildBaseUrl(endpoint = Endpoints.default, apiVersion = Version)
     return `${endpoint}${endpointIsCoveoProxy ? '' : '/rest'}/${apiVersion}`;
 }
 
+const COVEO_NAMESPACE = '38824e1f-37f5-42d3-8372-a4b8fa9df946'; //note: changing this value will destroy the mapping from tracking string to clientId.
+
 export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider {
     private get defaultOptions(): ClientOptions {
         return {
@@ -207,6 +210,15 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     async setCurrentVisitorId(visitorId: string) {
         this.visitorId = visitorId;
         await this.storage.setItem('visitorId', visitorId);
+    }
+
+    async setClientId(value: string, namespace?: string) {
+        if (uuidValidate(value)) {
+            this.setCurrentVisitorId(value);
+        } else {
+            if (!namespace) throw Error('Cannot generate uuid client id without a specific namespace string.');
+            this.setCurrentVisitorId(uuidv5(value, uuidv5(namespace, COVEO_NAMESPACE)));
+        }
     }
 
     async getParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -119,7 +119,10 @@ export function buildBaseUrl(endpoint = Endpoints.default, apiVersion = Version)
     return `${endpoint}${endpointIsCoveoProxy ? '' : '/rest'}/${apiVersion}`;
 }
 
-const COVEO_NAMESPACE = '38824e1f-37f5-42d3-8372-a4b8fa9df946'; //note: changing this value will destroy the mapping from tracking string to clientId.
+// Note: Changing this value will destroy the mapping from tracking string to clientId for all customers
+// using the setClientId() api. It will have the same effect as every visitor for those customers clearing
+// their cookie store at the same time, with corresponding downstream effects.
+const COVEO_NAMESPACE = '38824e1f-37f5-42d3-8372-a4b8fa9df946';
 
 export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider {
     private get defaultOptions(): ClientOptions {
@@ -216,7 +219,9 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         if (uuidValidate(value)) {
             this.setCurrentVisitorId(value);
         } else {
-            if (!namespace) throw Error('Cannot generate uuid client id without a specific namespace string.');
+            if (!namespace) {
+                throw Error('Cannot generate uuid client id without a specific namespace string.');
+            }
             this.setCurrentVisitorId(uuidv5(value, uuidv5(namespace, COVEO_NAMESPACE)));
         }
     }

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -46,7 +46,7 @@ export class Cookie {
 function writeCookie(name: string, value: string, expirationDate?: Date, domain?: string) {
     document.cookie =
         `${name}=${value}` +
-        (expirationDate ? `;expires=${(expirationDate as any).toGMTString()}` : '') +
+        (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
         (domain ? `;domain=${domain}` : '') +
         ';SameSite=Lax';
 }

--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -31,7 +31,7 @@ export class Cookie {
         for (var i = 0; i < cookieArray.length; i++) {
             var cookie = cookieArray[i];
             cookie = cookie.replace(/^\s+/, ''); //strip whitespace from front of cookie only
-            if (cookie.indexOf(cookiePrefix) == 0) {
+            if (cookie.lastIndexOf(cookiePrefix, 0) === 0) {
                 return cookie.substring(cookiePrefix.length, cookie.length);
             }
         }

--- a/src/coveoua/browser.ts
+++ b/src/coveoua/browser.ts
@@ -4,13 +4,13 @@ import handleOneAnalyticsEvent from './simpleanalytics';
 declare const self: any;
 
 const promise = (window as any)['Promise'];
-if (!(promise instanceof Function)) {
+if (!(promise instanceof Function) && !global) {
     console.error(
         `This script uses window.Promise which is not supported in your browser. Consider adding a polyfill like "es6-promise".`
     );
 }
 const fetch = (window as any)['fetch'];
-if (!(fetch instanceof Function)) {
+if (!(fetch instanceof Function) && !global) {
     console.error(
         `This script uses window.fetch which is not supported in your browser. Consider adding a polyfill like "fetch".`
     );

--- a/src/storage.spec.ts
+++ b/src/storage.spec.ts
@@ -1,4 +1,5 @@
 import {CookieStorage, CookieAndLocalStorage} from './storage';
+import {Cookie} from './cookieutils';
 
 describe('CookieStorage', () => {
     const key = 'wow';
@@ -14,6 +15,13 @@ describe('CookieStorage', () => {
         const storage = new CookieStorage();
         storage.setItem(key, someData);
         storage.removeItem(key);
+        expect(storage.getItem(key)).toBe(null);
+    });
+
+    it('honors expiration date', async () => {
+        const storage = new CookieStorage();
+        storage.setItem(key, someData, 1000);
+        await new Promise((res) => setTimeout(res, 1000)); // wait for 1 sec
         expect(storage.getItem(key)).toBe(null);
     });
 });

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -33,8 +33,8 @@ export class CookieStorage implements WebStorage {
     removeItem(key: string) {
         Cookie.erase(`${CookieStorage.prefix}${key}`);
     }
-    setItem(key: string, data: string): void {
-        Cookie.set(`${CookieStorage.prefix}${key}`, data);
+    setItem(key: string, data: string, expire?: number): void {
+        Cookie.set(`${CookieStorage.prefix}${key}`, data, expire);
     }
 }
 
@@ -52,7 +52,7 @@ export class CookieAndLocalStorage implements WebStorage {
 
     setItem(key: string, data: string): void {
         localStorage.setItem(key, data);
-        this.cookieStorage.setItem(key, data);
+        this.cookieStorage.setItem(key, data, 31556926000); // 1 year first party cookie
     }
 }
 


### PR DESCRIPTION
After closer investigation of the cookie generation code I found a few bugs:
- The first party cookie setting code did not do what it says it does. For a domain `some.domain.blah.com` it would try to write the cookie to `.domain.blah.com`. This is not wrong, but better would be to write to `blah.com`.
- The first party cookie was being set without expiration date, meaning it effectively acts **as a session cookie**. This means that cross sub-domain tracking won't work, as the cookie would expire at the end of a session.

In rare cases where a consistent id is needed across domains, I've provided an api call which allows a user to set a custom uuid, either directly from an existing uuid or from a given string. Coveo doesn't provide cross domain tracking in its code. If this string option is used, a cross-domain-consistent namespace string also needs to be provided, to increase entropy. Note that plaintext strings are not acceptable as clientIds, as they may (and have in the past) contain unintended personal information.

I'm relying on the industry standard `uuid` library to validate and generate uuid.v5. There is still code in the library which generates uuids v4. We should remove this in another change, as it's relying on `random()` to polyfill the browsers crypto.getRandomValues(). This in itself carries a risk to generate potentially overlapping uuids. At this point any browser [which does not support](https://caniuse.com/getrandomvalues) `getRandomValues` is either a decade old, or is called "Opera Mini". This additional dependency has increased the library size from 88kb to 91kb.

Small edits:
- Removed console log in tests by checking for presence of `global` variable.
- Fixed missing cross-fetch dependency warning in builds.

I would suggest everyone reviewing this to checkout the branch, run `npm run start`, set up two localhosts aliases (via /etc/hosts) and verify.




