### PR TITLE
[UA-8522] Encode payload as json rather than form

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "lint:fix": "prettier --write .",
         "build": "rollup -c",
         "start": "rollup -c -w --environment SERVE",
-        "test": "jest --clearCache && jest --coverage",
-        "test:watch": "jest --clearCache && jest --watch",
+        "test": "jest --clearCache && jest --coverage --silent",
+        "test:watch": "jest --clearCache && jest --watch --silent",
         "prepare-deploy": "mkdir -p deploy && cp dist/coveoua*.js dist/coveoua*.js.map deploy",
         "clean": "rimraf -rf dist dist_test coverage"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "coveo.analytics",
-    "version": "2.28.22",
+    "version": "2.29.0",
     "description": "📈 Coveo analytics client (node and browser compatible) ",
     "main": "dist/library.cjs",
     "module": "dist/browser.mjs",

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,34 @@
 
         function testBeacon() {
             const beaconClient = coveoanalytics.getCurrentClient().runtime.beaconClient;
+            beaconClient.sendEvent('click', {
+                anonymous: true,
+                clientId: '3c03d51b-9f73-4168-af5e-9853cdb9782a',
+                actionCause: 'documentOpen',
+                documentPosition: 2,
+                documentTitle: 'Coveo for Salesforce',
+                documentUrl: 'https://docs.coveo.com/en/1243/',
+                language: 'en',
+                originLevel1: 'ExternalSearch',
+                originLevel2: 'All',
+                searchQueryUid: 'df60b2fb-c276-49ae-b704-2ee45609f3a6',
+                sourceName: 'AnswersCloud',
+                userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36',
+                customData: {
+                    contentIDKey: 'permanentid',
+                    contentIDValue: '648a63d6a19545297692b4ae41a7d5e947c711be5f3c23dff69af3106960',
+                },
+            });
+            beaconClient.sendEvent('view', {
+                userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+                location: 'http://localhost:9001/',
+                contentIdKey: 'test',
+                contentIdValue: 'value',
+                contentType: 'product',
+                clientId: '3c03d51b-9f73-4168-af5e-9853cdb9782a',
+            });
             beaconClient.sendEvent('collect', {
                 cid: '3c03d51b-9f73-4168-af5e-9853cdb9782a',
                 de: 'windows-1252',

--- a/public/index.html
+++ b/public/index.html
@@ -32,15 +32,23 @@
         }, 1000);
 
         function testBeacon() {
-            coveoua('ec:addProduct', {
-                name: 'wow',
-                id: 'something',
-                brand: 'brand',
-                custom: {verycustom: 'value'},
-                unknown: 'shouldberemoved',
+            const beaconClient = coveoanalytics.getCurrentClient().runtime.beaconClient;
+            beaconClient.sendEvent('collect', {
+                cid: '3c03d51b-9f73-4168-af5e-9853cdb9782a',
+                de: 'windows-1252',
+                dl: 'http://localhost/firstpage',
+                dr: 'http://localhost:9001/',
+                pid: 'eea3997b-5f2e-4d23-b55c-cb577589ab56',
+                pa: 'add',
+                sd: '24-bit',
+                sr: '2560x1440',
+                t: 'event',
+                tm: 1704298479413,
+                ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36',
+                uid: 'anonymous',
+                ul: 'en-GB',
+                z: 'b0d275e9-a664-4d5b-b78f-b326de661f61',
             });
-            coveoua('ec:setAction', 'addToCart');
-            coveoua('send', 'event');
         }
 
         async function decorate(element) {

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -66,7 +66,9 @@ describe('AnalyticsBeaconClient', () => {
             expect.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
-            'access_token=%F0%9F%91%9B&pr1a=value&to%20encode=to%20encode'
+            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(
+                `{"pr1a":"value","to encode":"to encode"}`
+            )}`
         );
     });
 
@@ -95,7 +97,7 @@ describe('AnalyticsBeaconClient', () => {
             expect.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
-            `access_token=%F0%9F%91%9B&value=${encodeURIComponent(JSON.stringify({subvalue: 'ok'}))}`
+            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(`{"value":{"subvalue":"ok"}}`)}`
         );
     });
 
@@ -131,7 +133,7 @@ describe('AnalyticsBeaconClient', () => {
 
             expect(clientOrigin!).toBe('analyticsBeacon');
             expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, expect.anything());
-            expect(await getSendBeaconFirstCallBlobArgument()).toContain('test=custom');
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain('%22test%22%3A%22custom%22');
         });
 
         it('to modify the request body as a JSON string for a collect event', async () => {
@@ -144,7 +146,9 @@ describe('AnalyticsBeaconClient', () => {
             });
 
             await client.sendEvent(EventType.collect, {foo: 'bar'});
-            expect(await getSendBeaconFirstCallBlobArgument()).toContain(`foo=baz`);
+            expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+                'access_token=%F0%9F%91%9B&collectEvent=%7B%22foo%22%3A%22baz%22%7D'
+            );
         });
 
         it('to modify the request body as a JSON string for a click event', async () => {

--- a/src/client/analyticsBeaconClient.spec.ts
+++ b/src/client/analyticsBeaconClient.spec.ts
@@ -41,7 +41,7 @@ describe('AnalyticsBeaconClient', () => {
             `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`,
             expect.anything()
         );
-        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent(`{"wow":"ok"}`)}`);
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent('{"wow":"ok"}')}`);
     });
 
     it('can send a collect event with the proper payload', async () => {
@@ -67,7 +67,7 @@ describe('AnalyticsBeaconClient', () => {
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
             `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(
-                `{"pr1a":"value","to encode":"to encode"}`
+                '{"pr1a":"value","to encode":"to encode"}'
             )}`
         );
     });
@@ -97,7 +97,7 @@ describe('AnalyticsBeaconClient', () => {
             expect.anything()
         );
         expect(await getSendBeaconFirstCallBlobArgument()).toBe(
-            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(`{"value":{"subvalue":"ok"}}`)}`
+            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent('{"value":{"subvalue":"ok"}}')}`
         );
     });
 
@@ -162,7 +162,7 @@ describe('AnalyticsBeaconClient', () => {
 
             await client.sendEvent(EventType.click, {actionCause: 'foo'});
             expect(await getSendBeaconFirstCallBlobArgument()).toContain(
-                `clickEvent=${encodeURIComponent(`{"actionCause":"bar"}`)}`
+                `clickEvent=${encodeURIComponent('{"actionCause":"bar"}')}`
             );
         });
 
@@ -176,7 +176,7 @@ describe('AnalyticsBeaconClient', () => {
 
             await client.sendEvent(EventType.click, {actionCause: 'foo'});
             expect(await getSendBeaconFirstCallBlobArgument()).toContain(
-                `clickEvent=${encodeURIComponent(`{"actionCause":"foo","aNewProperty":"bar"}`)}`
+                `clickEvent=${encodeURIComponent('{"actionCause":"foo","aNewProperty":"bar"}')}`
             );
         });
 

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -68,8 +68,8 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
 
     private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {
         return this.isEventTypeLegacy(eventType)
-            ? this.encodeToJson(eventType, payload)
-            : this.encodeToJson(eventType, payload, this.opts.token);
+            ? this.encodeEventToJson(eventType, payload)
+            : this.encodeEventToJson(eventType, payload, this.opts.token);
     }
 
     private async getQueryParamsForEventType(eventType: EventType): Promise<string> {
@@ -88,13 +88,11 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         return [EventType.click, EventType.custom, EventType.search, EventType.view].indexOf(eventType) !== -1;
     }
 
-    private encodeToJson(eventType: EventType, payload: IRequestPayload, access_token?: string): string {
+    private encodeEventToJson(eventType: EventType, payload: IRequestPayload, access_token?: string): string {
+        let encoded = `${eventType}Event=${encodeURIComponent(JSON.stringify(payload))}`;
         if (access_token) {
-            return `access_token=${encodeURIComponent(access_token)}&${eventType}Event=${encodeURIComponent(
-                JSON.stringify(payload)
-            )}`;
-        } else {
-            return `${eventType}Event=${encodeURIComponent(JSON.stringify(payload))}`;
+            encoded = `access_token=${encodeURIComponent(access_token)}&${encoded}`;
         }
+        return encoded;
     }
 }

--- a/src/client/analyticsBeaconClient.ts
+++ b/src/client/analyticsBeaconClient.ts
@@ -68,11 +68,8 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
 
     private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {
         return this.isEventTypeLegacy(eventType)
-            ? this.encodeForLegacyType(eventType, payload)
-            : this.encodeForFormUrlEncoded({
-                  access_token: this.opts.token,
-                  ...payload,
-              });
+            ? this.encodeToJson(eventType, payload)
+            : this.encodeToJson(eventType, payload, this.opts.token);
     }
 
     private async getQueryParamsForEventType(eventType: EventType): Promise<string> {
@@ -91,20 +88,13 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
         return [EventType.click, EventType.custom, EventType.search, EventType.view].indexOf(eventType) !== -1;
     }
 
-    private encodeForLegacyType(eventType: EventType, payload: IRequestPayload): string {
-        return `${eventType}Event=${encodeURIComponent(JSON.stringify(payload))}`;
-    }
-
-    private encodeForFormUrlEncoded(payload: IRequestPayload): string {
-        return Object.keys(payload)
-            .filter((key) => !!payload[key])
-            .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(this.encodeValue(payload[key]))}`)
-            .join('&');
-    }
-
-    private encodeValue(value: any) {
-        return typeof value === 'number' || typeof value === 'string' || typeof value === 'boolean'
-            ? value
-            : JSON.stringify(value);
+    private encodeToJson(eventType: EventType, payload: IRequestPayload, access_token?: string): string {
+        if (access_token) {
+            return `access_token=${encodeURIComponent(access_token)}&${eventType}Event=${encodeURIComponent(
+                JSON.stringify(payload)
+            )}`;
+        } else {
+            return `${eventType}Event=${encodeURIComponent(JSON.stringify(payload))}`;
+        }
     }
 }


### PR DESCRIPTION
This change modifies the way the beacon client sends information to the UA endpoint. UA endpoint has already been modified in a backwards compatible way in [this change set](https://github.com/coveo/usageanalytics/pull/2686). Prior to the below change coveoua was sending in collect events in a form-encoded way, where each parameter is a separate URI encoded entry.
```
access_token=TOK&pa=add&pr1id=SKU%202353&tm=1243345
```
When the write service receives this content, it has no other option than to treat all parameters as strings and logs them in the data lake as such, which causes issues with validating parameters that were originally supplied as numeric (e.g. 1243345 above).

After this change, coveoua will still send in the information as formencoded, but the entire event content is stringified JSON. This allows re-parsing of the json on the backend, which can use double quotes to identify strings vs numeric variables:
```
access_token=TOK&collectEvent=%7B%22pa%22%3A%22add%22...%7D
```
The access_token is still part of the form parameters, as the original endpoint for receiving beaconCollect events requires it to be, and removing it would break existing logging with older versions of coveoua. Technically it could also have been sent as a query param. Note that we cannot introduce a collect parameter called `collectEvent` anymore, since the server side logic switches based on the presence of that formParameter.

I modified the index.html file to allow beacon testing. I'm not sure how this was tested previously. I verified that events logged using the beacon api with the new format end up in the data lake as expected.

---
Note that this change is hard to verify, since there's no good way to verify that beacon-collect events are logged appropriately in production (since they are quite rare), and it'll be impossible to detect that we are dropping these type of events on the backend. Prior to deployment the following steps should be taken:
- Verify that the write service change has been deployed in prod (!)
- Use the index.html page to manually send a few beacon-collect events to UA prod and verify they are logged in RAW
- Use a redirector plugin to load the new version of coveoua into a customer integration and verify existing logging still works: beacon-click, standard collect. It'll be very hard to trigger a beacon-collect event with site interactions.