### PR TITLE
Remove toString casting on epoch timestamp

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -12,7 +12,6 @@ describe('ec events', () => {
     const aToken = 'token';
     const anEndpoint = 'http://bloup';
 
-    const numberFormat = /[0-9]+/;
     const guidFormat = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
     const defaultContextValues = {
@@ -28,7 +27,7 @@ describe('ec events', () => {
         de: document.characterSet,
         pid: expect.stringMatching(guidFormat),
         cid: expect.stringMatching(guidFormat),
-        tm: expect.stringMatching(numberFormat),
+        tm: expect.any(Number),
         z: expect.stringMatching(guidFormat),
     };
 
@@ -41,7 +40,7 @@ describe('ec events', () => {
         const address = new RegExp('/rest/v15/analytics');
         fetchMock.reset();
         fetchMock.post(address, (url, {body}) => {
-            const parsedBody = JSON.parse(body.toString());
+            const parsedBody = JSON.parse(body!.toString());
             const visitorId = parsedBody.cid;
             return {
                 visitId: 'firsttimevisiting',
@@ -328,13 +327,13 @@ describe('ec events', () => {
     it('should return the same payload', async () => {
         const secondLocation = 'http://very.new/';
 
-        const firstPayload = await client.getPayload('pageview', {
+        const firstPayload = await client!.getPayload('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
             },
         });
-        const secondPayload = await client.getPayload('pageview', {
+        const secondPayload = await client!.getPayload('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
@@ -342,13 +341,13 @@ describe('ec events', () => {
         });
         await coveoua('send', 'pageview');
         changeDocumentLocation(secondLocation);
-        const firstAfterPayload = await client.getPayload('pageview', {
+        const firstAfterPayload = await client!.getPayload('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
             },
         });
-        const secondAfterPayload = await client.getPayload('pageview', {
+        const secondAfterPayload = await client!.getPayload('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
@@ -372,13 +371,13 @@ describe('ec events', () => {
     it('should return the same parameters', async () => {
         const secondLocation = 'http://very.new/';
 
-        const firstParameters = await client.getParameters('pageview', {
+        const firstParameters = await client!.getParameters('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
             },
         });
-        const secondParameters = await client.getParameters('pageview', {
+        const secondParameters = await client!.getParameters('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
@@ -386,13 +385,13 @@ describe('ec events', () => {
         });
         await coveoua('send', 'pageview');
         changeDocumentLocation(secondLocation);
-        const firstAfterParameters = await client.getParameters('pageview', {
+        const firstAfterParameters = await client!.getParameters('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
             },
         });
-        const secondAfterParameters = await client.getParameters('pageview', {
+        const secondAfterParameters = await client!.getParameters('pageview', {
             title: 'wow',
             custom: {
                 verycustom: 'value',
@@ -414,8 +413,8 @@ describe('ec events', () => {
     });
 
     it('should return similar parameters and payload', async () => {
-        const parameters = await client.getParameters('pageview', {});
-        const payload = await client.getPayload('pageview', {});
+        const parameters = await client!.getParameters('pageview', {});
+        const payload = await client!.getPayload('pageview', {});
 
         const firstParametersToCompare = returnCommonAttributes(parameters, ['time', 'eventId']);
 
@@ -435,9 +434,9 @@ describe('ec events', () => {
     });
 
     it('should return similar parameters and send', async () => {
-        const firstParameters = await client.getParameters('pageview', {});
+        const firstParameters = await client!.getParameters('pageview', {});
         await coveoua('send', 'pageview');
-        const secondParameters = await client.getParameters('pageview', {});
+        const secondParameters = await client!.getParameters('pageview', {});
         await coveoua('send', 'pageview');
 
         const [pageView, secondPageView] = getParsedBody();
@@ -475,9 +474,9 @@ describe('ec events', () => {
     });
 
     it('should return similar payload and send', async () => {
-        const firstPayload = await client.getPayload('pageview', {});
+        const firstPayload = await client!.getPayload('pageview', {});
         await coveoua('send', 'pageview');
-        const secondPayload = await client.getPayload('pageview', {});
+        const secondPayload = await client!.getPayload('pageview', {});
         await coveoua('send', 'pageview');
 
         const [pageView, secondPageView] = getParsedBody();
@@ -727,8 +726,7 @@ describe('ec events', () => {
             sd: defaultContextValues.sd,
             sr: defaultContextValues.sr,
             t: 'event',
-            // tid: "toosogoogleanalyticsevents0l18in4y", removed, this one is picked up from the `ca("create", TID)` call.
-            tm: expect.stringMatching(numberFormat),
+            tm: expect.any(Number),
             ua: defaultContextValues.ua, // Added
             ul: defaultContextValues.ul,
             // v: 1, removed, we don't send version as of now.
@@ -786,7 +784,7 @@ describe('ec events', () => {
             sd: defaultContextValues.sd,
             sr: defaultContextValues.sr,
             t: 'pageview',
-            tm: expect.stringMatching(numberFormat),
+            tm: expect.any(Number),
             ua: defaultContextValues.ua,
             ul: defaultContextValues.ul,
             z: expect.stringMatching(guidFormat),
@@ -914,6 +912,7 @@ describe('ec events', () => {
     };
 
     const changeDocumentLocation = (url: string) => {
+        // @ts-ignore
         delete window.location;
         // @ts-ignore
         // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.

--- a/functional/svc-events.spec.ts
+++ b/functional/svc-events.spec.ts
@@ -9,7 +9,6 @@ describe('svc events', () => {
     const aToken = 'token';
     const anEndpoint = 'http://bloup';
 
-    const numberFormat = /[0-9]+/;
     const guidFormat = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
     const defaultContextValues = {
@@ -25,7 +24,7 @@ describe('svc events', () => {
         de: document.characterSet,
         pid: expect.stringMatching(guidFormat),
         cid: expect.stringMatching(guidFormat),
-        tm: expect.stringMatching(numberFormat),
+        tm: expect.any(Number),
         z: expect.stringMatching(guidFormat),
     };
 
@@ -36,7 +35,7 @@ describe('svc events', () => {
         const address = `${anEndpoint}/rest/v15/analytics/collect`;
         fetchMock.reset();
         fetchMock.post(address, (url, {body}) => {
-            const parsedBody = JSON.parse(body.toString());
+            const parsedBody = JSON.parse(body!.toString());
             const visitorId = parsedBody.cid;
             return {
                 visitId: 'firsttimevisiting',
@@ -111,6 +110,7 @@ describe('svc events', () => {
     };
 
     const changeDocumentLocation = (url: string) => {
+        // @ts-ignore
         delete window.location;
         // @ts-ignore
         // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -77,7 +77,7 @@ export abstract class BasePlugin {
             userAgent: navigator.userAgent,
         };
         const eventContext = {
-            time: Date.now().toString(),
+            time: Date.now(),
             eventId: this.uuidGenerator(),
         };
         return {

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -15,7 +15,7 @@ describe('EC plugin', () => {
         title: 'MAH PAGE',
         screenColor: '24-bit',
         screenResolution: '0x0',
-        time: expect.any(String),
+        time: expect.any(Number),
         userAgent: navigator.userAgent,
         language: 'en-US',
         hitType: ECPluginEventTypes.event,

--- a/src/plugins/svc.spec.ts
+++ b/src/plugins/svc.spec.ts
@@ -15,7 +15,7 @@ describe('SVC plugin', () => {
         title: 'MAH PAGE',
         screenColor: '24-bit',
         screenResolution: '0x0',
-        time: expect.any(String),
+        time: expect.any(Number),
         userAgent: navigator.userAgent,
         language: 'en-US',
         hitType: SVCPluginEventTypes.event,


### PR DESCRIPTION
We were logging collect events with a `tm` (timestamp) of type **string** even though the implied type is "msec since epoch". Cleaner to log as type number, otherwise we'll have to ensure we parse out the string as a number and deal with edge cases. Jackson previously auto-cast the type and it's already internally specced as a long so this change will not be breaking. For the time being we'll accept both string and number as valid. Major change is here:
```
const eventContext = {
            time: Date.now(),
            eventId: this.uuidGenerator(),
        };
```
Rest is test changes and syntactic sugar to placate typescript.