### PR TITLE
feat(genQA): new RGA UA events added to the search page client

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1498,7 +1498,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #logGeneratedAnswerSourceHover', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            id: 'some-document-id',
+            citationId: 'some-document-id',
             permanentId: 'perm-id',
             citationHoverTimeMs: 100,
         };
@@ -1509,7 +1509,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makeGeneratedAnswerSourceHover', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            id: 'some-document-id',
+            citationId: 'some-document-id',
             permanentId: 'perm-id',
             citationHoverTimeMs: 100,
         };

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1460,13 +1460,21 @@ describe('SearchPageClient', () => {
     });
 
     it('should send proper payload for #logOpenGeneratedAnswerSource', async () => {
-        const meta = {generativeQuestionAnsweringId: fakeStreamId, id: 'some-document-id', permanentId: 'perm-id'};
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+        };
         await client.logOpenGeneratedAnswerSource(meta);
         expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
     });
 
     it('should send proper payload for #makeOpenGeneratedAnswerSource', async () => {
-        const meta = {generativeQuestionAnsweringId: fakeStreamId, id: 'some-document-id', permanentId: 'perm-id'};
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+        };
         const built = await client.makeOpenGeneratedAnswerSource(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -59,6 +59,7 @@ describe('SearchPageClient', () => {
 
     const provider: SearchPageClientProvider = {
         getBaseMetadata: () => ({foo: 'bar'}),
+        getGeneratedAnswerMetadata: () => ({genQaMetadata: 'bar'}),
         getSearchEventRequestPayload: () => ({
             queryText: 'queryText',
             responseTime: 123,
@@ -118,7 +119,7 @@ describe('SearchPageClient', () => {
 
     const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
         const body: string = lastCallBody(fetchMock);
-        const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
+        const customData = {foo: 'bar', genQaMetadata: 'bar', ...customDataFromMiddleware, ...meta};
         expect(JSON.parse(body)).toEqual({
             queryText: 'queryText',
             responseTime: 123,
@@ -142,6 +143,14 @@ describe('SearchPageClient', () => {
             actionCause,
             customData,
         });
+    };
+
+    const expectSearchEventToMatchDescription = (
+        description: EventDescription,
+        actionCause: SearchPageEvents,
+        meta = {}
+    ) => {
+        expectMatchDescription(description, actionCause, {...meta, genQaMetadata: 'bar'});
     };
 
     const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
@@ -211,7 +220,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeInterfaceLoad();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.interfaceLoad);
-        expectMatchDescription(built.description, SearchPageEvents.interfaceLoad);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.interfaceLoad);
     });
 
     it('should send proper payload for #interfaceChange', async () => {
@@ -225,7 +234,9 @@ describe('SearchPageClient', () => {
         const built = await client.makeInterfaceChange({interfaceChangeTo: 'bob'});
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
-        expectMatchDescription(built.description, SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.interfaceChange, {
+            interfaceChangeTo: 'bob',
+        });
     });
 
     it('should send proper payload for #didyoumeanAutomatic', async () => {
@@ -237,7 +248,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeDidYouMeanAutomatic();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
-        expectMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
     });
 
     it('should send proper payload for #didyoumeanClick', async () => {
@@ -249,7 +260,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeDidYouMeanClick();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.didyoumeanClick);
-        expectMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
     });
 
     it('should send proper payload for #resultsSort', async () => {
@@ -261,7 +272,9 @@ describe('SearchPageClient', () => {
         const built = await client.makeResultsSort({resultsSortBy: 'date ascending'});
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
-        expectMatchDescription(built.description, SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.resultsSort, {
+            resultsSortBy: 'date ascending',
+        });
     });
 
     it('should send proper payload for #searchboxSubmit', async () => {
@@ -273,7 +286,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeSearchboxSubmit();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxSubmit);
-        expectMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
     });
 
     it('should send proper payload for #searchboxClear', async () => {
@@ -285,7 +298,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeSearchboxClear();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxClear);
-        expectMatchDescription(built.description, SearchPageEvents.searchboxClear);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxClear);
     });
 
     it('should send proper payload for #searchboxAsYouType', async () => {
@@ -297,7 +310,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeSearchboxAsYouType();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchboxAsYouType);
-        expectMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
     });
 
     it('should send proper payload for #documentQuickview', async () => {
@@ -371,7 +384,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeOmniboxAnalytics(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
-        expectMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
     });
 
     it('should send proper payload for #logOmniboxFromLink', async () => {
@@ -397,7 +410,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeOmniboxFromLink(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
-        expectMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
     });
 
     it('should send proper payload for #logSearchFromLink', async () => {
@@ -409,7 +422,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeSearchFromLink();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.searchFromLink);
-        expectMatchDescription(built.description, SearchPageEvents.searchFromLink);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchFromLink);
     });
 
     it('should send proper payload for #logTriggerNotify', async () => {
@@ -487,7 +500,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeUndoTriggerQuery(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
-        expectMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
     });
 
     it('should send proper payload for #logTriggerRedirect', async () => {
@@ -594,7 +607,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeStaticFilterClearAll({staticFilterId});
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
-        expectMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
     });
 
     it('should send the proper payload for #logStaticFilterSelect', async () => {
@@ -622,7 +635,7 @@ describe('SearchPageClient', () => {
         await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
-        expectMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
     });
 
     it('should send the proper payload for #logStaticFilterDeselect', async () => {
@@ -649,7 +662,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeStaticFilterDeselect(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
-        expectMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
     });
 
     it('should send proper payload for #logFacetSearch', async () => {
@@ -671,7 +684,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetSearch(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSearch, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
     });
 
     it('should send proper payload for #logFacetSelect', async () => {
@@ -696,7 +709,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetSelect(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSelect, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
     });
 
     it('should send proper payload for #logFacetDeselect', async () => {
@@ -722,7 +735,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetDeselect(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetDeselect, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
     });
 
     it('should send proper payload for #logFacetExclude', async () => {
@@ -746,7 +759,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetExclude(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetExclude, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
     });
 
     it('should send proper payload for #logFacetUnexclude', async () => {
@@ -770,7 +783,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetUnexclude(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
     });
 
     it('should send proper payload for #logFacetSelectAll', async () => {
@@ -792,7 +805,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetSelectAll(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
     });
 
     it('should send proper payload for #logFacetUpdateSort', async () => {
@@ -816,7 +829,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeFacetUpdateSort(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
-        expectMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
     });
 
     it('should send proper payload for #logFacetShowMore', async () => {
@@ -937,7 +950,7 @@ describe('SearchPageClient', () => {
         const built = await client.makeRecommendationInterfaceLoad();
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
-        expectMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
     });
 
     it('should send proper payload for #logRecommendation', async () => {
@@ -1309,7 +1322,7 @@ describe('SearchPageClient', () => {
         await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.recentQueryClick);
-        expectMatchDescription(built.description, SearchPageEvents.recentQueryClick);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.recentQueryClick);
     });
 
     it('should send proper payload for #logClearRecentQueries', async () => {
@@ -1358,7 +1371,7 @@ describe('SearchPageClient', () => {
         await built.log({searchUID: provider.getSearchUID()});
 
         expectMatchPayload(SearchPageEvents.noResultsBack);
-        expectMatchDescription(built.description, SearchPageEvents.noResultsBack);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.noResultsBack);
     });
 
     it('should send proper payload for #logClearRecentResults', async () => {
@@ -1565,7 +1578,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #logRephraseGeneratedAnswer', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
         };
         await client.logRephraseGeneratedAnswer(meta);
         expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
@@ -1574,11 +1587,11 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makeRephraseGeneratedAnswer', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
         };
         const built = await client.makeRephraseGeneratedAnswer(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
-        expectMatchDescription(built.description, SearchPageEvents.rephraseGeneratedAnswer, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.rephraseGeneratedAnswer, meta);
     });
 });

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1479,7 +1479,7 @@ describe('SearchPageClient', () => {
             generativeQuestionAnsweringId: fakeStreamId,
             id: 'some-document-id',
             permanentId: 'perm-id',
-            citationHoverTime: 100,
+            citationHoverTimeMs: 100,
         };
         await client.logGeneratedAnswerSourceHover(meta);
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
@@ -1490,7 +1490,7 @@ describe('SearchPageClient', () => {
             generativeQuestionAnsweringId: fakeStreamId,
             id: 'some-document-id',
             permanentId: 'perm-id',
-            citationHoverTime: 100,
+            citationHoverTimeMs: 100,
         };
         const built = await client.makeGeneratedAnswerSourceHover(meta);
         await built.log({searchUID: provider.getSearchUID()});

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -5,6 +5,8 @@ import {
     CustomEventsTypes,
     OmniboxSuggestionsMetadata,
     StaticFilterToggleValueMetadata,
+    GeneratedAnswerFeedbackReason,
+    GeneratedAnswerRephraseStrategy,
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
@@ -1470,5 +1472,113 @@ describe('SearchPageClient', () => {
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
         expectMatchDescription(built.description, SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerCitationHover', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            id: 'some-document-id',
+            permanentId: 'perm-id',
+            citationHoverTime: 100,
+        };
+        await client.logGeneratedAnswerCitationHover(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCitationHover, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerCitationHover', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            id: 'some-document-id',
+            permanentId: 'perm-id',
+            citationHoverTime: 100,
+        };
+        const built = await client.makeGeneratedAnswerCitationHover(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCitationHover, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCitationHover, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerCopyToClipboard', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerCopyToClipboard(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerCopyToClipboard', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerCopyToClipboard(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerHideAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerHideAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerHideAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerHideAnswers(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerHideAnswers, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerShowAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerShowAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerShowAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerShowAnswers(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerShowAnswers, meta);
+    });
+
+    it('should send proper payload for #logGenerativeQuestionFeedbackSubmit', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            reason: <GeneratedAnswerFeedbackReason>'other',
+            details: 'a few additional details',
+        };
+        await client.logGenerativeQuestionFeedbackSubmit(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+    });
+
+    it('should send proper payload for #makeGenerativeQuestionFeedbackSubmit', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            reason: <GeneratedAnswerFeedbackReason>'other',
+            details: 'a few additional details',
+        };
+        const built = await client.makeGenerativeQuestionFeedbackSubmit(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+    });
+
+    it('should send proper payload for #logRephraseGeneratedAnswer', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            rephraseStrategy: <GeneratedAnswerRephraseStrategy>'stepByStep',
+        };
+        await client.logRephraseGeneratedAnswer(meta);
+        expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #makeRephraseGeneratedAnswer', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            rephraseStrategy: <GeneratedAnswerRephraseStrategy>'stepByStep',
+        };
+        const built = await client.makeRephraseGeneratedAnswer(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
+        expectMatchDescription(built.description, SearchPageEvents.rephraseGeneratedAnswer, meta);
     });
 });

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1474,28 +1474,28 @@ describe('SearchPageClient', () => {
         expectMatchDescription(built.description, SearchPageEvents.generatedAnswerStreamEnd, meta);
     });
 
-    it('should send proper payload for #logGeneratedAnswerCitationHover', async () => {
+    it('should send proper payload for #logGeneratedAnswerSourceHover', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             id: 'some-document-id',
             permanentId: 'perm-id',
             citationHoverTime: 100,
         };
-        await client.logGeneratedAnswerCitationHover(meta);
-        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCitationHover, meta);
+        await client.logGeneratedAnswerSourceHover(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
     });
 
-    it('should send proper payload for #makeGeneratedAnswerCitationHover', async () => {
+    it('should send proper payload for #makeGeneratedAnswerSourceHover', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             id: 'some-document-id',
             permanentId: 'perm-id',
             citationHoverTime: 100,
         };
-        const built = await client.makeGeneratedAnswerCitationHover(meta);
+        const built = await client.makeGeneratedAnswerSourceHover(meta);
         await built.log({searchUID: provider.getSearchUID()});
-        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCitationHover, meta);
-        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCitationHover, meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerSourceHover, meta);
     });
 
     it('should send proper payload for #logGeneratedAnswerCopyToClipboard', async () => {

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -6,7 +6,7 @@ import {
     OmniboxSuggestionsMetadata,
     StaticFilterToggleValueMetadata,
     GeneratedAnswerFeedbackReason,
-    GeneratedAnswerRephraseStrategy,
+    GeneratedAnswerRephraseFormat,
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
@@ -1565,7 +1565,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #logRephraseGeneratedAnswer', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            rephraseStrategy: <GeneratedAnswerRephraseStrategy>'stepByStep',
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
         };
         await client.logRephraseGeneratedAnswer(meta);
         expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
@@ -1574,7 +1574,7 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #makeRephraseGeneratedAnswer', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
-            rephraseStrategy: <GeneratedAnswerRephraseStrategy>'stepByStep',
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
         };
         const built = await client.makeRephraseGeneratedAnswer(meta);
         await built.log({searchUID: provider.getSearchUID()});

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -39,6 +39,9 @@ import {
     GeneratedAnswerFeedbackMeta,
     GeneratedAnswerCitationMeta,
     GeneratedAnswerStreamEndMeta,
+    GeneratedAnswerCitationHoverMeta,
+    GeneratedAnswerBaseMeta,
+    GeneratedAnswerRephraseMeta,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -885,19 +888,19 @@ export class CoveoSearchPageClient {
         };
     }
 
-    public makeLikeGeneratedAnswer(metadata: GeneratedAnswerFeedbackMeta) {
+    public makeLikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
         return this.makeCustomEvent(SearchPageEvents.likeGeneratedAnswer, metadata);
     }
 
-    public async logLikeGeneratedAnswer(metadata: GeneratedAnswerFeedbackMeta) {
+    public async logLikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
         return (await this.makeLikeGeneratedAnswer(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
-    public makeDislikeGeneratedAnswer(metadata: GeneratedAnswerFeedbackMeta) {
+    public makeDislikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
         return this.makeCustomEvent(SearchPageEvents.dislikeGeneratedAnswer, metadata);
     }
 
-    public async logDislikeGeneratedAnswer(metadata: GeneratedAnswerFeedbackMeta) {
+    public async logDislikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
         return (await this.makeDislikeGeneratedAnswer(metadata)).log({searchUID: this.provider.getSearchUID()});
     }
 
@@ -909,6 +912,64 @@ export class CoveoSearchPageClient {
         return (await this.makeOpenGeneratedAnswerSource(metadata)).log({
             searchUID: this.provider.getSearchUID(),
         });
+    }
+
+    public makeGeneratedAnswerCitationHover(metadata: GeneratedAnswerCitationHoverMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerCitationHover, metadata);
+    }
+
+    public async logGeneratedAnswerCitationHover(metadata: GeneratedAnswerCitationHoverMeta) {
+        return (await this.makeGeneratedAnswerCitationHover(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerCopyToClipboard(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerCopyToClipboard, metadata);
+    }
+
+    public async logGeneratedAnswerCopyToClipboard(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerCopyToClipboard(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerHideAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerHideAnswers, metadata);
+    }
+
+    public async logGeneratedAnswerHideAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerHideAnswers(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerShowAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerShowAnswers, metadata);
+    }
+
+    public async logGeneratedAnswerShowAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerShowAnswers(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGenerativeQuestionFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+    }
+
+    public async logGenerativeQuestionFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return (await this.makeGenerativeQuestionFeedbackSubmit(meta)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeRephraseGeneratedAnswer(meta: GeneratedAnswerRephraseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.rephraseGeneratedAnswer, meta);
+    }
+
+    public async logRephraseGeneratedAnswer(meta: GeneratedAnswerRephraseMeta) {
+        return (await this.makeRephraseGeneratedAnswer(meta)).log({searchUID: this.provider.getSearchUID()});
     }
 
     public makeRetryGeneratedAnswer() {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -61,6 +61,7 @@ export interface SearchPageClientProvider {
     getFacetState?: () => FacetStateMetadata[];
     getSplitTestRunName?: () => string | undefined;
     getSplitTestRunVersion?: () => string | undefined;
+    getGeneratedAnswerMetadata?: () => Record<string, any>;
 }
 
 export interface SearchPageClientOptions extends ClientOptions {
@@ -844,7 +845,7 @@ export class CoveoSearchPageClient {
         metadata?: Record<string, any>
     ): Promise<PreparedSearchEventRequest> {
         return {
-            ...(await this.getBaseEventRequest(metadata)),
+            ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
             ...this.provider.getSearchEventRequestPayload(),
             queryPipeline: this.provider.getPipeline(),
             actionCause: event,

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -39,7 +39,7 @@ import {
     GeneratedAnswerFeedbackMeta,
     GeneratedAnswerCitationMeta,
     GeneratedAnswerStreamEndMeta,
-    GeneratedAnswerCitationHoverMeta,
+    GeneratedAnswerSourceHoverMeta,
     GeneratedAnswerBaseMeta,
     GeneratedAnswerRephraseMeta,
 } from './searchPageEvents';
@@ -914,12 +914,12 @@ export class CoveoSearchPageClient {
         });
     }
 
-    public makeGeneratedAnswerCitationHover(metadata: GeneratedAnswerCitationHoverMeta) {
-        return this.makeCustomEvent(SearchPageEvents.generatedAnswerCitationHover, metadata);
+    public makeGeneratedAnswerSourceHover(metadata: GeneratedAnswerSourceHoverMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerSourceHover, metadata);
     }
 
-    public async logGeneratedAnswerCitationHover(metadata: GeneratedAnswerCitationHoverMeta) {
-        return (await this.makeGeneratedAnswerCitationHover(metadata)).log({
+    public async logGeneratedAnswerSourceHover(metadata: GeneratedAnswerSourceHoverMeta) {
+        return (await this.makeGeneratedAnswerSourceHover(metadata)).log({
             searchUID: this.provider.getSearchUID(),
         });
     }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -539,14 +539,14 @@ export interface GeneratedAnswerCitationMeta {
 
 export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';
 
-export type GeneratedAnswerRephraseStrategy = 'stepByStep' | 'bulletPoints' | 'summarize';
+export type GeneratedAnswerRephraseFormat = 'stepByStep' | 'bulletPoints' | 'summarize';
 
 export interface GeneratedAnswerSourceHoverMeta extends GeneratedAnswerCitationMeta {
     citationHoverTime: number;
 }
 
 export interface GeneratedAnswerRephraseMeta extends GeneratedAnswerBaseMeta {
-    rephraseStrategy: GeneratedAnswerRephraseStrategy;
+    rephraseFormat: GeneratedAnswerRephraseFormat;
 }
 
 export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -314,6 +314,30 @@ export enum SearchPageEvents {
      * Identified the custom event that gets logged when a generated answer stream is completed.
      */
     generatedAnswerStreamEnd = 'generatedAnswerStreamEnd',
+    /**
+     * Identifies the custom event that gets logged when a user hovers over a generated answer citation.
+     */
+    generatedAnswerCitationHover = 'generatedAnswerCitationHover',
+    /**
+     * Identifies the custom event that gets logged when a user clicks the copy to clip board button of a generated answer.
+     */
+    generatedAnswerCopyToClipboard = 'generatedAnswerCopyToClipboard',
+    /**
+     * Identifies the custom event that gets logged when a user deactivates the genQA feature.
+     */
+    generatedAnswerHideAnswers = 'generatedAnswerHideAnswers',
+    /**
+     * Identifies the custom event that gets logged when a user activates the genQA feature.
+     */
+    generatedAnswerShowAnswers = 'generatedAnswerShowAnswers',
+    /**
+     * Identifies the custom event that gets logged when a user submits a feedback of a generated answer.
+     */
+    generativeQuestionFeedbackSubmit = 'generativeQuestionFeedbackSubmit',
+    /**
+     * Identifies the search event that gets logged when a user clicks the rephrase button in a generated answer.
+     */
+    rephraseGeneratedAnswer = 'rephraseGeneratedAnswer',
 }
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
@@ -360,6 +384,11 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.dislikeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.openGeneratedAnswerSource]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerStreamEnd]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerCitationHover]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerCopyToClipboard]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerHideAnswers]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerShowAnswers]: 'generatedAnswer',
+    [SearchPageEvents.generativeQuestionFeedbackSubmit]: 'generatedAnswer',
 };
 
 export interface StaticFilterMetadata {
@@ -494,11 +523,9 @@ export interface SmartSnippetDocumentIdentifier {
 
 export type PartialDocumentInformation = Omit<DocumentInformation, 'actionCause' | 'searchQueryUid'>;
 
-interface GeneratedAnswerBaseMeta {
+export interface GeneratedAnswerBaseMeta {
     generativeQuestionAnsweringId: string;
 }
-
-export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {}
 
 export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
     answerGenerated: boolean;
@@ -508,4 +535,21 @@ export interface GeneratedAnswerCitationMeta {
     generativeQuestionAnsweringId: string;
     permanentId: string;
     id: string;
+}
+
+export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';
+
+export type GeneratedAnswerRephraseStrategy = 'stepByStep' | 'bulletPoints' | 'summarize';
+
+export interface GeneratedAnswerCitationHoverMeta extends GeneratedAnswerCitationMeta {
+    citationHoverTime: number;
+}
+
+export interface GeneratedAnswerRephraseMeta extends GeneratedAnswerBaseMeta {
+    rephraseStrategy: GeneratedAnswerRephraseStrategy;
+}
+
+export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {
+    reason: GeneratedAnswerFeedbackReason;
+    details?: string;
 }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -542,7 +542,7 @@ export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outO
 export type GeneratedAnswerRephraseFormat = 'stepByStep' | 'bulletPoints' | 'summarize';
 
 export interface GeneratedAnswerSourceHoverMeta extends GeneratedAnswerCitationMeta {
-    citationHoverTime: number;
+    citationHoverTimeMs: number;
 }
 
 export interface GeneratedAnswerRephraseMeta extends GeneratedAnswerBaseMeta {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -539,7 +539,7 @@ export interface GeneratedAnswerCitationMeta {
 
 export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';
 
-export type GeneratedAnswerRephraseFormat = 'stepByStep' | 'bulletPoints' | 'summarize';
+export type GeneratedAnswerRephraseFormat = 'step' | 'bullet' | 'concise' | 'default';
 
 export interface GeneratedAnswerSourceHoverMeta extends GeneratedAnswerCitationMeta {
     citationHoverTimeMs: number;

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -317,7 +317,7 @@ export enum SearchPageEvents {
     /**
      * Identifies the custom event that gets logged when a user hovers over a generated answer citation.
      */
-    generatedAnswerCitationHover = 'generatedAnswerCitationHover',
+    generatedAnswerSourceHover = 'generatedAnswerSourceHover',
     /**
      * Identifies the custom event that gets logged when a user clicks the copy to clip board button of a generated answer.
      */
@@ -384,7 +384,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.dislikeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.openGeneratedAnswerSource]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerStreamEnd]: 'generatedAnswer',
-    [SearchPageEvents.generatedAnswerCitationHover]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerSourceHover]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerCopyToClipboard]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerHideAnswers]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerShowAnswers]: 'generatedAnswer',
@@ -541,7 +541,7 @@ export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outO
 
 export type GeneratedAnswerRephraseStrategy = 'stepByStep' | 'bulletPoints' | 'summarize';
 
-export interface GeneratedAnswerCitationHoverMeta extends GeneratedAnswerCitationMeta {
+export interface GeneratedAnswerSourceHoverMeta extends GeneratedAnswerCitationMeta {
     citationHoverTime: number;
 }
 

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -534,7 +534,7 @@ export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
 export interface GeneratedAnswerCitationMeta {
     generativeQuestionAnsweringId: string;
     permanentId: string;
-    id: string;
+    citationId: string;
 }
 
 export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';


### PR DESCRIPTION
[SFINT-5206](https://coveord.atlassian.net/browse/SFINT-5206)

### The following events has been added:

#### Custom events:

- generatedAnswerCitationHover
- generatedAnswerCopyToClipboard
- generatedAnswerHideAnswers
- generatedAnswerShowAnswers
- generativeQuestionFeedbackSubmit

#### Search events:

- rephraseGeneratedAnswer


### Added the ability to send generated answer metadata in all the Search UA events by adding a new function `getGeneratedAnswerMetadata` to the `SearchPageClientProvider`:
#### example of adding the fields `showGeneratedAnswer` and `generatedAnswerFormat`: 

<img width="499" alt="ExampleSearch" src="https://github.com/coveo/coveo.analytics.js/assets/86681870/b230a6a4-1e7b-43be-9071-0531e9778cf0">


### The events are documented here: [UA events schemas- GenAI v2](https://docs.google.com/document/d/1vv9hKHZJ4tjSFRNoxG88DKqeTxvBAG-jBYMp-mAg6oE/edit#heading=h.91bl6jfm09i6)

[SFINT-5206]: https://coveord.atlassian.net/browse/SFINT-5206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ