### PR TITLE
fix: UA-7689 Convert product position and quantity to number if possible

### DIFF
--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -13,5 +13,6 @@ export function isObject(o: any): boolean {
  * @returns The input, possibly coerced to a number.
  */
 export function coerceToNumber(input: any): any {
-    return input != '' && !isNaN(input) ? +input : input;
+    // @ts-ignore
+    return typeof input === 'string' && input != '' && !isNaN(input) ? +input : input;
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -13,11 +13,5 @@ export function isObject(o: any): boolean {
  * @returns The input, possibly coerced to a number.
  */
 export function coerceToNumber(input: any): any {
-    if (typeof input === 'string' && /^-?\d*\.?\d+$/.test(input)) {
-        const value = +input;
-        if (!Number.isNaN(value)) {
-            return value;
-        }
-    }
-    return input;
+    return input != '' && !isNaN(input) ? +input : input;
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -13,6 +13,5 @@ export function isObject(o: any): boolean {
  * @returns The input, possibly coerced to a number.
  */
 export function coerceToNumber(input: any): any {
-    // @ts-ignore
-    return typeof input === 'string' && input != '' && !isNaN(input) ? +input : input;
+    return typeof input === 'string' && input != '' && !Number.isNaN(+input) ? +input : input;
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -4,3 +4,20 @@ export const keysOf = Object.keys as <T>(o: T) => Extract<keyof T, string>[];
 export function isObject(o: any): boolean {
     return o !== null && typeof o === 'object' && !Array.isArray(o);
 }
+
+/**
+ * Attempt to coerce strings to number values following the "remove any prefix" logic.
+ * Any trailing non-number characters will fail parsing, in which case the input string is returned.
+ *
+ * @param input The input to possibly coerce to a number, if it is a string and parses to a number.
+ * @returns The input, possibly coerced to a number.
+ */
+export function coerceToNumber(input: any): any {
+    if (typeof input === 'string' && input.match(/^-?\d*\.?\d+$/)) {
+        const value = +input;
+        if (!Number.isNaN(value)) {
+            return value;
+        }
+    }
+    return input;
+}

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -6,14 +6,14 @@ export function isObject(o: any): boolean {
 }
 
 /**
- * Attempt to coerce strings to number values following the "remove any prefix" logic.
- * Any trailing non-number characters will fail parsing, in which case the input string is returned.
+ * Attempt to coerce strings to number values.
+ * Any non-number characters will fail parsing, in which case the input string is returned.
  *
  * @param input The input to possibly coerce to a number, if it is a string and parses to a number.
  * @returns The input, possibly coerced to a number.
  */
 export function coerceToNumber(input: any): any {
-    if (typeof input === 'string' && input.match(/^-?\d*\.?\d+$/)) {
+    if (typeof input === 'string' && /^-?\d*\.?\d+$/.test(input)) {
         const value = +input;
         if (!Number.isNaN(value)) {
             return value;

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -123,36 +123,36 @@ describe('EC plugin', () => {
             // @ts-ignore
             ec.addProduct({name: 'product', position: '50'});
 
-            const result1 = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(result1).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 50});
+            expect(result).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 50});
         });
 
         it('should keep original value if position is not a number', () => {
             // @ts-ignore
             ec.addProduct({name: 'product', position: 'abc'});
 
-            const result2 = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(result2).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 'abc'});
+            expect(result).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 'abc'});
         });
 
         it('should convert quantity to number if possible', () => {
             // @ts-ignore
             ec.addProduct({name: 'product', quantity: '50'});
 
-            const result1 = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(result1).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 50});
+            expect(result).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 50});
         });
 
         it('should keep original value if quantity is not a number', () => {
             // @ts-ignore
             ec.addProduct({name: 'product', quantity: 'abc'});
 
-            const result2 = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(result2).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 'abc'});
+            expect(result).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 'abc'});
         });
 
         describe('when the position is invalid', () => {

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -120,19 +120,55 @@ describe('EC plugin', () => {
         });
 
         it('should convert position to number if possible', () => {
-            testValidNumberConversion('position', 'pr1ps');
+            const validValues = ['13', '5.5'];
+            for (const value of validValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', position: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, any> = {...defaultResult, pr1nm: 'product', pr1ps: +value};
+
+                expect(result).toEqual(expected);
+            }
         });
 
         it('should keep original value if position is not a number', () => {
-            testInvalidNumberConversion('position', 'pr1ps');
+            const invalidValues = ['1-2-3', '.', '-', '123abc'];
+            for (const value of invalidValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', position: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, unknown> = {...defaultResult, pr1nm: 'product', pr1ps: value};
+
+                expect(result).toEqual(expected);
+            }
         });
 
         it('should convert quantity to number if possible', () => {
-            testValidNumberConversion('quantity', 'pr1qt');
+            const validValues = ['13', '0', '.0', '-10', '5.0', '-1.1', '3.124e7'];
+            for (const value of validValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', quantity: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, any> = {...defaultResult, pr1nm: 'product', pr1qt: +value};
+
+                expect(result).toEqual(expected);
+            }
         });
 
         it('should keep original value if quantity is not a number', () => {
-            testInvalidNumberConversion('quantity', 'pr1qt');
+            const invalidValues = ['1-2-3', '', '.', '-', '123abc', 'abc123'];
+            for (const value of invalidValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', quantity: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, unknown> = {...defaultResult, pr1nm: 'product', pr1qt: value};
+
+                expect(result).toEqual(expected);
+            }
         });
 
         describe('when the position is invalid', () => {
@@ -529,37 +565,5 @@ describe('EC plugin', () => {
         const result = beforeHook(eventType, payload);
         afterHook(eventType, result);
         return result;
-    };
-
-    const testValidNumberConversion = (source: keyof Product, target: string) => {
-        const validValues = ['13', '0', '.0', '-10', '5.0', '-1.1'];
-        for (const value of validValues) {
-            // @ts-ignore
-            ec.addProduct({name: 'product', [source]: value});
-
-            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
-            const expected: Record<string, any> = {...defaultResult, pr1nm: 'product', [target]: +value};
-            if (source === 'position' && expected[target] < 1) {
-                delete expected[target];
-            }
-
-            expect(result).toEqual(expected);
-        }
-    };
-
-    const testInvalidNumberConversion = (source: keyof Product, target: string) => {
-        const invalidValues = ['1-2-3', '', '.', '-', '5.', '123abc'];
-        for (const value of invalidValues) {
-            // @ts-ignore
-            ec.addProduct({name: 'product', [source]: value});
-
-            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
-            const expected: Record<string, unknown> = {...defaultResult, pr1nm: 'product', [target]: value};
-            if (source === 'position' && !expected[target]) {
-                delete expected[target];
-            }
-
-            expect(result).toEqual(expected);
-        }
     };
 });

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -119,6 +119,42 @@ describe('EC plugin', () => {
             expect(secondResult).toEqual({...defaultResult});
         });
 
+        it('should convert position to number if possible', () => {
+            // @ts-ignore
+            ec.addProduct({name: 'product', position: '50'});
+
+            const result1 = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result1).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 50});
+        });
+
+        it('should keep original value if position is not a number', () => {
+            // @ts-ignore
+            ec.addProduct({name: 'product', position: 'abc'});
+
+            const result2 = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result2).toEqual({...defaultResult, pr1nm: 'product', pr1ps: 'abc'});
+        });
+
+        it('should convert quantity to number if possible', () => {
+            // @ts-ignore
+            ec.addProduct({name: 'product', quantity: '50'});
+
+            const result1 = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result1).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 50});
+        });
+
+        it('should keep original value if quantity is not a number', () => {
+            // @ts-ignore
+            ec.addProduct({name: 'product', quantity: 'abc'});
+
+            const result2 = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result2).toEqual({...defaultResult, pr1nm: 'product', pr1qt: 'abc'});
+        });
+
         describe('when the position is invalid', () => {
             it('should warn when executing hook on added product', () => {
                 jest.spyOn(console, 'warn').mockImplementation();

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -159,7 +159,7 @@ describe('EC plugin', () => {
         });
 
         it('should keep original value if quantity is not a number', () => {
-            const invalidValues = ['1-2-3', '', '.', '-', '123abc', 'abc123'];
+            const invalidValues = ['1-2-3', '', '.', '5..', '-', '123abc', 'abc123'];
             for (const value of invalidValues) {
                 // @ts-ignore
                 ec.addProduct({name: 'product', quantity: value});

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -5,6 +5,7 @@ import {
     convertImpressionListToMeasurementProtocol,
 } from '../client/measurementProtocolMapping/commerceMeasurementProtocolMapper';
 import {BasePlugin, BasePluginEventTypes, PluginClass, PluginOptions} from './BasePlugin';
+import {coerceToNumber} from '../client/utils';
 
 export const ECPluginEventTypes = {
     ...BasePluginEventTypes,
@@ -166,14 +167,13 @@ export class ECPlugin extends BasePlugin {
     }
 
     private convertNumberTypes(product: Product) {
-        let updatedProduct = {...product};
-        if (Object.keys(product).indexOf('quantity') != -1 && typeof product.quantity != 'number') {
-            updatedProduct = {...updatedProduct, quantity: parseInt(String(product.quantity)) || product.quantity};
+        let updatedProduct: Product = {...product};
+        if ('quantity' in updatedProduct) {
+            updatedProduct.quantity = coerceToNumber(updatedProduct.quantity);
         }
-        if (Object.keys(product).indexOf('position') != -1 && typeof product.position != 'number') {
-            updatedProduct = {...updatedProduct, position: parseInt(String(product.position)) || product.position};
+        if ('position' in updatedProduct) {
+            updatedProduct.position = coerceToNumber(updatedProduct.position);
         }
-
         return updatedProduct;
     }
 

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -160,9 +160,21 @@ export class ECPlugin extends BasePlugin {
             .reduce((newPayload, product, index) => {
                 return {
                     ...newPayload,
-                    ...convertProductToMeasurementProtocol(product, index),
+                    ...convertProductToMeasurementProtocol(this.convertNumberTypes(product), index),
                 };
             }, {});
+    }
+
+    private convertNumberTypes(product: Product) {
+        let updatedProduct = {...product};
+        if (Object.keys(product).indexOf('quantity') != -1 && typeof product.quantity != 'number') {
+            updatedProduct = {...updatedProduct, quantity: parseInt(String(product.quantity)) || product.quantity};
+        }
+        if (Object.keys(product).indexOf('position') != -1 && typeof product.position != 'number') {
+            updatedProduct = {...updatedProduct, position: parseInt(String(product.position)) || product.position};
+        }
+
+        return updatedProduct;
     }
 
     private getImpressionPayload() {

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -166,7 +166,7 @@ export class ECPlugin extends BasePlugin {
             }, {});
     }
 
-    private convertNumberTypes(product: Product) {
+    private convertNumberTypes(product: Product): Product {
         let updatedProduct: Product = {...product};
         if ('quantity' in updatedProduct) {
             updatedProduct.quantity = coerceToNumber(updatedProduct.quantity);


### PR DESCRIPTION
While this is technically not a bug, it is much easier for us to do this rather than asking every customer to send numbers instead of strings in those fields.

This simply checks if product quantity and position are of type "number" and if not we try to convert it. If the result is not a number, we send the original string to the collect endpoint and get the appropriate error from the backend.

- [x] Add tests