### PR TITLE
Adding cloudfront invalidation properly on deployment

### DIFF
--- a/terraform/coveo-analytics-js/invalidate-cloudfront.tf
+++ b/terraform/coveo-analytics-js/invalidate-cloudfront.tf
@@ -13,6 +13,9 @@ variable "package_version" {
 }
 
 resource "null_resource" "invalidate-cloudfront" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
   # do not do the call if the id is empty
   count = local.cloudfront_id != "" ? 1 : 0
   provisioner "local-exec" {


### PR DESCRIPTION
For some reason, the cloudfront invalidation hasn't run in maybe a year or more on deployment of analyticsjs. 

It's not catastrophic because the TTL is 1 day, but since I deployed to production today, I don't want to discover an issue during the weekend, so I would like to fix this invalidation process today.