### PR TITLE
Fix preprocess request for send beacon

### DIFF
--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -162,6 +162,20 @@ describe('AnalyticsBeaconClient', () => {
             );
         });
 
+        it('to augment the request body as a JSON string for a click event', async () => {
+            const client = setupClient((request) => {
+                const bodyParsedAsJSON = JSON.parse(request.body as string);
+                bodyParsedAsJSON.aNewProperty = 'bar';
+                request.body = JSON.stringify(bodyParsedAsJSON);
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'foo'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent(`{"actionCause":"foo","aNewProperty":"bar"}`)}`
+            );
+        });
+
         it('should keep original request body if preprocessRequest returns an invalid JSON string', async () => {
             const client = setupClient((request) => {
                 request.body = 'invalid JSON string';

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -1,6 +1,6 @@
 import {AnalyticsBeaconClient} from './analyticsBeaconClient';
 import {EventType} from '../events';
-import {AnalyticsClientOrigin, IAnalyticsRequestOptions} from './analyticsRequestClient';
+import {AnalyticsClientOrigin, IAnalyticsRequestOptions, PreprocessAnalyticsRequest} from './analyticsRequestClient';
 
 describe('AnalyticsBeaconClient', () => {
     const baseUrl = 'https://bloup.com';
@@ -99,33 +99,80 @@ describe('AnalyticsBeaconClient', () => {
         );
     });
 
-    it('should preprocess the request with the preprocessRequest', async () => {
-        let clientOrigin: AnalyticsClientOrigin;
-        const processedRequest: IAnalyticsRequestOptions = {
-            url: 'https://www.myownanalytics.com/endpoint',
-            body: JSON.stringify({
-                test: 'custom',
-            }),
-        };
-        const client = new AnalyticsBeaconClient({
-            baseUrl,
-            token,
-            visitorIdProvider: {
-                getCurrentVisitorId: () => {
-                    return Promise.resolve(currentVisitorId);
+    describe('allows to preprocessRequest', () => {
+        const setupClient = (preprocessRequest: PreprocessAnalyticsRequest) => {
+            return new AnalyticsBeaconClient({
+                baseUrl,
+                token,
+                visitorIdProvider: {
+                    getCurrentVisitorId: () => {
+                        return Promise.resolve(currentVisitorId);
+                    },
+                    setCurrentVisitorId: () => {},
                 },
-                setCurrentVisitorId: () => {},
-            },
-            preprocessRequest: (_request, type) => {
+                preprocessRequest,
+            });
+        };
+
+        it('to modify the origin and the body of the request', async () => {
+            let clientOrigin: AnalyticsClientOrigin;
+            const processedRequest: IAnalyticsRequestOptions = {
+                url: 'https://www.myownanalytics.com/endpoint',
+                body: JSON.stringify({
+                    test: 'custom',
+                }),
+            };
+            const client = setupClient((_request, type) => {
                 clientOrigin = type;
                 return processedRequest;
-            },
+            });
+
+            await client.sendEvent(EventType.collect, {});
+
+            expect(clientOrigin!).toBe('analyticsBeacon');
+            expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, expect.anything());
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain('test=custom');
         });
 
-        await client.sendEvent(EventType.collect, {});
+        it('to modify the request body as a JSON string for a collect event', async () => {
+            const client = setupClient((request) => {
+                const bodyShouldBeAvailableAsJSONString = JSON.parse(request.body as string);
+                expect(bodyShouldBeAvailableAsJSONString).toEqual({foo: 'bar'});
+                bodyShouldBeAvailableAsJSONString.foo = 'baz';
+                request.body = JSON.stringify(bodyShouldBeAvailableAsJSONString);
+                return request;
+            });
 
-        expect(clientOrigin!).toBe('analyticsBeacon');
-        expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, processedRequest.body);
+            await client.sendEvent(EventType.collect, {foo: 'bar'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(`foo=baz`);
+        });
+
+        it('to modify the request body as a JSON string for a click event', async () => {
+            const client = setupClient((request) => {
+                const bodyParsedAsJSON = JSON.parse(request.body as string);
+                expect(bodyParsedAsJSON).toEqual({actionCause: 'foo'});
+                bodyParsedAsJSON.actionCause = 'bar';
+                request.body = JSON.stringify(bodyParsedAsJSON);
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'foo'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent(`{"actionCause":"bar"}`)}`
+            );
+        });
+
+        it('should keep original request body if preprocessRequest returns an invalid JSON string', async () => {
+            const client = setupClient((request) => {
+                request.body = 'invalid JSON string';
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'bar'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent(`{"actionCause":"bar"}`)}`
+            );
+        });
     });
 
     const getSendBeaconFirstCallBlobArgument = async () => {

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -1,10 +1,10 @@
-import {AnalyticsRequestClient, IAnalyticsRequestOptions, IAnalyticsClientOptions} from './analyticsRequestClient';
+import {AnalyticsRequestClient, IAnalyticsClientOptions, PreprocessAnalyticsRequest} from './analyticsRequestClient';
 import {EventType, IRequestPayload} from '../events';
 
 export class AnalyticsBeaconClient implements AnalyticsRequestClient {
     constructor(private opts: IAnalyticsClientOptions) {}
 
-    public async sendEvent(eventType: EventType, payload: IRequestPayload): Promise<void> {
+    public async sendEvent(eventType: EventType, originalPayload: IRequestPayload): Promise<void> {
         if (!this.isAvailable()) {
             throw new Error(
                 `navigator.sendBeacon is not supported in this browser. Consider adding a polyfill like "sendbeacon-polyfill".`
@@ -15,19 +15,13 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
 
         const paramsFragments = await this.getQueryParamsForEventType(eventType);
 
-        if (preprocessRequest) {
-            payload = await preprocessRequest(
-                {
-                    url: `${baseUrl}/analytics/${eventType}?${paramsFragments}`,
-                    body: JSON.stringify(payload),
-                },
-                'analyticsBeacon'
-            );
-        }
+        const {url, payload} = await this.preProcessRequestAsPotentialJSONString(
+            `${baseUrl}/analytics/${eventType}?${paramsFragments}`,
+            originalPayload,
+            preprocessRequest
+        );
 
         const parsedRequestData = this.encodeForEventType(eventType, payload);
-
-        const url = `${baseUrl}/analytics/${eventType}?${paramsFragments}`;
         const body = new Blob([parsedRequestData], {
             type: 'application/x-www-form-urlencoded',
         });
@@ -42,6 +36,34 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
 
     public deleteHttpCookieVisitorId() {
         return Promise.resolve();
+    }
+
+    private async preProcessRequestAsPotentialJSONString(
+        originalURL: string,
+        originalPayload: IRequestPayload,
+        preprocessRequest?: PreprocessAnalyticsRequest
+    ): Promise<{url: string; payload: IRequestPayload}> {
+        let returnedUrl = originalURL;
+        let returnedPayload = originalPayload;
+
+        if (preprocessRequest) {
+            const processedRequest = await preprocessRequest(
+                {url: originalURL, body: JSON.stringify(originalPayload)},
+                'analyticsBeacon'
+            );
+            const {url: processedURL, body: processedBody} = processedRequest;
+            returnedUrl = processedURL || originalURL;
+            try {
+                returnedPayload = JSON.parse(processedBody as string);
+            } catch (e) {
+                console.error('Unable to process the request body as a JSON string', e);
+            }
+        }
+
+        return {
+            payload: returnedPayload,
+            url: returnedUrl,
+        };
     }
 
     private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {


### PR DESCRIPTION
Following the changes to use `sendBeacon` in Headless for clicks (through coveo.analytics  PR: https://github.com/coveo/coveo.analytics.js/pull/435) , we've stumbled upon a problem in the `preprocess` functionality that is implemented in the Beacon client

It's a functionality that allows implementers to either augment some analytics event (add custom data), override properties, or simply use them as hooks to copy the events payload to other system (google analytics). They are often used in the field.


The main problem is that the old `preprocess` functionality for sendBeacon was sending the payload as a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) to the implementer's `preprocess` function.

Even though the function signature says that the request body "could be anything" (including a Blob), the reality is that many implementers won't defensively code around that fact, and generally expect everything in there to be a JSON string.

Also, Blob in general are unwieldy to manipulate.

This PR changes this so that we send the stringified JSON object to the implementers (similar to how the `analyticsFetchClient` does it), before changing it to a blob and sending the event.
