### PR TITLE
[UA-7615] Lowercase value provided through setClientId

### DIFF
--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -462,6 +462,12 @@ describe('custom clientId', () => {
         expect(await client.getCurrentVisitorId()).toBe('c7d57b22-4aa8-487a-a106-be5243885f0a');
     });
 
+    it('persists clientId in lowercase', async () => {
+        const client = new CoveoAnalyticsClient({});
+        client.setClientId('C7D57B22-4AA8-487A-A106-BE5243885F0A');
+        expect(await client.getCurrentVisitorId()).toBe('c7d57b22-4aa8-487a-a106-be5243885f0a');
+    });
+
     it('allows setting a custom consistent clientId given a string', async () => {
         const client = new CoveoAnalyticsClient({});
         client.setClientId('somestring', 'testNameSpace');

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -228,7 +228,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
     async setClientId(value: string, namespace?: string) {
         if (uuidValidate(value)) {
-            this.setCurrentVisitorId(value);
+            this.setCurrentVisitorId(value.toLowerCase());
         } else {
             if (!namespace) {
                 throw Error('Cannot generate uuid client id without a specific namespace string.');

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -148,7 +148,6 @@ describe('SearchPageClient', () => {
             anonymous: false,
             actionCause,
             customData,
-            queryPipeline: 'my-pipeline',
             language: 'en',
             clientId: 'visitor-id',
             facetState: fakeFacetState,


### PR DESCRIPTION
We're seeing some uppercase uuid's trying to pass the new pipelines syntax validation, and failing as we're expecting lowercase uuids. While not a terrible issue, the [uuid spec](https://www.ietf.org/rfc/rfc4122.txt) says uuids should be output lowercase, although they're case insensitive on input. It's good to explicitly cast the user provided value to lowercase before persisting just in case.

Also fixed a typescript nag on the side (the provided value for queryPipeline is always overwritten by the one from the doc entry). It does not affect the test.