### PR TITLE
[KIT-2568] Support logging facet excludes in insight client

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -210,6 +210,18 @@ describe('InsightClient', () => {
             expectMatchPayload(SearchPageEvents.facetSelect, meta);
         });
 
+        it('should send proper payload for #logFacetExclude', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetExclude(meta);
+            expectMatchPayload(SearchPageEvents.facetExclude, meta);
+        });
+
         it('should send proper payload for #logFacetDeselect', async () => {
             const meta = {
                 facetField: '@foo',
@@ -613,6 +625,29 @@ describe('InsightClient', () => {
 
             await client.logFacetSelect(metadata);
             expectMatchPayload(SearchPageEvents.facetSelect, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetExclude', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetExclude(metadata);
+            expectMatchPayload(SearchPageEvents.facetExclude, expectedMetadata);
         });
 
         it('should send proper payload for #logFacetDeselect', async () => {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -141,6 +141,11 @@ export class CoveoInsightClient {
         return this.logSearchEvent(SearchPageEvents.facetSelect, metadataToSend);
     }
 
+    public logFacetExclude(metadata: InsightFacetMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetExclude, metadataToSend);
+    }
+
     public logFacetDeselect(metadata: InsightFacetMetadata) {
         const metadataToSend = generateMetadataToSend(metadata);
         return this.logSearchEvent(SearchPageEvents.facetDeselect, metadataToSend);


### PR DESCRIPTION
Change is done as a part of ongoing Headless changes to support facet value excluding:
https://coveord.atlassian.net/browse/KIT-2554

Before we can log insight analytics for facet exclusion in the headless controller, we must first update the CoveoInsightController to expose such feature