### PR TITLE
feat(genQA): added "stream end" custom event

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1457,4 +1457,18 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
         expectMatchDescription(built.description, SearchPageEvents.openGeneratedAnswerSource, meta);
     });
+
+    it('should send proper payload for #logGeneratedAnswerStreamEnd', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true};
+        await client.logGeneratedAnswerStreamEnd(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerStreamEnd', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true};
+        const built = await client.makeGeneratedAnswerStreamEnd(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
 });

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -38,6 +38,7 @@ import {
     SmartSnippetLinkMeta,
     GeneratedAnswerFeedbackMeta,
     GeneratedAnswerCitationMeta,
+    GeneratedAnswerStreamEndMeta,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -916,5 +917,13 @@ export class CoveoSearchPageClient {
 
     public async logRetryGeneratedAnswer() {
         return (await this.makeRetryGeneratedAnswer()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeGeneratedAnswerStreamEnd(metadata: GeneratedAnswerStreamEndMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerStreamEnd, metadata);
+    }
+
+    public async logGeneratedAnswerStreamEnd(metadata: GeneratedAnswerStreamEndMeta) {
+        return (await this.makeGeneratedAnswerStreamEnd(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -310,6 +310,10 @@ export enum SearchPageEvents {
      * Identifies the custom event that gets logged when a user opens a generated answer citation.
      */
     openGeneratedAnswerSource = 'openGeneratedAnswerSource',
+    /**
+     * Identified the custom event that gets logged when a generated answer stream is completed.
+     */
+    generatedAnswerStreamEnd = 'generatedAnswerStreamEnd',
 }
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
@@ -355,6 +359,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.likeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.dislikeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.openGeneratedAnswerSource]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerStreamEnd]: 'generatedAnswer',
 };
 
 export interface StaticFilterMetadata {
@@ -489,8 +494,14 @@ export interface SmartSnippetDocumentIdentifier {
 
 export type PartialDocumentInformation = Omit<DocumentInformation, 'actionCause' | 'searchQueryUid'>;
 
-export interface GeneratedAnswerFeedbackMeta {
+interface GeneratedAnswerBaseMeta {
     generativeQuestionAnsweringId: string;
+}
+
+export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {}
+
+export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
+    answerGenerated: boolean;
 }
 
 export interface GeneratedAnswerCitationMeta {


### PR DESCRIPTION
Added a custom event that will be dispatched when the Gen QA stream completes.
The event will contain as metadata the stream ID and a boolean value returned by the stream indicating whether the stream contained a generated answer.