### PR TITLE
feat(genQa): RGA ua events for insight use case created

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -600,7 +600,7 @@ describe('InsightClient', () => {
         it('should send proper payload for #rephraseGeneratedAnswer', async () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
-                rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
             };
 
             await client.logRephraseGeneratedAnswer(exampleGeneratedAnswerMetadata);
@@ -1346,7 +1346,7 @@ describe('InsightClient', () => {
         it('should send proper payload for #rephraseGeneratedAnswer', async () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
-                rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
             };
             const expectedMetadata = {
                 ...exampleGeneratedAnswerMetadata,

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -65,6 +65,7 @@ describe('InsightClient', () => {
         getLanguage: () => 'en',
         getFacetState: () => fakeFacetState,
         getIsAnonymous: () => false,
+        getGeneratedAnswerMetadata: () => ({genratedAnswerMetadata: 'foo'}),
     };
 
     const initClient = () => {
@@ -80,7 +81,7 @@ describe('InsightClient', () => {
 
     const expectMatchPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
         const body: string = lastCallBody(fetchMock);
-        const customData = {foo: 'bar', ...meta};
+        const customData = {foo: 'bar', genratedAnswerMetadata: 'foo', ...meta};
         expect(JSON.parse(body)).toMatchObject({
             queryText: 'queryText',
             responseTime: 123,

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -535,7 +535,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 permanentId: 'foo',
-                id: 'bar',
+                citationId: 'bar',
             };
 
             await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata);
@@ -546,7 +546,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 permanentId: 'foo',
-                id: 'bar',
+                citationId: 'bar',
                 citationHoverTimeMs: 100,
             };
 
@@ -1263,7 +1263,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 permanentId: 'foo',
-                id: 'bar',
+                citationId: 'bar',
             };
             const expectedMetadata = {
                 ...exampleGeneratedAnswerMetadata,
@@ -1278,7 +1278,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 permanentId: 'foo',
-                id: 'bar',
+                citationId: 'bar',
                 citationHoverTimeMs: 100,
             };
             const expectedMetadata = {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -584,16 +584,16 @@ describe('InsightClient', () => {
             expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, exampleGeneratedAnswerMetadata);
         });
 
-        it('should send proper payload for #generativeQuestionFeedbackSubmit', async () => {
+        it('should send proper payload for #generatedAnswerFeedbackSubmit', async () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 reason: <GeneratedAnswerFeedbackReason>'other',
                 details: 'foo',
             };
 
-            await client.logGenerativeQuestionFeedbackSubmit(exampleGeneratedAnswerMetadata);
+            await client.logGeneratedAnswerFeedbackSubmit(exampleGeneratedAnswerMetadata);
             expectMatchCustomEventPayload(
-                SearchPageEvents.generativeQuestionFeedbackSubmit,
+                SearchPageEvents.generatedAnswerFeedbackSubmit,
                 exampleGeneratedAnswerMetadata
             );
         });
@@ -1329,7 +1329,7 @@ describe('InsightClient', () => {
             expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, expectedMetadata);
         });
 
-        it('should send proper payload for #generativeQuestionFeedbackSubmit', async () => {
+        it('should send proper payload for #generatedAnswerFeedbackSubmit', async () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 reason: <GeneratedAnswerFeedbackReason>'other',
@@ -1340,8 +1340,8 @@ describe('InsightClient', () => {
                 ...expectedBaseCaseMetadata,
             };
 
-            await client.logGenerativeQuestionFeedbackSubmit(exampleGeneratedAnswerMetadata, baseCaseMetadata);
-            expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, expectedMetadata);
+            await client.logGeneratedAnswerFeedbackSubmit(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, expectedMetadata);
         });
 
         it('should send proper payload for #rephraseGeneratedAnswer', async () => {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -511,6 +511,116 @@ describe('InsightClient', () => {
             await client.logShowLessFoldedResults();
             expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
         });
+
+        it('should send proper payload for #likeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logLikeGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #dislikeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logDislikeGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #openGeneratedAnswerSource', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                id: 'bar',
+            };
+
+            await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerSourceHover', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                id: 'bar',
+                citationHoverTimeMs: 100,
+            };
+
+            await client.logGeneratedAnswerSourceHover(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCopyToClipboard', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerCopyToClipboard(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generatedAnswerCopyToClipboard,
+                exampleGeneratedAnswerMetadata
+            );
+        });
+
+        it('should send proper payload for #generatedAnswerHideAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerHideAnswers(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerShowAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerShowAnswers(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generativeQuestionFeedbackSubmit', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                reason: <GeneratedAnswerFeedbackReason>'other',
+                details: 'foo',
+            };
+
+            await client.logGenerativeQuestionFeedbackSubmit(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generativeQuestionFeedbackSubmit,
+                exampleGeneratedAnswerMetadata
+            );
+        });
+
+        it('should send proper payload for #rephraseGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+            };
+
+            await client.logRephraseGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #retryGeneratedAnswer', async () => {
+            await client.logRetryGeneratedAnswer();
+            expectMatchPayload(SearchPageEvents.retryGeneratedAnswer);
+        });
+
+        it('should send proper payload for #generatedAnswerStreamEnd', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                answerGenerated: true,
+            };
+
+            await client.logGeneratedAnswerStreamEnd(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, exampleGeneratedAnswerMetadata);
+        });
     });
 
     describe('when the case metadata is included', () => {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -3,6 +3,8 @@ import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {
     CustomEventsTypes,
+    GeneratedAnswerFeedbackReason,
+    GeneratedAnswerRephraseFormat,
     PartialDocumentInformation,
     SearchPageEvents,
     StaticFilterToggleValueMetadata,
@@ -1118,6 +1120,154 @@ describe('InsightClient', () => {
             };
             await client.logShowLessFoldedResults(baseCaseMetadata);
             expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults, expectedMetadata);
+        });
+
+        it('should send proper payload for #likeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logLikeGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #dislikeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logDislikeGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #openGeneratedAnswerSource', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                id: 'bar',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerSourceHover', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                id: 'bar',
+                citationHoverTimeMs: 100,
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerSourceHover(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCopyToClipboard', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerCopyToClipboard(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerHideAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerHideAnswers(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerShowAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerShowAnswers(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, expectedMetadata);
+        });
+
+        it('should send proper payload for #generativeQuestionFeedbackSubmit', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                reason: <GeneratedAnswerFeedbackReason>'other',
+                details: 'foo',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGenerativeQuestionFeedbackSubmit(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, expectedMetadata);
+        });
+
+        it('should send proper payload for #rephraseGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'stepByStep',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logRephraseGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #retryGeneratedAnswer', async () => {
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logRetryGeneratedAnswer(baseCaseMetadata);
+            expectMatchPayload(SearchPageEvents.retryGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerStreamEnd', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                answerGenerated: true,
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerStreamEnd(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, expectedMetadata);
         });
     });
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -555,12 +555,12 @@ export class CoveoInsightClient {
         );
     }
 
-    public logGenerativeQuestionFeedbackSubmit(
+    public logGeneratedAnswerFeedbackSubmit(
         generatedAnswerFeedbackMetadata: GeneratedAnswerFeedbackMeta,
         metadata?: CaseMetadata
     ) {
         return this.logCustomEvent(
-            SearchPageEvents.generativeQuestionFeedbackSubmit,
+            SearchPageEvents.generatedAnswerFeedbackSubmit,
             metadata
                 ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
                 : generatedAnswerFeedbackMetadata

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -6,6 +6,12 @@ import {
     CustomEventsTypes,
     DocumentIdentifier,
     FacetStateMetadata,
+    GeneratedAnswerBaseMeta,
+    GeneratedAnswerCitationMeta,
+    GeneratedAnswerFeedbackMeta,
+    GeneratedAnswerRephraseMeta,
+    GeneratedAnswerSourceHoverMeta,
+    GeneratedAnswerStreamEndMeta,
     PartialDocumentInformation,
     SearchPageEvents,
     SmartSnippetDocumentIdentifier,
@@ -473,6 +479,121 @@ export class CoveoInsightClient {
                 contentIDValue: snippetAndLink.documentId.contentIdValue,
             },
             metadata ? {...generateMetadataToSend(metadata, false), ...snippetAndLink} : snippetAndLink
+        );
+    }
+
+    public logLikeGeneratedAnswer(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.likeGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logDislikeGeneratedAnswer(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.dislikeGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logOpenGeneratedAnswerSource(
+        generatedAnswerSourceMetadata: GeneratedAnswerCitationMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.openGeneratedAnswerSource,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerSourceMetadata}
+                : generatedAnswerSourceMetadata
+        );
+    }
+
+    public logGeneratedAnswerSourceHover(
+        generatedAnswerSourceMetadata: GeneratedAnswerSourceHoverMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerSourceHover,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerSourceMetadata}
+                : generatedAnswerSourceMetadata
+        );
+    }
+
+    public logGeneratedAnswerCopyToClipboard(
+        generatedAnswerMetadata: GeneratedAnswerBaseMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerCopyToClipboard,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerHideAnswers(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerHideAnswers,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerShowAnswers(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerShowAnswers,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGenerativeQuestionFeedbackSubmit(
+        generatedAnswerFeedbackMetadata: GeneratedAnswerFeedbackMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generativeQuestionFeedbackSubmit,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
+                : generatedAnswerFeedbackMetadata
+        );
+    }
+
+    public logRephraseGeneratedAnswer(
+        generatedAnswerRephraseMetadata: GeneratedAnswerRephraseMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logSearchEvent(
+            SearchPageEvents.rephraseGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerRephraseMetadata}
+                : generatedAnswerRephraseMetadata
+        );
+    }
+
+    public logRetryGeneratedAnswer(metadata?: CaseMetadata) {
+        return this.logSearchEvent(
+            SearchPageEvents.retryGeneratedAnswer,
+            metadata ? {...generateMetadataToSend(metadata, false)} : {}
+        );
+    }
+
+    public logGeneratedAnswerStreamEnd(
+        generatedAnswerStreamEndMetadata: GeneratedAnswerStreamEndMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerStreamEnd,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerStreamEndMetadata}
+                : generatedAnswerStreamEndMetadata
         );
     }
 

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -49,6 +49,7 @@ export interface InsightClientProvider {
     getLanguage: () => string;
     getIsAnonymous: () => boolean;
     getFacetState?: () => FacetStateMetadata[];
+    getGeneratedAnswerMetadata?: () => Record<string, any>;
 }
 
 export interface InsightClientOptions extends ClientOptions {
@@ -662,7 +663,7 @@ export class CoveoInsightClient {
         metadata?: Record<string, any>
     ): Promise<SearchEventRequest> {
         return {
-            ...(await this.getBaseEventRequest(metadata)),
+            ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
             ...this.provider.getSearchEventRequestPayload(),
             searchQueryUid: this.provider.getSearchUID(),
             queryPipeline: this.provider.getPipeline(),

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1561,26 +1561,26 @@ describe('SearchPageClient', () => {
         expectMatchDescription(built.description, SearchPageEvents.generatedAnswerShowAnswers, meta);
     });
 
-    it('should send proper payload for #logGenerativeQuestionFeedbackSubmit', async () => {
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmit', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             reason: <GeneratedAnswerFeedbackReason>'other',
             details: 'a few additional details',
         };
-        await client.logGenerativeQuestionFeedbackSubmit(meta);
-        expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+        await client.logGeneratedAnswerFeedbackSubmit(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
     });
 
-    it('should send proper payload for #makeGenerativeQuestionFeedbackSubmit', async () => {
+    it('should send proper payload for #makeGeneratedAnswerFeedbackSubmit', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             reason: <GeneratedAnswerFeedbackReason>'other',
             details: 'a few additional details',
         };
-        const built = await client.makeGenerativeQuestionFeedbackSubmit(meta);
+        const built = await client.makeGeneratedAnswerFeedbackSubmit(meta);
         await built.log({searchUID: provider.getSearchUID()});
-        expectMatchCustomEventPayload(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
-        expectMatchDescription(built.description, SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
     });
 
     it('should send proper payload for #logRephraseGeneratedAnswer', async () => {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -955,12 +955,12 @@ export class CoveoSearchPageClient {
         });
     }
 
-    public makeGenerativeQuestionFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
-        return this.makeCustomEvent(SearchPageEvents.generativeQuestionFeedbackSubmit, meta);
+    public makeGeneratedAnswerFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
     }
 
-    public async logGenerativeQuestionFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
-        return (await this.makeGenerativeQuestionFeedbackSubmit(meta)).log({
+    public async logGeneratedAnswerFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return (await this.makeGeneratedAnswerFeedbackSubmit(meta)).log({
             searchUID: this.provider.getSearchUID(),
         });
     }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -333,7 +333,7 @@ export enum SearchPageEvents {
     /**
      * Identifies the custom event that gets logged when a user submits a feedback of a generated answer.
      */
-    generativeQuestionFeedbackSubmit = 'generativeQuestionFeedbackSubmit',
+    generatedAnswerFeedbackSubmit = 'generatedAnswerFeedbackSubmit',
     /**
      * Identifies the search event that gets logged when a user clicks the rephrase button in a generated answer.
      */
@@ -388,7 +388,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.generatedAnswerCopyToClipboard]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerHideAnswers]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerShowAnswers]: 'generatedAnswer',
-    [SearchPageEvents.generativeQuestionFeedbackSubmit]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerFeedbackSubmit]: 'generatedAnswer',
 };
 
 export interface StaticFilterMetadata {


### PR DESCRIPTION
[SFINT-5198](https://coveord.atlassian.net/browse/SFINT-5198)

### The following events has been added to support RGA for the insight use case:

#### Custom events:

- likeGeneratedAnswer
- dislikeGeneratedAnswer
- openGeneratedAnswerSource
- generatedAnswerStreamEnd
- generatedAnswerSourceHover
- generatedAnswerCopyToClipboard
- generatedAnswerHideAnswers
- generatedAnswerShowAnswers
- generativeQuestionFeedbackSubmit

#### Search events:

- retryGeneratedAnswer
- rephraseGeneratedAnswer


### Added the ability to send generated answer metadata in all the Search UA events by adding a new function `getGeneratedAnswerMetadata` to the `InsightClientProvider`

[SFINT-5198]: https://coveord.atlassian.net/browse/SFINT-5198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ