### PR TITLE
[UA-7777] fix coveoua build

### DIFF
--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:14
 
 RUN apt-get update && \
-    apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
+    apt-get -y install xvfb libgtk2.0-0 libgbm-dev libnotify-dev libxss1 xauth \
+      gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
       libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
       libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
       libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \


### PR DESCRIPTION
After upgrading to node14 the build continues, but Cypress now has a few missing dependencies. The new ones added comes from this list:
https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
I did not remove older ones as I'm not sure why they were added in the first place.