### PR TITLE
[UA-8420] Add ClientId mapping for all event types

### DIFF
--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -1,4 +1,11 @@
-import {DefaultEventResponse, EventType, ViewEventRequest} from '../events';
+import {
+    ClickEventRequest,
+    CustomEventRequest,
+    DefaultEventResponse,
+    EventType,
+    SearchEventRequest,
+    ViewEventRequest,
+} from '../events';
 import {CoveoAnalyticsClient} from './analytics';
 import {IAnalyticsRequestOptions} from './analyticsRequestClient';
 import {CookieAndLocalStorage, CookieStorage, NullStorage} from '../storage';
@@ -29,6 +36,24 @@ describe('Analytics', () => {
         contentIdValue: 'value',
         language: 'en',
     };
+    const searchEvent: SearchEventRequest = {
+        searchQueryUid: 'sqUid',
+        actionCause: 'interfaceLoad',
+        queryText: 'test',
+        responseTime: 50,
+    };
+    const clickEvent: ClickEventRequest = {
+        searchQueryUid: 'sqUid',
+        actionCause: 'documentOpen',
+        documentPosition: 1,
+        documentUriHash: 'docUriHash',
+        sourceName: 'source',
+    };
+    const customEvent: CustomEventRequest = {
+        eventType: 'custom',
+        eventValue: 'value',
+    };
+
     const eventResponse: DefaultEventResponse = {
         visitId: 'firsttimevisiting',
         visitorId: aVisitorId,
@@ -158,7 +183,46 @@ describe('Analytics', () => {
         const [body] = getParsedBodyCalls();
 
         expect(body).toMatchObject({
-            language: 'en',
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the search event', async () => {
+        mockFetchRequestForEventType(EventType.search);
+
+        await client.sendSearchEvent(searchEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the click event', async () => {
+        mockFetchRequestForEventType(EventType.click);
+
+        await client.sendClickEvent(clickEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the custom event', async () => {
+        mockFetchRequestForEventType(EventType.custom);
+
+        await client.sendCustomEvent(customEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
             userAgent: navigator.userAgent,
         });
     });

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -187,6 +187,11 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             this.clear();
             this.runtime.storage = new NullStorage();
         }
+
+        this.addEventTypeMapping(EventType.view, {newEventType: EventType.view, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.click, {newEventType: EventType.click, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.custom, {newEventType: EventType.custom, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.search, {newEventType: EventType.search, addClientIdParameter: true});
     }
 
     private initRuntime(clientsOptions: IAnalyticsClientOptions) {

--- a/src/coveoua/simpleanalytics.ts
+++ b/src/coveoua/simpleanalytics.ts
@@ -48,7 +48,6 @@ export class CoveoUA {
                 ...payload,
                 ...this.params,
             }));
-            this.client.addEventTypeMapping(EventType.view, {newEventType: EventType.view, addClientIdParameter: true});
         } else {
             throw new Error(`You must pass either your token or a valid object when you call 'init'`);
         }

--- a/src/events.ts
+++ b/src/events.ts
@@ -71,19 +71,19 @@ export interface SearchEventRequest extends EventBaseRequest {
 export interface PreparedSearchEventRequest extends Omit<SearchEventRequest, 'searchQueryUid'> {}
 
 export interface DocumentInformation {
-    documentUri: string;
+    documentUri?: string;
     documentUriHash: string;
-    collectionName: string;
+    collectionName?: string;
     sourceName: string;
     documentPosition: number;
     actionCause: string;
 
     searchQueryUid: string;
-    documentTitle: string;
-    documentUrl: string;
-    documentAuthor: string;
-    queryPipeline: string;
-    rankingModifier: string;
+    documentTitle?: string;
+    documentUrl?: string;
+    documentAuthor?: string;
+    queryPipeline?: string;
+    rankingModifier?: string;
 }
 
 export interface ClickEventRequest extends EventBaseRequest, DocumentInformation {}

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -1390,7 +1390,7 @@ describe('InsightClient', () => {
             expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, expectedMetadata);
         });
 
-        it.only('should send proper payload for #createArticle', async () => {
+        it('should send proper payload for #createArticle', async () => {
             const exampleCreateArticleMetadata = {
                 articleType: 'Knowledge__kav',
                 triggeredBy: 'CreateArticleButton',


### PR DESCRIPTION
This change adds a mapping to inject clientId into all UA events. Previously, this setting was enabled for calls through `coveoua` only, and only for view events. Rationale for this change:
- Some clients use the `AnalyticsClient` to create custom integrations. They should get the same mapping as clients using `coveoua` in the browser.
- There's no reason why view events should get a clientId injected, but e.g. custom, click and search events should not.
This change should also cut down on the number of events we get with no clientId.

Notes:
- Added tests. Removed a single line from the view test on language (language was explicitly transmitted in the payload already).
- Fixed tests for the insight client, which had accidentally disabled all of their testing through `it.only`.