### PR TITLE
support trackingId

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -555,7 +555,7 @@ describe('ec events', () => {
 
     it('context_website does not overwrite trackingId', async () => {
         const contextWebsite = 'tracksite';
-        const trackingId = 'tracksite';
+        const trackingId = 'trackingid';
         await coveoua('set', 'custom', {context_website: contextWebsite});
         await coveoua('set', 'trackingId', trackingId);
         await coveoua('send', 'pageview');

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -524,6 +524,52 @@ describe('ec events', () => {
         });
     });
 
+    it('should be able to set trackingId using set action', async () => {
+        const trackingId = 'tracksite';
+        await coveoua('set', 'trackingId', trackingId);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: trackingId,
+        });
+    });
+
+    it('should be able to set trackingId with context_website', async () => {
+        const contextWebsite = 'tracksite';
+        await coveoua('set', 'custom', {context_website: contextWebsite});
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: contextWebsite,
+            context_website: contextWebsite,
+        });
+    });
+
+    it('context_website does not overwrite trackingId', async () => {
+        const contextWebsite = 'tracksite';
+        const trackingId = 'tracksite';
+        await coveoua('set', 'custom', {context_website: contextWebsite});
+        await coveoua('set', 'trackingId', trackingId);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: trackingId,
+            context_website: contextWebsite,
+        });
+    });
+
     describe('with auto-detection of userId', () => {
         describe('with API key', () => {
             beforeEach(() => {

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -439,6 +439,29 @@ describe('Analytics', () => {
         });
     });
 
+    describe('with context_website is set', () => {
+        const contextWebsite = 'yourbestfriend.com';
+        const trackingId = 'yourfavaritefood.ca ';
+        beforeEach(() => {
+            client = new CoveoAnalyticsClient({
+                token: 'xtoken',
+                endpoint: anEndpoint,
+                version: A_VERSION,
+            });
+            mockFetchRequestForEventType(EventType.view);
+        });
+        it('should set trackingId when trackingId is not specified', async () => {
+            await client.sendEvent(EventType.view, {custom: {context_website: contextWebsite}});
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(contextWebsite);
+        });
+        it('should not set trackingId when trackingId is specified', async () => {
+            await client.sendEvent(EventType.view, {trackingId: trackingId, custom: {context_website: contextWebsite}});
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(trackingId);
+        });
+    });
+
     it('should support clearing cookies for visitorId and historyStore', () => {
         const visitorId = 'foo';
         const history = {name: 'foo', time: '123', value: 'bar'};

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -450,11 +450,13 @@ describe('Analytics', () => {
             });
             mockFetchRequestForEventType(EventType.view);
         });
+
         it('should set trackingId when trackingId is not specified', async () => {
             await client.sendEvent(EventType.view, {custom: {context_website: contextWebsite}});
             const [body] = getParsedBodyCalls();
             expect(body.trackingId).toBe(contextWebsite);
         });
+
         it('should not set trackingId when trackingId is specified', async () => {
             await client.sendEvent(EventType.view, {trackingId: trackingId, custom: {context_website: contextWebsite}});
             const [body] = getParsedBodyCalls();

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -344,6 +344,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     async resolvePayloadForParameters(eventType: EventType | string, parameters: any) {
         const {usesMeasurementProtocol = false} = this.eventTypeMapping[eventType] || {};
 
+        const addTrackingIdStep: ProcessPayloadStep = (currentPayload) => this.setTrackingId(currentPayload);
         const cleanPayloadStep: ProcessPayloadStep = (currentPayload) =>
             this.removeEmptyPayloadValues(currentPayload, eventType);
         const validateParams: ProcessPayloadStep = (currentPayload) => this.validateParams(currentPayload, eventType);
@@ -357,6 +358,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
                 : this.mapCustomParametersToCustomData(currentPayload);
 
         const payloadToSend = await [
+            addTrackingIdStep,
             cleanPayloadStep,
             validateParams,
             processMeasurementProtocolConversionStep,
@@ -378,7 +380,6 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
         const parametersToSend = await this.resolveParameters(eventType, ...payload);
         const payloadToSend = await this.resolvePayloadForParameters(eventType, parametersToSend);
-
         return {
             eventType: eventTypeToSend,
             payload: payloadToSend,
@@ -618,6 +619,16 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         if (isApiKey(this.options.token) && !userId) {
             rest['userId'] = 'anonymous';
             return rest;
+        } else {
+            return payload;
+        }
+    }
+
+    private setTrackingId(payload: IRequestPayload): IRequestPayload {
+        const {trackingId, custom, ...rest} = payload;
+        if (!trackingId && custom && isObject(custom) && 'context_website' in custom) {
+            rest['trackingId'] = custom.context_website;
+            return {custom, ...rest};
         } else {
             return payload;
         }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -628,7 +628,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         const {trackingId, custom, ...rest} = payload;
         if (!trackingId && custom && isObject(custom) && 'context_website' in custom) {
             rest['trackingId'] = custom.context_website;
-            return {custom, ...rest};
+            return {custom: custom, ...rest};
         } else {
             return payload;
         }

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -344,7 +344,8 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     async resolvePayloadForParameters(eventType: EventType | string, parameters: any) {
         const {usesMeasurementProtocol = false} = this.eventTypeMapping[eventType] || {};
 
-        const addTrackingIdStep: ProcessPayloadStep = (currentPayload) => this.setTrackingId(currentPayload);
+        const addTrackingIdStep: ProcessPayloadStep = (currentPayload) =>
+            this.setTrackingIdFromContextWebsiteIfTrackingIdNotPresent(currentPayload);
         const cleanPayloadStep: ProcessPayloadStep = (currentPayload) =>
             this.removeEmptyPayloadValues(currentPayload, eventType);
         const validateParams: ProcessPayloadStep = (currentPayload) => this.validateParams(currentPayload, eventType);
@@ -624,7 +625,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         }
     }
 
-    private setTrackingId(payload: IRequestPayload): IRequestPayload {
+    private setTrackingIdFromContextWebsiteIfTrackingIdNotPresent(payload: IRequestPayload): IRequestPayload {
         const {trackingId, custom, ...rest} = payload;
         if (!trackingId && custom && isObject(custom) && 'context_website' in custom) {
             rest['trackingId'] = custom.context_website;

--- a/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
+++ b/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
@@ -44,6 +44,7 @@ const coveoExtensionsKeys = [
     'searchUid',
     'permanentId',
     'contentLocale',
+    'trackingId',
 ];
 
 export const baseMeasurementProtocolKeysMapping: {[name: string]: string} = {

--- a/src/coveoua/simpleanalytics.spec.ts
+++ b/src/coveoua/simpleanalytics.spec.ts
@@ -387,6 +387,30 @@ describe('simpleanalytics', () => {
             expect(result).toHaveProperty('somedata', 'something');
             expect(result).toHaveProperty('customData.context_website', 'MY_OTHER_WEBSITE');
         });
+
+        it('can set trackingId', async () => {
+            const trackingId = 'yourbestfriend';
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'trackingId', trackingId);
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toHaveProperty('trackingId', trackingId);
+        });
+
+        it('context_website does not overwrite trackingId', async () => {
+            const trackingId = 'yourbestfriend';
+            const contextWebsite = 'yoursite';
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'custom', {context_website: contextWebsite});
+            coveoua('set', 'trackingId', trackingId);
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toHaveProperty('trackingId', trackingId);
+        });
     });
 
     describe('onLoad', () => {


### PR DESCRIPTION
### [UA-7856](https://coveord.atlassian.net/browse/UA-7856)
1.  add trackingId in the payload when sending events
2. `trackingId` in the payload is set to `trackingId` or `context_website`. When `trackingId` is not set explicitly AND `context_website` is present, `trackingId` will be set with `context_website` 

[UA-7856]: https://coveord.atlassian.net/browse/UA-7856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ