### PR TITLE
fix: add @types/uuid into prd dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.28.12",
             "license": "MIT",
             "dependencies": {
+                "@types/uuid": "^9.0.0",
                 "cross-fetch": "^3.1.5",
                 "react-native-get-random-values": "^1.8.0",
                 "uuid": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     },
     "license": "MIT",
     "dependencies": {
+        "@types/uuid": "^9.0.0",
         "cross-fetch": "^3.1.5",
         "uuid": "^9.0.0",
         "react-native-get-random-values": "^1.8.0"


### PR DESCRIPTION
CAJS exposes the types of a package in its artifacts without including the package where the types are exposed.
![image](https://github.com/coveo/coveo.analytics.js/assets/12366410/1c77457e-85cb-4388-a5ec-f3934db8e080)
This fix that by putting `@types/uuid` as a prod dependency.