### PR TITLE
[UA-7637] Restrict length of URL params

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
           ]
           deploymentPackage.command(command: 'package create', parameters: [
             version: env.PACKAGE_JSON_MAJOR_VERSION,
-            package-suffix: env.PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION,
+            'package-suffix': env.PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION,
             resolve: tgfResolveParameter,
             withDeploy: IS_MASTER,
             dryRun: !IS_MASTER

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,6 +114,7 @@ pipeline {
           ]
           deploymentPackage.command(command: 'package create', parameters: [
             version: env.PACKAGE_JSON_MAJOR_VERSION,
+            package-suffix: env.PACKAGE_JSON_MAJOR_MINOR_PATCH_VERSION,
             resolve: tgfResolveParameter,
             withDeploy: IS_MASTER,
             dryRun: !IS_MASTER

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -908,7 +908,7 @@ describe('ec events', () => {
     });
 
     const getParsedBody = (): any[] => {
-        return fetchMock.calls().map(([, {body}]) => JSON.parse(body.toString()));
+        return fetchMock.calls().map(([, {body}]: any) => JSON.parse(body.toString()));
     };
 
     const changeDocumentLocation = (url: string) => {

--- a/functional/svc-events.spec.ts
+++ b/functional/svc-events.spec.ts
@@ -106,7 +106,7 @@ describe('svc events', () => {
     });
 
     const getParsedBody = (): any[] => {
-        return fetchMock.calls().map(([, {body}]) => JSON.parse(body.toString()));
+        return fetchMock.calls().map(([, {body}]: any) => JSON.parse(body.toString()));
     };
 
     const changeDocumentLocation = (url: string) => {

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -6,7 +6,7 @@ import {
     DocumentSuggestion,
     FieldSuggestion,
 } from './caseAssistActions';
-import {mockFetch} from '../../tests/fetchMock';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
 import {TicketProperties} from '../plugins/svc';
 const {fetchMock, fetchMockBeforeEach} = mockFetch();
 import doNotTrack from '../donottrack';
@@ -90,8 +90,8 @@ describe('CaseAssistClient', () => {
     };
 
     const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
-        const [, {body}] = fetchMock.lastCall();
-        const content = JSON.parse(body.toString());
+        const body: string = lastCallBody(fetchMock);
+        const content = JSON.parse(body);
 
         expectMatchActionPayload(content, actionName, actionData);
         expectMatchTicketPayload(content, ticket);
@@ -125,7 +125,7 @@ describe('CaseAssistClient', () => {
         if (typeof propValue !== 'undefined') {
             if (typeof propValue === 'object') {
                 expect(content).toHaveProperty(propName);
-                expect(content[propName]).toMatchObject(propValue);
+                expect(content[propName]).toMatchObject(propValue as object);
             } else {
                 expect(content).toHaveProperty(propName, propValue);
             }

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -7,7 +7,6 @@ import {mockFetch} from '../../tests/fetchMock';
 import {BrowserRuntime} from './runtimeEnvironment';
 import * as doNotTrack from '../donottrack';
 import {Cookie} from '../cookieutils';
-import {v4 as uuidv4} from 'uuid';
 import {CoveoLinkParam} from '../plugins/link';
 
 const aVisitorId = '123';
@@ -142,6 +141,27 @@ describe('Analytics', () => {
             fine: 1,
             ok: 0,
         });
+    });
+
+    describe('should cap the maxlength for URL parameters at 128 characters for ua events', () => {
+        const desiredMax: number = 128;
+        const longUrl: string =
+            'http://somefakelocation.withalongurlnamewhichexceedsthemaximumnumberofcharactersbecauseiaddedarandomqueryparameterattheend.com?q=hi';
+        expect(longUrl.length).toBeGreaterThan(desiredMax);
+        async function testEventType(type: EventType) {
+            mockFetchRequestForEventType(type);
+            await client.sendEvent(type, {
+                location: type == EventType.view ? longUrl : undefined,
+                originLevel3: longUrl,
+            });
+            const [body] = getParsedBodyCalls();
+            if (type == EventType.view) expect(body.location.length).toBeLessThanOrEqual(desiredMax);
+            expect(body.originLevel3.length).toBeLessThanOrEqual(desiredMax);
+        }
+        it('- for view events', () => testEventType(EventType.view));
+        it('- for click events', () => testEventType(EventType.click));
+        it('- for search events', () => testEventType(EventType.search));
+        it('- for custom events', () => testEventType(EventType.custom));
     });
 
     it('should not remove #queryText for search events even if empty', async () => {

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -144,8 +144,8 @@ describe('Analytics', () => {
     });
 
     describe('should truncate the maxlength for URL parameters at 128 characters for ua events', () => {
-        const desiredMax: number = 2048;
-        const longUrl: string = 'http://coveo.com/?q=' + 'a'.repeat(2048);
+        const desiredMax: number = 128;
+        const longUrl: string = 'http://coveo.com/?q=' + 'a'.repeat(desiredMax);
         expect(longUrl.length).toBeGreaterThan(desiredMax);
         async function testEventType(type: EventType, url: string) {
             mockFetchRequestForEventType(type);

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -585,22 +585,21 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             }
         }
 
-        const maxLength: number = 2048;
         if (
             eventType == EventType.view ||
             eventType == EventType.click ||
             eventType == EventType.search ||
             eventType == EventType.custom
         ) {
-            rest.originLevel3 = this.limit(rest.originLevel3, maxLength);
+            rest.originLevel3 = this.limit(rest.originLevel3, 128);
         }
         if (eventType == EventType.view) {
-            rest.location = this.limit(rest.location, maxLength);
+            rest.location = this.limit(rest.location, 128);
         }
         if (eventType == 'pageview' || eventType == 'event') {
-            rest.referrer = this.limit(rest.referrer, maxLength);
-            rest.location = this.limit(rest.location, maxLength);
-            rest.page = this.limit(rest.page, maxLength);
+            rest.referrer = this.limit(rest.referrer, 2048);
+            rest.location = this.limit(rest.location, 2048);
+            rest.page = this.limit(rest.page, 2048);
         }
         return rest;
     }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -585,7 +585,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             }
         }
 
-        const maxLength: number = 128;
+        const maxLength: number = 2048;
         if (
             eventType == EventType.view ||
             eventType == EventType.click ||
@@ -616,7 +616,9 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
 
     private limit(input: string, length: number): string | undefined | null {
-        if (input == undefined || input == null) return input;
+        if (typeof input !== 'string') {
+            return input;
+        }
         return input.substring(0, length);
     }
 

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -3,7 +3,7 @@ import {createAnalyticsClientMock, visitorIdMock} from '../../tests/analyticsCli
 import {TestPlugin} from '../../tests/pluginMock';
 import {v4 as uuidv4} from 'uuid';
 import {PluginOptions} from '../plugins/BasePlugin';
-import {mockFetch} from '../../tests/fetchMock';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
 import {CookieStorage} from '../storage';
 import {libVersion} from '../version';
 
@@ -194,7 +194,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/pageview`);
-            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({somedata: 'asd'});
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({somedata: 'asd'});
         });
 
         it('can send view event with clientId', async () => {
@@ -203,7 +203,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/view?visitor=${visitorIdMock}`);
-            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString()).clientId).toBe(visitorIdMock);
+            expect(JSON.parse(lastCallBody(fetchMock)).clientId).toBe(visitorIdMock);
         });
 
         it('can send any event to the endpoint', async () => {
@@ -223,18 +223,16 @@ describe('simpleanalytics', () => {
         });
 
         describe('will restrict referrers and url lengths', () => {
-            const max: number = 128;
-            const reallyLongPath1: string =
-                '/some/really/long/path/which/will/be/longer/than/the/maximum/path/we/want/to/store/becasue/it/may/contain?queryParameters=whichcancontainencodedinformation';
-            const reallyLongPath2: string =
-                '/other/really/long/path/which/will/be/longer/than/the/maximum/path/we/want/to/store/becasue/it/may/contain?queryParameters=whichcancontainencodedinformation';
+            const max: number = 2048;
+            const reallyLongPath1: string = 'http://coveo.com/?q=' + 'a'.repeat(max);
+            const reallyLongPath2: string = 'http://coveo.com/?q=' + 'b'.repeat(max);
             expect(reallyLongPath1.length).toBeGreaterThan(max);
             expect(reallyLongPath2.length).toBeGreaterThan(max);
             it('does this for pageviews', async () => {
                 coveoua('init', 'MYTOKEN');
                 await coveoua('send', 'pageview', reallyLongPath1);
                 await coveoua('send', 'pageview', reallyLongPath2);
-                const body = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+                const body = JSON.parse(lastCallBody(fetchMock));
                 expect(body.dr.length).toBeLessThanOrEqual(max);
                 expect(body.dl.length).toBeLessThanOrEqual(max);
                 expect(body.dp.length).toBeLessThanOrEqual(max);
@@ -244,7 +242,7 @@ describe('simpleanalytics', () => {
                 await coveoua('send', 'pageview', reallyLongPath1);
                 await coveoua('send', 'pageview', reallyLongPath2);
                 await coveoua('send', 'event');
-                const body = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+                const body = JSON.parse(lastCallBody(fetchMock));
                 expect(body.dr.length).toBeLessThanOrEqual(max);
                 expect(body.dl.length).toBeLessThanOrEqual(max);
             });
@@ -259,7 +257,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({userId: 'something'});
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({userId: 'something'});
         });
 
         it('can set parameters using an object', async () => {
@@ -271,7 +269,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({userId: 'something'});
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({userId: 'something'});
         });
 
         it('can set a custom_website parameter on a collect event', async () => {
@@ -280,7 +278,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'pageview');
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('context_website', 'MY_WEBSITE');
         });
 
@@ -290,7 +288,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'pageview');
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(Object.keys(result).length).toBe(11);
         });
 
@@ -300,7 +298,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'pageview');
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(Object.keys(result).length).toBe(11);
         });
 
@@ -310,7 +308,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'pageview');
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(Object.keys(result).length).toBe(11);
         });
 
@@ -320,7 +318,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'pageview');
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(Object.keys(result).length).toBe(11);
         });
 
@@ -330,7 +328,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something'});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).toHaveProperty('customData.context_website', 'MY_WEBSITE');
         });
@@ -341,7 +339,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something'});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).not.toHaveProperty('customData');
         });
@@ -352,7 +350,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something'});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).not.toHaveProperty('customData');
         });
@@ -363,7 +361,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something'});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).not.toHaveProperty('customData');
         });
@@ -374,7 +372,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something'});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).not.toHaveProperty('customData');
         });
@@ -385,7 +383,7 @@ describe('simpleanalytics', () => {
             await coveoua('send', 'view', {somedata: 'something', customData: {context_website: 'MY_OTHER_WEBSITE'}});
 
             expect(fetchMock.calls().length).toBe(1);
-            let result = JSON.parse(fetchMock.lastCall()![1]!.body!.toString());
+            let result = JSON.parse(lastCallBody(fetchMock));
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).toHaveProperty('customData.context_website', 'MY_OTHER_WEBSITE');
         });
@@ -499,7 +497,7 @@ describe('simpleanalytics', () => {
 
             expect(fetchMock.calls().length).toBe(1);
             expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
-            expect(JSON.parse(fetchMock.lastCall()![1]!.body!.toString())).toEqual({});
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({});
         });
     });
 

--- a/src/donottrack.spec.ts
+++ b/src/donottrack.spec.ts
@@ -16,25 +16,25 @@ describe('doNotTrack', () => {
         if (hasNav) {
             Object.defineProperty(<any>navigator, 'globalPrivacyControl', {
                 get() {
-                    return options.navigatorGlobalPrivacyControl;
+                    return options!.navigatorGlobalPrivacyControl;
                 },
                 configurable: true,
             });
             Object.defineProperty(<any>navigator, 'doNotTrack', {
                 get() {
-                    return options.navigatorDoNotTrack;
+                    return options!.navigatorDoNotTrack;
                 },
                 configurable: true,
             });
             Object.defineProperty(<any>navigator, 'msDoNotTrack', {
                 get() {
-                    return options.navigatorMsDoNotTrack;
+                    return options!.navigatorMsDoNotTrack;
                 },
                 configurable: true,
             });
             Object.defineProperty(<any>window, 'doNotTrack', {
                 get() {
-                    return options.windowDoNotTrack;
+                    return options!.windowDoNotTrack;
                 },
                 configurable: true,
             });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -77,7 +77,7 @@ describe('InsightClient', () => {
     });
 
     const expectMatchPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
         expect(JSON.parse(body.toString())).toMatchObject({
             queryText: 'queryText',
@@ -93,7 +93,7 @@ describe('InsightClient', () => {
     };
 
     const expectMatchCustomEventPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
         expect(JSON.parse(body.toString())).toMatchObject({
             eventValue: actionCause,
@@ -107,7 +107,7 @@ describe('InsightClient', () => {
     };
 
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...meta};
         expect(JSON.parse(body.toString())).toMatchObject({
             actionCause,

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -1,4 +1,4 @@
-import {mockFetch} from '../../tests/fetchMock';
+import {lastCallBody, mockFetch} from '../../tests/fetchMock';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {
@@ -77,9 +77,9 @@ describe('InsightClient', () => {
     });
 
     const expectMatchPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...meta};
-        expect(JSON.parse(body.toString())).toMatchObject({
+        expect(JSON.parse(body)).toMatchObject({
             queryText: 'queryText',
             responseTime: 123,
             queryPipeline: 'my-pipeline',
@@ -93,9 +93,9 @@ describe('InsightClient', () => {
     };
 
     const expectMatchCustomEventPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...meta};
-        expect(JSON.parse(body.toString())).toMatchObject({
+        expect(JSON.parse(body)).toMatchObject({
             eventValue: actionCause,
             eventType: CustomEventsTypes[actionCause],
             lastSearchQueryUid: 'my-uid',
@@ -107,7 +107,7 @@ describe('InsightClient', () => {
     };
 
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...meta};
         expect(JSON.parse(body.toString())).toMatchObject({
             actionCause,

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
-import {mockFetch} from '../../tests/fetchMock';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
 import doNotTrack from '../donottrack';
 jest.mock('../donottrack', () => {
     return {
@@ -113,9 +113,9 @@ describe('SearchPageClient', () => {
     });
 
     const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
-        expect(JSON.parse(body.toString())).toEqual({
+        expect(JSON.parse(body)).toEqual({
             queryText: 'queryText',
             responseTime: 123,
             searchQueryUid: provider.getSearchUID(),
@@ -141,9 +141,9 @@ describe('SearchPageClient', () => {
     };
 
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
-        expect(JSON.parse(body.toString())).toEqual({
+        expect(JSON.parse(body)).toEqual({
             anonymous: false,
             actionCause,
             customData,
@@ -163,9 +163,9 @@ describe('SearchPageClient', () => {
         meta = {},
         eventType = CustomEventsTypes[actionCause]
     ) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
-        expect(JSON.parse(body.toString())).toEqual({
+        expect(JSON.parse(body)).toEqual({
             anonymous: false,
             eventValue: actionCause,
             eventType,
@@ -181,9 +181,9 @@ describe('SearchPageClient', () => {
     };
 
     const expectMatchCustomEventWithTypePayload = (eventValue: string, eventType: string, meta = {}) => {
-        const [, {body}]: any = fetchMock.lastCall();
+        const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
-        expect(JSON.parse(body.toString())).toEqual({
+        expect(JSON.parse(body)).toEqual({
             anonymous: false,
             eventValue,
             eventType,

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -3,7 +3,6 @@ import {
     SearchPageEvents,
     PartialDocumentInformation,
     CustomEventsTypes,
-    SmartSnippetFeedbackReason,
     OmniboxSuggestionsMetadata,
     StaticFilterToggleValueMetadata,
 } from './searchPageEvents';
@@ -114,7 +113,7 @@ describe('SearchPageClient', () => {
     });
 
     const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
         expect(JSON.parse(body.toString())).toEqual({
             queryText: 'queryText',
@@ -142,7 +141,7 @@ describe('SearchPageClient', () => {
     };
 
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
         expect(JSON.parse(body.toString())).toEqual({
             anonymous: false,
@@ -164,7 +163,7 @@ describe('SearchPageClient', () => {
         meta = {},
         eventType = CustomEventsTypes[actionCause]
     ) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
         expect(JSON.parse(body.toString())).toEqual({
             anonymous: false,
@@ -182,7 +181,7 @@ describe('SearchPageClient', () => {
     };
 
     const expectMatchCustomEventWithTypePayload = (eventValue: string, eventType: string, meta = {}) => {
-        const [, {body}] = fetchMock.lastCall();
+        const [, {body}]: any = fetchMock.lastCall();
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
         expect(JSON.parse(body.toString())).toEqual({
             anonymous: false,

--- a/tests/fetchMock.ts
+++ b/tests/fetchMock.ts
@@ -1,4 +1,4 @@
-import {sandbox} from 'fetch-mock';
+import {sandbox, FetchMockSandbox} from 'fetch-mock';
 import * as CrossFetch from 'cross-fetch';
 
 export function mockFetch() {
@@ -7,4 +7,10 @@ export function mockFetch() {
         fetchMock,
         fetchMockBeforeEach: () => jest.spyOn(CrossFetch, 'fetch').mockImplementation(fetchMock as any),
     };
+}
+
+export function lastCallBody(fetchMock: FetchMockSandbox): string {
+    const [, res]: any = fetchMock.lastCall();
+    const {body} = res!;
+    return body!.toString();
 }


### PR DESCRIPTION
We're not capturing full length URLs in the data platform (or at the very least, we should not be). Some URLs passed to us contain crypto blocks of thousands of characters, others contain base64'd information. All of this adds to a significant amount of storage. We've decided to limit maximum URL length to 2048 characters for now. If this is not enough, upping this value will be trivial.

This change amends an a existing processing step to truncate URLs if they are longer than 2048 characters on known events. Tests were added to both `analytics.spec.ts` (for classic) and `simpleanalytics.spec.ts`. This will not impact events other than view, click, search, custom or collect (dl,dp,dr).

Extra additions:
- Typescript type fixes
- Adding version to package name, so it's easier to identify which package is deploying in Spinnaker.