### PR TITLE
added "modules" sub-package

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,8 +1,9 @@
 {
     "name": "modules",
     "private": true,
-    "main": "../dist/library.js",
-    "browser": "../dist/library.es.js",
+    "main": "../dist/library.cjs",
+    "module": "../dist/library.mjs",
+    "browser": "../dist/browser.mjs",
     "types": "./../dist/definitions/coveoua/library.d.ts",
     "files": [
         "../dist"

--- a/modules/package.json
+++ b/modules/package.json
@@ -4,7 +4,7 @@
     "main": "../dist/library.cjs",
     "module": "../dist/library.mjs",
     "browser": "../dist/browser.mjs",
-    "types": "./../dist/definitions/coveoua/library.d.ts",
+    "types": "../dist/definitions/coveoua/library.d.ts",
     "files": [
         "../dist"
     ]

--- a/modules/package.json
+++ b/modules/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "modules",
+    "private": true,
+    "main": "../dist/library.js",
+    "browser": "../dist/library.es.js",
+    "types": "./../dist/definitions/coveoua/library.d.ts",
+    "files": [
+        "../dist"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "plist": "3.0.5"
     },
     "files": [
+        "modules/",
         "dist/**/*.d.ts",
         "dist/**/*.js",
         "dist/**/*.js.map",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "coveo.analytics",
     "version": "2.28.12",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
-    "main": "dist/library.js",
-    "module": "dist/library.es.js",
+    "main": "dist/library.cjs",
+    "module": "dist/browser.mjs",
     "browser": "dist/coveoua.browser.js",
     "types": "dist/definitions/coveoua/library.d.ts",
     "scripts": {
@@ -66,8 +66,8 @@
     "files": [
         "modules/",
         "dist/**/*.d.ts",
-        "dist/**/*.js",
-        "dist/**/*.js.map",
+        "dist/**/*.{js, mjs, cjs}",
+        "dist/**/*.{js, mjs, cjs}.map",
         "src/**/*.ts",
         "react-native/",
         "LICENSE"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,6 +10,10 @@ import {resolve} from 'path';
 import packageJson from './package.json' assert {type: 'json'};
 import * as url from 'url';
 
+/**
+ * @typedef {import('rollup').RollupOptions} RollupOptions
+ */
+
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const browserFetch = () =>
@@ -33,7 +37,10 @@ const versionReplace = () =>
         'process.env.PKG_VERSION': JSON.stringify(packageJson.version),
     });
 
-const browserUMD = {
+/**
+ * @satisfies {RollupOptions}
+ */
+const coveouaConfig = {
     input: './src/coveoua/browser.ts',
     output: [
         {
@@ -75,12 +82,15 @@ const browserUMD = {
     ],
 };
 
-const nodeCJS = {
+/**
+ * @satisfies {RollupOptions}
+ */
+const nodeModulesConfig = {
     input: './src/coveoua/library.ts',
-    output: {
-        file: './dist/library.js',
-        format: 'cjs',
-    },
+    output: /** @type {const} */ (['cjs', 'es']).map((format) => ({
+        file: `./dist/library.${format === 'cjs' ? 'cjs' : 'mjs'}`,
+        format,
+    })),
     plugins: [
         nodeResolve({mainFields: ['main'], preferBuiltins: true}),
         versionReplace(),
@@ -90,12 +100,15 @@ const nodeCJS = {
     ],
 };
 
-const browserESM = {
+/**
+ * @satisfies {RollupOptions}
+ */
+const browserModulesConfig = {
     input: './src/coveoua/headless.ts',
-    output: {
-        file: './dist/library.es.js',
-        format: 'es',
-    },
+    output: /** @type {const} */ (['cjs', 'es']).map((format) => ({
+        file: `./dist/browser.${format === 'cjs' ? 'cjs' : 'mjs'}`,
+        format,
+    })),
     plugins: [
         browserFetch(),
         nodeResolve({preferBuiltins: true}),
@@ -107,7 +120,10 @@ const browserESM = {
     ],
 };
 
-const libRN = {
+/**
+ * @satisfies {RollupOptions}
+ */
+const reactNativeConfig = {
     external: ['react-native', 'cross-fetch'],
     input: './src/react-native/index.ts',
     output: {
@@ -126,4 +142,4 @@ const libRN = {
     ],
 };
 
-export default [browserUMD, nodeCJS, browserESM, libRN];
+export default [coveouaConfig, nodeModulesConfig, browserModulesConfig, reactNativeConfig];


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2003

When importing `coveo.analytics` with Next.js, we get an error on the client side. This is because, on the client side, Next.js imports the "browser" field from the `package.json` file. In `coveo.analytics`, this field refers to the `coveoua` Javascript file, which doesn't have the same exports as the type definitions and globally defines `coveoua`.

Additionally, unlike the "main" export, the "module" export references the global `window` object.

In this PR, I did three things:
1. I renamed the entrypoints so they reflect their real use case
   * `library.es.js` became `browser.mjs`
   * `library.js` became `library.cjs`.
2. I ensured there's a corresponding ESM/CJS output for every output.
   * I added `library.mjs` and `browser.cjs`
3. I added a "modules` sub-package which exports the same modules as the type definitions across the board.
   * Can be imported using `import { someStuff } from 'coveo.analytics/modules'`.
   * I added this module instead of fixing the fields in the original `package.json` since doing so would've been a breaking change.

I'm not 100% certain if I want to merge this PR. There are ways to work around this issue in implementations, and exporting a new sub-package is pretty ugly. I'm curious what you guys think.