### PR TITLE
[UA-7368] Allow cross domain tracking via link parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,33 @@ As a sample, here is how an [addition to the cart interaction](https://docs.cove
     coveoua('send', 'event');
     ```
 
+## Linking clientIds across different domains using a URL parameter
+
+For tracking in situations where the clientID must remain the same, but the hostnames for two different sites are different, the library offers functionality to initialize a clientId from a link parameter. This functionality is encoded in the Link plugin, which is loaded by default. A URL query link will be picked up by the target page if the following conditions hold:
+
+-   The target page has a equal or greater version of coveo.analytics.js loaded.
+-   The link contains a valid uuid.
+-   The link contains a valid timestamp, and that timestamp is no more than 5 seconds in the past.
+-   The receiving page has specified a list of valid referrers and the current referrer host matches that list, using wildcards, including ports if specified.
+
+Given that you want to ensure the clientId remains consistent when you navigate from a source page on http://foo.com/index.html to a target page http://bar.com/index.html, the following steps are needed.
+
+1. Ensure coveo.analytics.js is loaded on the source page.
+2. Modify the source page such that whenever a link to the target page is clicked, its `href` is replaced by `coveoua('link:decorate', 'http://bar.com/index.html')`. For example, by creating an onClick event listener on the element or on the page. It's important that the decorated link is generated at the moment the link is clicked, as it will be valid only for a short time after generation.
+
+```html
+<script>
+    async function decorate(element) {
+        element.href = await coveoua('link:decorate', element.href);
+        return false;
+    }
+</script>
+<a onclick="decorate(this)" href="http://bar.com/index.html">Navigate</a>>
+```
+
+3. Ensure coveo.analytics.js is loaded on the target page.
+4. Ensure that the target page allows reception of links from the source page by adding `coveoua('link:acceptFrom', ['foo.com']);` immediately after script load.
+
 # Developer information
 
 Information for contributors or Coveo developers developing or integrating coveoua.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "prettier": "2.1.2",
                 "rimraf": "^3.0.2",
                 "rollup": "^2.50.6",
+                "rollup-plugin-polyfill-node": "^0.12.0",
                 "rollup-plugin-serve": "^1.0.1",
                 "rollup-plugin-terser": "^7.0.2",
                 "rollup-plugin-typescript2": "^0.27.0",
@@ -14195,6 +14196,80 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup-plugin-polyfill-node": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
+            "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/plugin-inject": "^5.0.1"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0"
+            }
+        },
+        "node_modules/rollup-plugin-polyfill-node/node_modules/@rollup/plugin-inject": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
+            "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.27.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/rollup-plugin-polyfill-node/node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/rollup-plugin-polyfill-node/node_modules/@types/estree": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+            "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+            "dev": true
+        },
+        "node_modules/rollup-plugin-polyfill-node/node_modules/magic-string": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.13"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/rollup-plugin-serve": {
@@ -30439,6 +30514,56 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "rollup-plugin-polyfill-node": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
+            "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
+            "dev": true,
+            "requires": {
+                "@rollup/plugin-inject": "^5.0.1"
+            },
+            "dependencies": {
+                "@rollup/plugin-inject": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
+                    "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
+                    "dev": true,
+                    "requires": {
+                        "@rollup/pluginutils": "^5.0.1",
+                        "estree-walker": "^2.0.2",
+                        "magic-string": "^0.27.0"
+                    },
+                    "dependencies": {
+                        "@rollup/pluginutils": {
+                            "version": "5.0.2",
+                            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+                            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+                            "dev": true,
+                            "requires": {
+                                "@types/estree": "^1.0.0",
+                                "estree-walker": "^2.0.2",
+                                "picomatch": "^2.3.1"
+                            }
+                        }
+                    }
+                },
+                "@types/estree": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+                    "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+                    "dev": true
+                },
+                "magic-string": {
+                    "version": "0.27.0",
+                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+                    "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+                    "dev": true,
+                    "requires": {
+                        "@jridgewell/sourcemap-codec": "^1.4.13"
+                    }
+                }
             }
         },
         "rollup-plugin-serve": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.27.0",
+        "rollup-plugin-polyfill-node": "^0.12.0",
         "stylelint": "^13.6.1",
         "ts-jest": "^25.2.0",
         "tsjs": "4.2.1",

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,9 @@
         // Replace YOUR-TOKEN with your real token
         // (eg: an API key which has the rights to write into Coveo UsageAnalytics)
         coveoua('init', 'YOUR-TOKEN');
+        // tests cross domain linking
+        coveoua('link:acceptFrom', ['localhost.corp.coveo.com:9001']);
+
         coveoua('ec:addProduct', {
             name: 'wow',
             id: 'something',
@@ -38,11 +41,16 @@
             });
             coveoua('ec:setAction', 'addToCart');
             coveoua('send', 'event');
-            window.location = 'index.html?added=' + new Date().valueOf();
+        }
+
+        async function decorate(element) {
+            element.href = await coveoua('link:decorate', element.href);
+            return false;
         }
     </script>
 
     <body>
         <button onclick="testBeacon()">Test beacon</button>
+        <a onclick="decorate(this)" href="http://localhost1.corp.coveo.com:9001">Navigate</a>
     </body>
 </html>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import {terser} from 'rollup-plugin-terser';
 import serve from 'rollup-plugin-serve';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
 import commonjs from '@rollup/plugin-commonjs';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import alias from '@rollup/plugin-alias';
@@ -55,6 +56,7 @@ const browserUMD = {
         },
     ],
     plugins: [
+        nodePolyfills(),
         browserFetch(),
         nodeResolve({preferBuiltins: true, only: ['uuid']}),
         versionReplace(),

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -24,6 +24,7 @@ import {addDefaultValues} from '../hook/addDefaultValues';
 import {enhanceViewEvent} from '../hook/enhanceViewEvent';
 import {v4 as uuidv4, v5 as uuidv5, validate as uuidValidate} from 'uuid';
 import {libVersion} from '../version';
+import {CoveoLinkParam} from '../plugins/link';
 import {
     convertKeysToMeasurementProtocol,
     isMeasurementProtocolKey,
@@ -105,6 +106,7 @@ export interface AnalyticsClient {
      */
     readonly currentVisitorId: string;
     getCurrentVisitorId?(): Promise<string>; // TODO: v3 make required
+    setAcceptedLinkReferrers?(hosts: string[]): void;
 }
 
 export interface BufferedRequest {
@@ -146,6 +148,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private afterSendHooks: AnalyticsClientSendEventHook[];
     private eventTypeMapping: {[name: string]: EventTypeConfig};
     private options: ClientOptions;
+    private acceptedLinkReferrers: string[] = [];
 
     constructor(opts: Partial<ClientOptions>) {
         if (!opts) {
@@ -196,7 +199,11 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     private async determineVisitorId() {
         try {
-            return (await this.storage.getItem('visitorId')) || uuidv4();
+            return (
+                this.extractClientIdFromLink(window.location.href) ||
+                (await this.storage.getItem('visitorId')) ||
+                uuidv4()
+            );
         } catch (err) {
             console.log(
                 'Could not get visitor ID from the current runtime environment storage. Using a random ID instead.',
@@ -256,6 +263,33 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     set currentVisitorId(visitorId: string) {
         this.visitorId = visitorId;
         this.storage.setItem('visitorId', visitorId);
+    }
+
+    private extractClientIdFromLink(urlString: string): string | null {
+        try {
+            const linkParam: string | null = new URL(urlString).searchParams.get(CoveoLinkParam.cvo_cid);
+            if (linkParam && !doNotTrack()) {
+                const linker: CoveoLinkParam | null = CoveoLinkParam.fromString(linkParam);
+                if (linker && !linker.expired && this.matchReferrer(document.referrer)) {
+                    return linker.clientId;
+                }
+            }
+        } catch (error) {
+            return null;
+        }
+        return null;
+    }
+
+    private matchReferrer(urlString: string): boolean {
+        try {
+            const url: URL = new URL(urlString);
+            return this.acceptedLinkReferrers.some((value: string) => {
+                const hostRegExp: RegExp = new RegExp(value.replace(/\./g, '\\.').replace(/\*/g, '.*') + '$');
+                return url.host.match(hostRegExp);
+            });
+        } catch (error) {
+            return false;
+        }
     }
 
     async resolveParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
@@ -451,6 +485,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void {
         this.eventTypeMapping[eventType] = eventConfig;
+    }
+
+    setAcceptedLinkReferrers(hosts: string[]): void {
+        if (Array.isArray(hosts)) this.acceptedLinkReferrers = hosts;
     }
 
     private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {

--- a/src/coveoua/plugins.ts
+++ b/src/coveoua/plugins.ts
@@ -1,15 +1,14 @@
-import {PluginClass, PluginOptions, BasePlugin} from '../plugins/BasePlugin';
-import {EC} from '../plugins/ec';
-import {SVC} from '../plugins/svc';
-
-export type UAPluginOptions = any[];
-export type Plugin = BasePlugin & {[propName: string]: unknown};
+import {PluginClass, PluginOptions, BasePlugin, Plugin} from '../plugins/BasePlugin';
+import {EC, ECPlugin} from '../plugins/ec';
+import {Link, LinkPlugin} from '../plugins/link';
+import {SVC, SVCPlugin} from '../plugins/svc';
 
 export class Plugins {
-    public static readonly DefaultPlugins: string[] = [EC.Id, SVC.Id];
+    public static readonly DefaultPlugins: string[] = [ECPlugin.Id, SVCPlugin.Id, LinkPlugin.Id];
     private registeredPluginsMap: Record<string, PluginClass> = {
         [EC.Id]: EC,
         [SVC.Id]: SVC,
+        [Link.Id]: Link,
     };
     private requiredPlugins: Record<string, BasePlugin> = {};
 
@@ -31,18 +30,18 @@ export class Plugins {
         this.requiredPlugins = {};
     }
 
-    execute(name: string, fn: string, ...pluginOptions: UAPluginOptions) {
+    execute(name: string, fn: string, ...args: any[]): any {
         const plugin = this.requiredPlugins[name] as Plugin;
         if (!plugin) {
             throw new Error(`The plugin "${name}" is not required. Check that you required it on initialization.`);
         }
-        const actionFunction = plugin[fn];
+        const actionFunction = plugin.getApi(fn);
         if (!actionFunction) {
             throw new Error(`The function "${fn}" does not exist on the plugin "${name}".`);
         }
         if (typeof actionFunction !== 'function') {
             throw new Error(`"${fn}" of the plugin "${name}" is not a function.`);
         }
-        return actionFunction.apply(plugin, pluginOptions);
+        return actionFunction.apply(plugin, args);
     }
 }

--- a/src/coveoua/plugins.ts
+++ b/src/coveoua/plugins.ts
@@ -1,10 +1,10 @@
 import {PluginClass, PluginOptions, BasePlugin, Plugin} from '../plugins/BasePlugin';
-import {EC, ECPlugin} from '../plugins/ec';
-import {Link, LinkPlugin} from '../plugins/link';
-import {SVC, SVCPlugin} from '../plugins/svc';
+import {EC} from '../plugins/ec';
+import {Link} from '../plugins/link';
+import {SVC} from '../plugins/svc';
 
 export class Plugins {
-    public static readonly DefaultPlugins: string[] = [ECPlugin.Id, SVCPlugin.Id, LinkPlugin.Id];
+    public static readonly DefaultPlugins: string[] = [EC.Id, SVC.Id, Link.Id];
     private registeredPluginsMap: Record<string, PluginClass> = {
         [EC.Id]: EC,
         [SVC.Id]: SVC,

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -129,8 +129,8 @@ export class CoveoUA {
         this.plugins.require(name, {...options, client: this.client});
     }
 
-    callPlugin(pluginName: string, fn: string, ...args: any): void {
-        this.plugins.execute(pluginName, fn, ...args);
+    callPlugin(pluginName: string, fn: string, ...args: any): any {
+        return this.plugins.execute(pluginName, fn, ...args);
     }
 
     reset() {

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -71,6 +71,19 @@ export class ECPlugin extends BasePlugin {
         super({client, uuidGenerator});
     }
 
+    public getApi(name: string): Function | null {
+        const superCall: Function | null = super.getApi(name);
+        if (superCall !== null) return superCall;
+        switch (name) {
+            case 'addProduct':
+                return this.addProduct;
+            case 'addImpression':
+                return this.addImpression;
+            default:
+                return null;
+        }
+    }
+
     protected addHooks(): void {
         this.addHooksForPageView();
         this.addHooksForEvent();

--- a/src/plugins/link.spec.ts
+++ b/src/plugins/link.spec.ts
@@ -1,0 +1,151 @@
+import {CoveoLinkParam, LinkPlugin} from './link';
+import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
+import {v4 as uuidv4} from 'uuid';
+
+function currentSecsSinceEpoch() {
+    return Math.floor(Date.now() / 1000);
+}
+
+describe('CoveoLinkParam class', () => {
+    it('can create a new link using a uuid', () => {
+        const uuid = uuidv4();
+        const link: CoveoLinkParam = new CoveoLinkParam(uuid);
+        expect(link.clientId).toBe(uuid);
+        expect(link.creationDate).toBe(currentSecsSinceEpoch());
+    });
+
+    it('can create a new link using a uuid and timestamp', () => {
+        const uuid = uuidv4();
+        const link: CoveoLinkParam = new CoveoLinkParam(uuid, 1676298678329);
+        expect(link.clientId).toBe(uuid);
+        expect(link.creationDate).toBe(1676298678);
+    });
+
+    it('can not create a new link using a non uuid', () => {
+        const uuid = 'Not_a_uuid';
+        expect(() => new CoveoLinkParam(uuid)).toThrow('Not a valid uuid');
+    });
+
+    it('can parse a link from a string', () => {
+        const link = 'c0b48880743e484f8044d7c37910c55b.1676298678';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).not.toBeNull;
+        expect(coveoLinkParam?.clientId).toBe('c0b48880-743e-484f-8044-d7c37910c55b');
+        expect(coveoLinkParam?.creationDate).toBe(1676298678);
+    });
+
+    it('will not parse links without a valid uuid', () => {
+        const link = 'a0c56830743d46537f703.1676298678';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).toBe(null);
+    });
+
+    it('will not parse links with invalid timestamps', () => {
+        const link = 'a0c56830743d46537f703.invalidtimestamp';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).toBe(null);
+    });
+
+    it('can serialize a link to a string', () => {
+        const coveoLink: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9');
+        const link = coveoLink.toString();
+        const parts = link.split('.');
+        expect(parts[0]).toBe('074af291224b47059dc5a47bd80a8db9');
+        expect(Number.parseInt(parts[1])).toBe(currentSecsSinceEpoch());
+    });
+
+    it('checks for expiration on a link', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9');
+        expect(coveoLink1.expired).toBe(false);
+        const coveoLink2: CoveoLinkParam = new CoveoLinkParam(
+            '074af291-224b-4705-9dc5-a47bd80a8db9',
+            Date.now() - 6000
+        );
+        expect(coveoLink2.expired).toBe(true);
+    });
+
+    it('checks for expiration on a link if the timestamp is in the future', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9');
+        expect(coveoLink1.expired).toBe(false);
+        const coveoLink2: CoveoLinkParam = new CoveoLinkParam(
+            '074af291-224b-4705-9dc5-a47bd80a8db9',
+            Date.now() + 5000
+        );
+        expect(coveoLink2.expired).toBe(true);
+    });
+});
+
+describe('CoveoLinkPlugin', () => {
+    let link: LinkPlugin;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        const analyticsClient = createAnalyticsClientMock();
+        analyticsClient.getCurrentVisitorId = jest.fn(() => Promise.resolve('85698661-efdf-4c6d-9cad-c4632bf81ce3'));
+        link = new LinkPlugin({client: analyticsClient});
+    });
+
+    it('decorates links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com';
+        const result: string = await link.decorate(url);
+        expect(result).toBe('https://coveo.com/?cvo_id=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch());
+    });
+
+    it('decorates links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com/some/path/';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/some/path/?cvo_id=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch()
+        );
+    });
+
+    it('decorates links with valid urls and existing params', async () => {
+        const url: string = 'https://coveo.com/query?q=something&p=param';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/query?q=something&p=param&cvo_id=85698661efdf4c6d9cadc4632bf81ce3.' +
+                currentSecsSinceEpoch()
+        );
+    });
+
+    it('decorates links with valid urls, existing params and fragments', async () => {
+        const url: string = 'https://coveo.com/?q=something#frag';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/?q=something&cvo_id=85698661efdf4c6d9cadc4632bf81ce3.' +
+                currentSecsSinceEpoch() +
+                '#frag'
+        );
+    });
+
+    it('updates an existing decoration links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com/?cvo_id=c0b48880743e484f8044d7c37910c55b.1676298678';
+        const result: string = await link.decorate(url);
+        expect(result).toBe('https://coveo.com/?cvo_id=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch());
+    });
+
+    it('errors on invalid urls', async () => {
+        const url: string = 'somethingthatisobviouslynotaurl';
+        await expect(link.decorate(url)).rejects.toThrow('Invalid URL provided');
+    });
+
+    it('errors when there is no current clientId', async () => {
+        // initialize with missing clientId method
+        const analyticsClient = createAnalyticsClientMock();
+        analyticsClient.getCurrentVisitorId = undefined;
+        link = new LinkPlugin({client: analyticsClient});
+
+        const url: string = 'https://coveo.com/';
+        await expect(link.decorate(url)).rejects.toThrow('Could not retrieve current clientId');
+    });
+
+    it('can set a list of referrers on the client', () => {
+        const analyticsClient = createAnalyticsClientMock();
+        const mock: jest.Mock = jest.fn();
+        analyticsClient.setAcceptedLinkReferrers = mock;
+        link = new LinkPlugin({client: analyticsClient});
+        link.acceptFrom(['*.somedomain.com', 'www.coveo.com']);
+
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/plugins/link.ts
+++ b/src/plugins/link.ts
@@ -1,0 +1,98 @@
+import {URL} from 'url';
+import {validate as uuidvalidate, v4 as uuidv4} from 'uuid';
+import {Plugin, PluginOptions, PluginClass} from './BasePlugin';
+
+export class CoveoLinkParam {
+    public static readonly cvo_cid: string = 'cvo_id'; // name of the url parameter
+    private static readonly expirationTime: number = 5; // expirationTime in secs
+    private _clientId: string; //uuid
+    private _creationDate: number; //seconds since epoch to save space in serialized param
+
+    constructor(clientId: string, timestamp?: number) {
+        if (!uuidvalidate(clientId)) throw Error('Not a valid uuid');
+        this._clientId = clientId;
+        this._creationDate = Math.floor((timestamp || Date.now()) / 1000);
+    }
+
+    public toString(): string {
+        // strips the dashes and uses second granularity to save on url length.
+        return this.clientId.replace(/-/g, '') + '.' + this.creationDate.toString();
+    }
+
+    public get clientId(): string {
+        return this._clientId;
+    }
+
+    public get creationDate(): number {
+        return this._creationDate;
+    }
+
+    public get expired(): boolean {
+        const age = Math.floor(Date.now() / 1000) - this.creationDate;
+        return age < 0 || age > CoveoLinkParam.expirationTime;
+    }
+
+    public static fromString(input: string): CoveoLinkParam | null {
+        const parts = input.split('.');
+        if (parts.length === 2) {
+            const clientIdPart = parts[0];
+            const creationDate = parts[1];
+            if (clientIdPart.length === 32 && !isNaN(parseInt(creationDate))) {
+                const clientId =
+                    clientIdPart.substring(0, 8) +
+                    '-' +
+                    clientIdPart.substring(8, 12) +
+                    '-' +
+                    clientIdPart.substring(12, 16) +
+                    '-' +
+                    clientIdPart.substring(16, 20) +
+                    '-' +
+                    clientIdPart.substring(20, 32);
+                if (uuidvalidate(clientId)) {
+                    return new CoveoLinkParam(clientId, Number.parseInt(creationDate) * 1000);
+                }
+            }
+        }
+        return null;
+    }
+}
+
+export class LinkPlugin extends Plugin {
+    public static readonly Id = 'link';
+
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+    }
+
+    public getApi(name: string): Function | null {
+        switch (name) {
+            case 'decorate':
+                return this.decorate;
+            case 'acceptFrom':
+                return this.acceptFrom;
+            default:
+                return null;
+        }
+    }
+
+    public async decorate(urlString: string): Promise<string> {
+        // Note: clientId retrieval function is marked as optional
+        if (!this.client.getCurrentVisitorId) {
+            throw new Error('Could not retrieve current clientId');
+        }
+        try {
+            const url = new URL(urlString);
+            const clientId: string = await this.client.getCurrentVisitorId!();
+            url.searchParams.set(CoveoLinkParam.cvo_cid, new CoveoLinkParam(clientId).toString());
+            return url.toString();
+        } catch (error) {
+            throw new Error('Invalid URL provided');
+        }
+    }
+
+    public acceptFrom(acceptedReferrers: string[]) {
+        this.client.setAcceptedLinkReferrers!(acceptedReferrers);
+    }
+}
+
+export const Link: PluginClass = LinkPlugin;

--- a/src/plugins/svc.ts
+++ b/src/plugins/svc.ts
@@ -34,6 +34,17 @@ export class SVCPlugin extends BasePlugin {
         super({client, uuidGenerator});
     }
 
+    public getApi(name: string): Function | null {
+        const superCall: Function | null = super.getApi(name);
+        if (superCall !== null) return superCall;
+        switch (name) {
+            case 'setTicket':
+                return this.setTicket;
+            default:
+                return null;
+        }
+    }
+
     protected addHooks(): void {
         this.addHooksForEvent();
         this.addHooksForPageView();

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,8 +1,3 @@
-const nodeCrypto = require('crypto');
-global.crypto = {
-    getRandomValues: (buffer) => nodeCrypto.randomFillSync(buffer),
-};
-
 const documentMock = {
     referrer: 'http://somewhere.over/thereferrer',
     title: 'MAH PAGE',


### PR DESCRIPTION
This PR implements [this design](https://docs.google.com/document/d/1rxcG2gCBkWi6gcsLYYbZ4HIs_OhcymtaUXeGYFGEl3U/edit?usp=sharing) to round off our cross-site tracking capabilities. In cases where a customer wants to track a single anonymous browser session across different top-level domain, they can add a query parameter to the outgoing link, which will be picked up by the coveo.analytics.js script on the incoming page, if the following conditions apply:
- The parameter contains a valid uuid.
- The parameter was created at most 5 seconds ago.
- The referring page is present in a preset white list of accepted link referrers, which was set on the receiving page.
If a valid non-expired uuid is detected, and navigation is coming from a whitelisted page, this uuid will overwrite any previously stored uuid and will be valid on the entire toplevel receiving domain.

**Implementation notes**
- The reason for having an expiration on the links is to prevent users from accidentally persisting them in their cache or sending them to others.
- The parameter is called `cvo_id` and is formatted as `<UUID>.<secSinceEpoch>`. UUID has been stripped of dashes and we're using seconds to save 7 characters in the url.
- It's implemented as a plugin to isolate some of the commands on `coveoua`. Similar to GA design.
- I had to restructure and safeguard the plugin architecture a little bit, as the `executePlugin` command had access to *any* internal plugin function, not just the public ones.
- Referrer are matched using wildcards, so `*` matches all. `*.example.com` would match all subdomains under example.com. Empty whitelists will cause nothing to match.
- Inclusion of URL type mandated inclusion of `nodePolyfills` for the browser.
- Updated docs and added battery of tests.

**Testing notes**
You can try this out by creating two arbitrary domains (e.g. in `hosts`) and forwarding both of them to localhost.