### PR TITLE
[UA-8726] Remove double quotation around dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.27.12",
+    "version": "2.28.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.js",
     "module": "dist/library.es.js",

--- a/src/history.spec.ts
+++ b/src/history.spec.ts
@@ -20,7 +20,7 @@ describe('history', () => {
         data = {
             name: 'name',
             value: 'value',
-            time: JSON.stringify(new Date()),
+            time: new Date().toISOString(),
         };
     });
 
@@ -99,7 +99,7 @@ describe('history', () => {
             historyElements.push({
                 name: 'name' + i,
                 value: 'value' + i,
-                time: JSON.stringify(new Date()),
+                time: new Date().toISOString(),
                 internalTime: new Date().getTime(),
             });
         }

--- a/src/hook/enhanceViewEvent.ts
+++ b/src/hook/enhanceViewEvent.ts
@@ -21,7 +21,7 @@ const addPageViewToHistory = async (pageViewValue: string) => {
     const historyElement = {
         name: 'PageView',
         value: pageViewValue,
-        time: JSON.stringify(new Date()),
+        time: new Date().toISOString(),
     };
     await store.addElementAsync(historyElement);
 };


### PR DESCRIPTION
Code in the History store used json stringification on Dates, which results in a '"doubleQuoted"' string being passed on the backend. ML has to strip these back out. Javascript has a [widely supported](https://caniuse.com/?search=toISOString) `toISOString()` api.