### PR TITLE
UA-7368 remove rollup-plugin-polyfill-node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "coveo.analytics",
-    "version": "2.25.3",
+    "version": "2.26.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "coveo.analytics",
-            "version": "2.25.3",
+            "version": "2.26.0",
             "license": "MIT",
             "dependencies": {
                 "cross-fetch": "^3.1.5",
@@ -38,7 +38,6 @@
                 "prettier": "2.1.2",
                 "rimraf": "^3.0.2",
                 "rollup": "^2.50.6",
-                "rollup-plugin-polyfill-node": "^0.12.0",
                 "rollup-plugin-serve": "^1.0.1",
                 "rollup-plugin-terser": "^7.0.2",
                 "rollup-plugin-typescript2": "^0.27.0",
@@ -14196,80 +14195,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/rollup-plugin-polyfill-node": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
-            "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/plugin-inject": "^5.0.1"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0"
-            }
-        },
-        "node_modules/rollup-plugin-polyfill-node/node_modules/@rollup/plugin-inject": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
-            "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
-            "dev": true,
-            "dependencies": {
-                "@rollup/pluginutils": "^5.0.1",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.27.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/rollup-plugin-polyfill-node/node_modules/@rollup/plugin-inject/node_modules/@rollup/pluginutils": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
-            "dev": true,
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-walker": "^2.0.2",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/rollup-plugin-polyfill-node/node_modules/@types/estree": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-            "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-            "dev": true
-        },
-        "node_modules/rollup-plugin-polyfill-node/node_modules/magic-string": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-            "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-            "dev": true,
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.13"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/rollup-plugin-serve": {
@@ -30514,56 +30439,6 @@
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
-            }
-        },
-        "rollup-plugin-polyfill-node": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/rollup-plugin-polyfill-node/-/rollup-plugin-polyfill-node-0.12.0.tgz",
-            "integrity": "sha512-PWEVfDxLEKt8JX1nZ0NkUAgXpkZMTb85rO/Ru9AQ69wYW8VUCfDgP4CGRXXWYni5wDF0vIeR1UoF3Jmw/Lt3Ug==",
-            "dev": true,
-            "requires": {
-                "@rollup/plugin-inject": "^5.0.1"
-            },
-            "dependencies": {
-                "@rollup/plugin-inject": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz",
-                    "integrity": "sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==",
-                    "dev": true,
-                    "requires": {
-                        "@rollup/pluginutils": "^5.0.1",
-                        "estree-walker": "^2.0.2",
-                        "magic-string": "^0.27.0"
-                    },
-                    "dependencies": {
-                        "@rollup/pluginutils": {
-                            "version": "5.0.2",
-                            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-                            "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
-                            "dev": true,
-                            "requires": {
-                                "@types/estree": "^1.0.0",
-                                "estree-walker": "^2.0.2",
-                                "picomatch": "^2.3.1"
-                            }
-                        }
-                    }
-                },
-                "@types/estree": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-                    "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-                    "dev": true
-                },
-                "magic-string": {
-                    "version": "0.27.0",
-                    "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-                    "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-                    "dev": true,
-                    "requires": {
-                        "@jridgewell/sourcemap-codec": "^1.4.13"
-                    }
-                }
             }
         },
         "rollup-plugin-serve": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.27.0",
-        "rollup-plugin-polyfill-node": "^0.12.0",
         "stylelint": "^13.6.1",
         "ts-jest": "^25.2.0",
         "tsjs": "4.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import typescript from 'rollup-plugin-typescript2';
 import {terser} from 'rollup-plugin-terser';
 import serve from 'rollup-plugin-serve';
-import nodePolyfills from 'rollup-plugin-polyfill-node';
 import commonjs from '@rollup/plugin-commonjs';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import alias from '@rollup/plugin-alias';
@@ -56,7 +55,6 @@ const browserUMD = {
         },
     ],
     plugins: [
-        nodePolyfills(),
         browserFetch(),
         nodeResolve({preferBuiltins: true, only: ['uuid']}),
         versionReplace(),

--- a/src/plugins/link.ts
+++ b/src/plugins/link.ts
@@ -1,4 +1,3 @@
-import {URL} from 'url';
 import {validate as uuidvalidate, v4 as uuidv4} from 'uuid';
 import {Plugin, PluginOptions, PluginClass} from './BasePlugin';
 


### PR DESCRIPTION
**Context**

The rollup warnings were due to importing `URL` from the `url` module instead of referencing the global variable.
The `url` module is a nodejs module rather than a package.json dependency. When rollup created the browser bundle, it correctly detected the mismatch, and suggested adding node polyfills to the browser bundle.

**Solution**

This PR removes the import in favor of use the global (note that the other instance of `URL` in `analytics.ts` was already doing this). The global is available on [nodejs](https://nodejs.org/api/url.html#new-urlinput-base) and modern [browsers](https://caniuse.com/url).


**Aside 1**

Being transparent, I did not see any difference in bundle size with or without the plugin. In both cases, the `coveoua.browser` bundle was 94kb. Still I think there's a benefit in not introducing the dependency.

More interesting point though is the increase in the last few months. The last build on my machine was from Aug 5th, 2022. Comparison of the bundle sizes between then and now:

|file | Aug 2022 (kb)| Mar 2023 (kb)|
|---|---|---|
|coveoua.browser|61| 94
|coveoua|61|94
|library.es|81|122
|library|718|784
|react-native|6|708

Only worth focusing on the first three since these are the ones that run in the browser. The increase has been ~50% in the last 6 months. Maybe there are good reasons, but it feels suspicious? If the size continues to increase to the point where clients start complaining about it, we'd be in reactive rather than proactive mode, which is never fun.

Just want to put this on your radar for now, but some actions could include:
- Investigating what caused the recent increase
- Adding a github action that reports the increase in bundle size on PRs.
- Looking for optimizations and quick wins.


**Aside 2**
[Thought for a separate PR, curious to get your thoughts on this topic]

If we want `coveo.analytics.js` to be more resilient, and run in any JS runtime without crashing (e.g. [react-native]), it could be better to use a function to retrieve globals, that checks if they exist, and fails gracefully when they don't. e.g.

```
function getUrlGlobal() {
  return global.URL ? global.URL : null;
}

const URL = getUrlGlobal()

if (!URL) {
   // log warning or throw error or do nothing
   return;
}

new URL(...)
```

Alternatively, we can just let the code crash and have someone report it. Or maybe middle-ground, considering each global on a case-by-case basis.

Note: in the case of react-native specifically, we can [polyfill](https://www.npmjs.com/package/react-native-url-polyfill) just that bundle, but I don't like that we're operating blind. If we want to invest there, we'd ideally start with a test suite that can catch errors when unsupported globals are introduced to `coveo.analytics.js`, and only polyfill when we can guarantee that a) there is an error, and b) that adding the polyfill solves the error.