### PR TITLE
feat(SFINT-5080): Add missing result actions analytics

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -324,6 +324,16 @@ describe('InsightClient', () => {
             expectMatchDocumentPayload(SearchPageEvents.copyToClipboard, fakeDocInfo, fakeDocID);
         });
 
+        it('should send proper payload for #caseSendEmail', async () => {
+            await client.logCaseSendEmail(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.caseSendEmail, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #feedItemTextPost', async () => {
+            await client.logFeedItemTextPost(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.feedItemTextPost, fakeDocInfo, fakeDocID);
+        });
+
         it('should send proper payload for #documentQuickview', async () => {
             const expectedMetadata = {
                 ...fakeDocID,
@@ -854,6 +864,28 @@ describe('InsightClient', () => {
             };
             await client.logCopyToClipboard(fakeDocInfo, fakeDocID, metadata);
             expectMatchDocumentPayload(SearchPageEvents.copyToClipboard, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseSendEmail', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logCaseSendEmail(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.caseSendEmail, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #feedItemTextPost', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logFeedItemTextPost(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.feedItemTextPost, fakeDocInfo, expectedMetadata);
         });
 
         it('should send proper payload for #documentQuickview', async () => {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -276,6 +276,28 @@ export class CoveoInsightClient {
         );
     }
 
+    public logCaseSendEmail(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
+        return this.logClickEvent(
+            SearchPageEvents.caseSendEmail,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logFeedItemTextPost(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.feedItemTextPost,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
     public logDocumentQuickview(
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -279,6 +279,14 @@ export enum SearchPageEvents {
      */
     copyToClipboard = 'copyToClipboard',
     /**
+     * Identifies the click event that gets logged when a user clicks the Send As Email result action.
+     */
+    caseSendEmail = 'Case.SendEmail',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Send As Email result action.
+     */
+    feedItemTextPost = 'FeedItem.TextPost',
+    /**
      * Identifies the click event that gets logged when a user clicks the Attach To Case result action.
      */
     caseAttach = 'caseAttach',

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -283,7 +283,7 @@ export enum SearchPageEvents {
      */
     caseSendEmail = 'Case.SendEmail',
     /**
-     * Identifies the click event that gets logged when a user clicks the Send As Email result action.
+     * Identifies the click event that gets logged when a user clicks the Post To Feed result action.
      */
     feedItemTextPost = 'FeedItem.TextPost',
     /**


### PR DESCRIPTION
[SFINT-5080]

Adding the two result actions missing analytics event to the client.

`Case.SendEmail` already exists in the Coveo for Salesforce integration Insight Panel. I am adding it so we can use it in the Hosted Insight Panel and Quantic/Headless.

On the left is the new event being sent in the Hosted Insight Panel (using this PR's code inside Headless), on the right is the event in the previous Insight Panel (Aura)
![image](https://github.com/coveo/coveo.analytics.js/assets/2488155/21c61aa1-b0f0-4d7d-a2d8-1da47f45e828)

`FeedItem.TextPost` also already exists in the Coveo for Salesforce integration Insight Panel. Also adding it for the same reasons:

On the left is the new event being sent in the Hosted Insight Panel  (using this PR's code inside Headless), on the right is the event in the previous Insight Panel (Aura)
![image](https://github.com/coveo/coveo.analytics.js/assets/2488155/4e3ef194-5776-4304-b344-71926d00cbb6)

There are slight differences but I do not think they are important?
@tedre191 Remember anything about the fields that are different?

[SFINT-5080]: https://coveord.atlassian.net/browse/SFINT-5080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ