### PR TITLE
[UA-7863] Cookie path parameter

### DIFF
--- a/src/cookieutils.ts
+++ b/src/cookieutils.ts
@@ -48,5 +48,5 @@ function writeCookie(name: string, value: string, expirationDate?: Date, domain?
         `${name}=${value}` +
         (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
         (domain ? `;domain=${domain}` : '') +
-        ';SameSite=Lax';
+        ';path=/;SameSite=Lax';
 }


### PR DESCRIPTION
Cookie logic did not set the path explicitly, which causes browsers to use the current website's path when setting the Cookie. For some sites this results in multiple cookies, one for each subpath:
![image](https://github.com/coveo/coveo.analytics.js/assets/89939715/c5b67215-7b93-4a23-8357-79bab4f45952)
Setting an explicit path to `/` will mean the Cookie will be valid for all subpaths on that domain.
