### PR TITLE
Fix missing bundles in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,12 @@
     "files": [
         "modules/",
         "dist/**/*.d.ts",
-        "dist/**/*.{js, mjs, cjs}",
-        "dist/**/*.{js, mjs, cjs}.map",
+        "dist/**/*.js",
+        "dist/**/*.mjs",
+        "dist/**/*.cjs",
+        "dist/**/*.js.map",
+        "dist/**/*.mjs.map",
+        "dist/**/*.cjs.map",
         "src/**/*.ts",
         "react-native/",
         "LICENSE"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-2749

I introduced a bug in https://github.com/coveo/coveo.analytics.js/pull/433.

Turns out that the new `.mjs` files weren't being included in the final package. I was able to reproduce the issue by running `npm pack` locally.

My guess is that the glob patterns in `files` weren't matching any Javascript files. I think that `.js` and `.cjs` files must've been included due to some defaults with NPM. I tested the new array locally and `.mjs` files are now added successfully.