### PR TITLE
fix(SFINT-4992): fix a crash in HistoryStore

### DIFF
--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -184,4 +184,18 @@ describe('history', () => {
 
         expect(storageMock.setItem).toHaveBeenCalledTimes(2);
     });
+
+    it('should not throw when the content of localStorage is not an array', async () => {
+        storageMock.setItem(history.STORE_KEY, '{"foo":"bar"}');
+        let ex: any;
+        try {
+            const mostRecentElement = await historyStore.getMostRecentElement();
+            expect(mostRecentElement).toBeNull();
+            const localHistory = await historyStore.getHistoryAsync();
+            expect(localHistory).toStrictEqual([]);
+        } catch (err) {
+            ex = err;
+        }
+        expect(ex).toBeUndefined();
+    });
 });

--- a/src/history.ts
+++ b/src/history.ts
@@ -103,7 +103,7 @@ export class HistoryStore {
 
     getMostRecentElement(): HistoryElement | null {
         let currentHistory = this.getHistoryWithInternalTime();
-        if (currentHistory != null) {
+        if (Array.isArray(currentHistory)) {
             const sorted = currentHistory.sort((first: HistoryElement, second: HistoryElement) => {
                 // Internal time might not be set for all history element (on upgrade).
                 // Ensure to return the most recent element for which we have a value for internalTime.
@@ -132,10 +132,13 @@ export class HistoryStore {
     }
 
     private stripInternalTime(history: HistoryElement[]): HistoryElement[] {
-        return history.map((part) => {
-            const {name, time, value} = part;
-            return {name, time, value};
-        });
+        if (Array.isArray(history)) {
+            return history.map((part) => {
+                const {name, time, value} = part;
+                return {name, time, value};
+            });
+        }
+        return [];
     }
 
     private stripEmptyQuery(part: HistoryElement) {


### PR DESCRIPTION
[SFINT-4992](https://coveord.atlassian.net/browse/SFINT-4992)

For whatever reason, the value in `__coveo.analytics.history` in the localStorage when is valid JSON but NOT an array, makes the HistoryStore crash because it tries to call `.sort` and `.map` on something that isn't enforced to be an array.

I added safeguards against this, and a test to make sure it was covered.

[SFINT-4992]: https://coveord.atlassian.net/browse/SFINT-4992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ