### PR TITLE
feat(SFINT-5328): Removed triggeredBy from the metadata of createArticle event

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -1393,7 +1393,6 @@ describe('InsightClient', () => {
         it('should send proper payload for #createArticle', async () => {
             const exampleCreateArticleMetadata = {
                 articleType: 'Knowledge__kav',
-                triggeredBy: 'CreateArticleButton',
             };
             const expectedMetadata = {
                 ...exampleCreateArticleMetadata,

--- a/src/insight/insightEvents.ts
+++ b/src/insight/insightEvents.ts
@@ -72,7 +72,6 @@ export interface UserActionsPageViewMetadata {
 
 export interface CreateArticleMetadata {
     articleType: string;
-    triggeredBy: string;
 }
 
 export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}


### PR DESCRIPTION
[SFINT-5328](https://coveord.atlassian.net/browse/SFINT-5328)

Following discussions about the usefulness of the `triggeredBy` in the createArticle metadata sent to UA, we decided to remove it. Going forward, the createArticle event will only send the articleType to UA.

It should not impact the platform as no feature in prod currently use this custom event.

[SFINT-5328]: https://coveord.atlassian.net/browse/SFINT-5328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ