### PR TITLE
SFINT-4963: Folded Results analytics events added in the insightClient

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -478,6 +478,17 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
+
+        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+        });
+
+        it.skip('should send proper payload for #logShowLessFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     describe('when the case metadata is included', () => {
@@ -1026,6 +1037,21 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
+
+        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, expectedMetadata);
+        });
+
+        it.skip('should send proper payload for #logShowLessFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     it('should enable analytics tracking by default', () => {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -478,6 +478,19 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
+        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #logShowLessFoldedResults', async () => {
+            await client.logShowLessFoldedResults();
+            expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+        });
+
+        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     describe('when the case metadata is included', () => {
@@ -1026,6 +1039,27 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
+
+        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #logShowLessFoldedResults', async () => {
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logShowLessFoldedResults(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults, expectedMetadata);
+        });
+
+        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
+
+        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     it('should enable analytics tracking by default', () => {
@@ -1139,18 +1173,4 @@ describe('InsightClient', () => {
             pageView,
         });
     });
-
-    it('should send proper payload for #logShowMoreFoldedResults', async () => {
-        await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
-        expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
-    });
-
-    it('should send proper payload for #logShowLessFoldedResults', async () => {
-        await client.logShowLessFoldedResults();
-        expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
-    });
-
-    it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
-
-    it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
 });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -478,17 +478,6 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
-
-        it('should send proper payload for #logShowMoreFoldedResults', async () => {
-            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
-            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
-        });
-
-        it.skip('should send proper payload for #logShowLessFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     describe('when the case metadata is included', () => {
@@ -1037,21 +1026,6 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
-
-        it('should send proper payload for #logShowMoreFoldedResults', async () => {
-            const expectedMetadata = {
-                ...fakeDocID,
-                ...expectedBaseCaseMetadata,
-            };
-            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID, baseCaseMetadata);
-            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, expectedMetadata);
-        });
-
-        it.skip('should send proper payload for #logShowLessFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     it('should enable analytics tracking by default', () => {
@@ -1165,4 +1139,18 @@ describe('InsightClient', () => {
             pageView,
         });
     });
+
+    it('should send proper payload for #logShowMoreFoldedResults', async () => {
+        await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #logShowLessFoldedResults', async () => {
+        await client.logShowLessFoldedResults();
+        expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+    });
+
+    it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
+
+    it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
 });

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -478,19 +478,15 @@ describe('InsightClient', () => {
                 expectedMetadata
             );
         });
-        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+        it('should send proper payload for #showMoreFoldedResults', async () => {
             await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
             expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
         });
 
-        it('should send proper payload for #logShowLessFoldedResults', async () => {
+        it('should send proper payload for #showLessFoldedResults', async () => {
             await client.logShowLessFoldedResults();
             expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
         });
-
-        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     describe('when the case metadata is included', () => {
@@ -1040,7 +1036,7 @@ describe('InsightClient', () => {
             );
         });
 
-        it('should send proper payload for #logShowMoreFoldedResults', async () => {
+        it('should send proper payload for #showMoreFoldedResults', async () => {
             const expectedMetadata = {
                 ...fakeDocID,
                 ...expectedBaseCaseMetadata,
@@ -1049,17 +1045,13 @@ describe('InsightClient', () => {
             expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, expectedMetadata);
         });
 
-        it('should send proper payload for #logShowLessFoldedResults', async () => {
+        it('should send proper payload for #showLessFoldedResults', async () => {
             const expectedMetadata = {
                 ...expectedBaseCaseMetadata,
             };
             await client.logShowLessFoldedResults(baseCaseMetadata);
             expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults, expectedMetadata);
         });
-
-        it.skip('should send proper payload for #makeShowMoreFoldedResults', async () => {});
-
-        it.skip('should send proper payload for #makeShowLessFoldedResults', async () => {});
     });
 
     it('should enable analytics tracking by default', () => {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -486,22 +486,13 @@ export class CoveoInsightClient {
 
     // public makeShowLessFoldedResults() {}
 
-    public async logShowMoreFoldedResults(
-        info: PartialDocumentInformation,
-        identifier: DocumentIdentifier,
-        metadata?: CaseMetadata
-    ) {
-        return this.logClickEvent(
-            SearchPageEvents.showMoreFoldedResults,
-            info,
-            identifier,
-            metadata ? generateMetadataToSend(metadata, false) : undefined
-        );
+    public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.logClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
     }
 
-    // public async logShowLessFoldedResults() {
-    //     return this.logCustomEvent(SearchPageEvents.showLessFoldedResults);
-    // }
+    public async logShowLessFoldedResults() {
+        return this.logCustomEvent(SearchPageEvents.showLessFoldedResults);
+    }
 
     private async getBaseCustomEventRequest(metadata?: Record<string, any>) {
         return {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -482,10 +482,6 @@ export class CoveoInsightClient {
         return this.coveoAnalyticsClient.sendClickEvent(payload);
     }
 
-    // public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {}
-
-    // public makeShowLessFoldedResults(metadata?: CaseMetadata) {}
-
     public async logShowMoreFoldedResults(
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -482,6 +482,27 @@ export class CoveoInsightClient {
         return this.coveoAnalyticsClient.sendClickEvent(payload);
     }
 
+    // public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {}
+
+    // public makeShowLessFoldedResults() {}
+
+    public async logShowMoreFoldedResults(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.showMoreFoldedResults,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    // public async logShowLessFoldedResults() {
+    //     return this.logCustomEvent(SearchPageEvents.showLessFoldedResults);
+    // }
+
     private async getBaseCustomEventRequest(metadata?: Record<string, any>) {
         return {
             ...(await this.getBaseEventRequest(metadata)),

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -482,16 +482,28 @@ export class CoveoInsightClient {
         return this.coveoAnalyticsClient.sendClickEvent(payload);
     }
 
-    // public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {}
+    // public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {}
 
-    // public makeShowLessFoldedResults() {}
+    // public makeShowLessFoldedResults(metadata?: CaseMetadata) {}
 
-    public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
-        return this.logClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
+    public async logShowMoreFoldedResults(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.showMoreFoldedResults,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
     }
 
-    public async logShowLessFoldedResults() {
-        return this.logCustomEvent(SearchPageEvents.showLessFoldedResults);
+    public async logShowLessFoldedResults(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.showLessFoldedResults,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
     }
 
     private async getBaseCustomEventRequest(metadata?: Record<string, any>) {


### PR DESCRIPTION
[SFINT-4963](https://coveord.atlassian.net/browse/SFINT-4963)

**As an Admin**
I want to have an accurate reporting of the usage of the folding feature in the Quantic Insight Panel.

Thus the need to expose the different analytics events that need to be logged when the user interacts with the Quantic Folded Result List component.

The insight analytics client will be then called by the Headless Folding controller to log the events.


Added the following analytics events:

- showMoreFoldedResults
- showLessFoldedResults

[SFINT-4963]: https://coveord.atlassian.net/browse/SFINT-4963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ