### PR TITLE
[UA-7922] Patch fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7510,9 +7510,9 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
-            "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
             "funding": [
                 {
                     "type": "paypal",
@@ -23913,9 +23913,9 @@
             "dev": true
         },
         "fast-xml-parser": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz",
-            "integrity": "sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+            "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
             "peer": true,
             "requires": {
                 "strnum": "^1.0.5"


### PR DESCRIPTION
Dependabot flagged a high vulnerability in fast-xml-parser, which is a transitive dependency of another package (react-native). Upgrading in package log.json.