### PR TITLE
fix: add quick `window` check

### DIFF
--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -214,7 +214,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private async determineVisitorId() {
         try {
             return (
-                this.extractClientIdFromLink(window.location.href) ||
+                (hasWindow() && this.extractClientIdFromLink(window.location.href)) || // This is not good, because it fails for nodeJsRuntime
                 (await this.storage.getItem('visitorId')) ||
                 uuidv4()
             );

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -214,7 +214,7 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     private async determineVisitorId() {
         try {
             return (
-                (hasWindow() && this.extractClientIdFromLink(window.location.href)) || // This is not good, because it fails for nodeJsRuntime
+                (hasWindow() && this.extractClientIdFromLink(window.location.href)) ||
                 (await this.storage.getItem('visitorId')) ||
                 uuidv4()
             );


### PR DESCRIPTION
When attempting to generate the client ID, the `CoveoAnalyticsClient` initially tries to extract it from the browser URL by reading `window.location.href`. However, in server-side rendering (SSR) environments, such as when running the code on the server, the `window` variable is not defined. This results in a warning message being printed to the console.

Despite the window variable being undefined, the client ID is still generated randomly. However, the presence of the warning message is undesirable and can be considered an annoyance.