### PR TITLE
Adding support for reverse-proxies in analytics.js library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ After the library has loaded sucessfully, you can interact with coveoua through 
 -   `coveoua('init', <COVEO_API_KEY>, <ENDPOINT>)`: Initializes the library with the given api key and endpoint. The following parameters are accepted
     -   COVEO_API_KEY (mandatory): A valid api key.
     -   ENDPOINT (optional): A string specifying the desired analytics endpoint. The default value is https://analytics.cloud.coveo.com/rest/ua. In case your organization is HIPAA enabled, you should override with https://analyticshipaa.cloud.coveo.com/rest/ua.
--   `coveoua('init', <COVEO_API_KEY>, {endpoint: <ENDPOINT>, plugins: <PLUGINS>})`: Initializes the library with the given api key, endpoint and plugins. The following parameters are accepted
+-   `coveoua('init', <COVEO_API_KEY>, {endpoint: <ENDPOINT>, isCustomEndpoint: <IS_CUSTOM_ENDPOINT>, plugins: <PLUGINS>})`: Initializes the library with the given api key, endpoint, isCustomEndpoint option and plugins. The following parameters are accepted
     -   COVEO_API_KEY (mandatory): A valid api key.
     -   ENDPOINT (optional): An object string specifying the desired analytics endpoint. The default value is https://analytics.cloud.coveo.com/rest/ua. In case your organization is HIPAA enabled, you should override with https://analyticshipaa.cloud.coveo.com/rest/ua.
+    -   IS_CUSTOM_ENDPOINT (optional): An boolean specifying if the desired analytics endpoint is custom. This means the library will not try to add any prefix logic like /rest/ua at the end of the provided endpoint. This can be useful when implementing analytics through a reverse-proxy solution like cloudfront.
     -   PLUGINS (optional): An array of known plugin names. See [plugins](#plugins) for more information.
 -   `coveoua('set', <NAME>, <VALUE>)`: Attempts to inject an attribute with given name and value on every logged event, overriding any existing value. Some payloads may reject attributes they do not support.
 -   `coveoua('set', <OBJECT>)`: Attempts to inject all attributes and values of the given object on every logged event, overriding any existing value. Some payloads may reject attributes they do not support.

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -9,6 +9,7 @@ export type AvailableActions = keyof CoveoUA;
 
 export interface CoveoUAOptions {
     endpoint?: string;
+    isCustomEndpoint?: boolean;
     plugins?: string[];
 }
 
@@ -31,6 +32,7 @@ export class CoveoUA {
             this.client = new CoveoAnalyticsClient({
                 token: token,
                 endpoint: this.getEndpoint(optionsOrEndpoint),
+                isCustomEndpoint: this.getIsCustomEndpoint(optionsOrEndpoint),
             });
         } else if (this.isAnalyticsClient(token)) {
             this.client = token;
@@ -72,9 +74,18 @@ export class CoveoUA {
         return Endpoints.default;
     }
 
+    private getIsCustomEndpoint(optionsOrEndpoint: string | CoveoUAOptions) {
+        if (typeof optionsOrEndpoint === 'string') {
+            return false;
+        } else if (optionsOrEndpoint?.isCustomEndpoint) {
+            return optionsOrEndpoint.isCustomEndpoint;
+        }
+        return false;
+    }
+
     // init initializes a new client intended to be used with a proxy that injects the access token.
     // @param endpoint is the endpoint of your proxy.
-    initForProxy(endpoint: string): void {
+    initForProxy(endpoint: string, isCustomEndpoint = false): void {
         if (!endpoint) {
             throw new Error(`You must pass your endpoint when you call 'initForProxy'`);
         }
@@ -85,6 +96,7 @@ export class CoveoUA {
 
         this.client = new CoveoAnalyticsClient({
             endpoint: endpoint,
+            isCustomEndpoint: isCustomEndpoint,
         });
     }
 


### PR DESCRIPTION
![image (4)](https://user-images.githubusercontent.com/12234108/235479142-b487c568-fac4-468d-8a05-eac182349c91.png)

We're working on adding documentation on how to serve analytics through a reverse-proxy for some of our customers. One problem with that approach is that when a customer would set an endpoint like this,

`coveoua('init', "xxd3323beb-702b-49bf-b563-698604eef887", "https://dwt17j4ahkcnx.cloudfront.net/rest/ua", );`

the effective endpoint would become "https://dwt17j4ahkcnx.cloudfront.net/rest/ua/rest"

This feature aims at fixing this behaviour, but also tries to improve the default logic when passing endpoints instead on relying on a condition to check if the url contains .cloud.coveo.com

It will effectively do the following.

1. Remove any trailing slash
2. If it's a custom endpoint, it will take the endpoint as is, and add the api version to it
3. if the endpoint has "/rest/ua" in it, it will effectively add the api version number to it, and return it
4. if the endpoint does not have /rest/ua in it, and its not a custom endpoint, it will add it to it.

This should support all the following endpoints that could be currently passed by customers.

- https://usageanalytics.com
- https://usageanalytics.com/
- https://usageanalytics.com/rest/ua
- https://analytics.cloud.coveo.com/rest/ua
- https://analytics.cloud.coveo.com/
- https://analytics.cloud.coveo.com

IT WILL NOT WORK if somebody would pass 

https://usageanalytics.com/rest but it would already not be working so that's ok.

This will allow customer to customize and endpoint like coveo.com/analytics that would be forwarded to analytics.cloud.coveo.com/rest/ua if they want to implement a reverse-proxy.

