### PR TITLE
use beacon api to send event depending on event type

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -393,7 +393,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
                     this.afterSendHooks.map((hook) => hook(eventType, {...parametersToSend, ...remainingPayload}))
                 );
                 await this.deferExecution();
-                return (await this.sendFromBufferWithFetch()) as TResponse | void;
+                return (await this.sendFromBuffer()) as TResponse | void;
             },
         };
     }
@@ -406,11 +406,11 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
         return new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    private async sendFromBufferWithFetch(): Promise<AnyEventResponse | void> {
+    private async sendFromBuffer(): Promise<AnyEventResponse | void> {
         const popped = this.bufferedRequests.shift();
         if (popped) {
             const {eventType, payload} = popped;
-            return this.runtime.client.sendEvent(eventType, payload);
+            return this.runtime.getClientDependingOnEventType(eventType).sendEvent(eventType, payload);
         }
     }
 

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -26,7 +26,6 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         };
 
         // tslint:disable-next-line: no-console
-        console.log(`Sending beacon for "${eventType}" with: `, JSON.stringify(payload));
         navigator.sendBeacon(url, body as any); // https://github.com/microsoft/TypeScript/issues/38715
         return;
     }

--- a/src/client/runtimeEnvironment.ts
+++ b/src/client/runtimeEnvironment.ts
@@ -4,10 +4,12 @@ import {hasLocalStorage, hasCookieStorage} from '../detector';
 import {AnalyticsRequestClient, IAnalyticsClientOptions, NoopAnalyticsClient} from './analyticsRequestClient';
 import {AnalyticsFetchClient} from './analyticsFetchClient';
 import {BufferedRequest} from './analytics';
+import {EventType} from '../events';
 
 export interface IRuntimeEnvironment {
     storage: WebStorage;
     client: AnalyticsRequestClient;
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient;
 }
 
 export class BrowserRuntime implements IRuntimeEnvironment {
@@ -33,6 +35,10 @@ export class BrowserRuntime implements IRuntimeEnvironment {
             }
         });
     }
+
+    public getClientDependingOnEventType(eventType: EventType) {
+        return eventType === 'click' ? this.beaconClient : this.client;
+    }
 }
 
 export class NodeJSRuntime implements IRuntimeEnvironment {
@@ -43,9 +49,17 @@ export class NodeJSRuntime implements IRuntimeEnvironment {
         this.storage = storage || new NullStorage();
         this.client = new AnalyticsFetchClient(clientOptions);
     }
+
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient {
+        return this.client;
+    }
 }
 
 export class NoopRuntime implements IRuntimeEnvironment {
     public storage = new NullStorage();
     public client = new NoopAnalyticsClient();
+
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient {
+        return this.client;
+    }
 }


### PR DESCRIPTION
This is a tentative fix for click events on iOS.

Discuss from where the issue originated: https://discuss.coveo.com/t/ua-drop-in-clickthrough-events-following-a-migration-from-jsui-to-atomic-headless/9958

Sending events when the end users is getting redirected (for example when they click on a result from a search page) will often fail on iOS + Safari. 

The reason is relatively simple to understand: When the current page is getting unloaded from memory from the browser, the browser won't necessarily wait to finish all current function execution, in order to speed up navigation for the end user.

The proposed fix is to use the navigator beacon API for click events specifically: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon

The beacon API  support is already implemented in the project, and seems to be working correctly.

Even with this change, if you look at browser dev tool on Safari + iOS, you'll see the beacon request often appear to fail (ie: cancelled).

However, with the manual tests I've done, when you actually look at the visit browser in the admin UI, the clicks appears correctly tracked on iOS Safari. 

It would be interesting to add some full end to end test for this, since we can't really rely on what's happening client side to verify that clicks were actually captured by the platform...

