### PR TITLE
Upgrade node to 14 (buster/bullseye)

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 RUN apt-get update && \
     apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \


### PR DESCRIPTION
The build is broken because (I think) the Debian distro (Stretch) that came with node-10 is longer in LTS support. Node is used to run the FT's on the backend. apt-get update fails as a result. This change upgrade the node version to 14, which should upgrade the Debian version to at least Buster.