### PR TITLE
fix: preserve visitorId when disabling coveoua, or when DNT is active

### DIFF
--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -10,6 +10,7 @@ import {mockFetch, lastCallBody} from '../../tests/fetchMock';
 import {TicketProperties} from '../plugins/svc';
 const {fetchMock, fetchMockBeforeEach} = mockFetch();
 import doNotTrack from '../donottrack';
+import {Cookie} from '../cookieutils';
 jest.mock('../donottrack', () => {
     return {
         default: jest.fn(),
@@ -176,6 +177,15 @@ describe('CaseAssistClient', () => {
         });
 
         expect(fetchMock.called()).toBe(false);
+    });
+
+    it('disabling does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        client.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
     });
 
     it('should send events after #enable function is called', async () => {

--- a/src/caseAssist/caseAssistClient.ts
+++ b/src/caseAssist/caseAssistClient.ts
@@ -37,9 +37,6 @@ export class CaseAssistClient {
     }
 
     public disable() {
-        if (this.coveoAnalyticsClient instanceof CoveoAnalyticsClient) {
-            this.coveoAnalyticsClient.clear();
-        }
         this.coveoAnalyticsClient = new NoopAnalytics();
         this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
     }

--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -667,14 +667,14 @@ describe('doNotTrack', () => {
         expect(client.runtime.storage).toBeInstanceOf(NullStorage);
     });
 
-    it('should clear existing cookies', async () => {
+    it('should not clear existing cookies', async () => {
         jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => true);
         Cookie.set('coveo_visitorId', aVisitorId);
         expect(Cookie.get('coveo_visitorId')).toBe(aVisitorId);
 
         new CoveoAnalyticsClient({});
 
-        expect(Cookie.get('coveo_visitorId')).not.toBe(aVisitorId);
+        expect(Cookie.get('coveo_visitorId')).toBe(aVisitorId);
     });
 });
 

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -184,7 +184,6 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
 
         this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);
         if (doNotTrack()) {
-            this.clear();
             this.runtime.storage = new NullStorage();
         }
 

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -12,6 +12,7 @@ import {
 import {CoveoInsightClient, InsightClientProvider} from './insightClient';
 import doNotTrack from '../donottrack';
 import {InsightEvents, InsightStaticFilterToggleValueMetadata} from './insightEvents';
+import {Cookie} from '../cookieutils';
 
 const baseCaseMetadata = {
     caseId: '1234',
@@ -1418,6 +1419,16 @@ describe('InsightClient', () => {
         expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
         c.disable();
         expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('disabling analytics does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+        const c = new CoveoInsightClient({enableAnalytics: true}, provider);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        c.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
     });
 
     it('should disable analytics when doNotTrack is enabled', async () => {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -93,9 +93,6 @@ export class CoveoInsightClient {
     }
 
     public disable() {
-        if (this.coveoAnalyticsClient instanceof CoveoAnalyticsClient) {
-            this.coveoAnalyticsClient.clear();
-        }
         this.coveoAnalyticsClient = new NoopAnalytics();
     }
 

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -12,6 +12,8 @@ import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {mockFetch, lastCallBody} from '../../tests/fetchMock';
 import doNotTrack from '../donottrack';
+import {Cookie} from '../cookieutils';
+
 jest.mock('../donottrack', () => {
     return {
         default: jest.fn(),
@@ -1422,6 +1424,16 @@ describe('SearchPageClient', () => {
         expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
         c.disable();
         expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('disabling analytics does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+        const c = new CoveoSearchPageClient({enableAnalytics: true}, provider);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        c.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
     });
 
     it('should allow enabling analytics after initialization', () => {

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -84,10 +84,6 @@ export class CoveoSearchPageClient {
     }
 
     public disable() {
-        if (this.coveoAnalyticsClient instanceof CoveoAnalyticsClient) {
-            this.coveoAnalyticsClient.clear();
-        }
-
         this.coveoAnalyticsClient = new NoopAnalytics();
     }
 


### PR DESCRIPTION
**Context**
Disabling coveoua has an unexpected side-effect of deleting the visitorId.
This can contribute to clientId [de-sync issues](https://coveord.atlassian.net/browse/LENS-1346) between Coveo libraries (e.g. headless and relay).
It also loses out on anonymous customer personalization if a customer temporarily changes their preferences. e.g. activating DNT and then reverting it, or accepting being tracked -> declining -> accepting.

**Solution**
When coveoua is disabled, or DNT is active, coveoua will no longer clear the visitorId cookie.

**Is this legal?**
Yes, confirmed with Marie Blanchet (@Mblanchetdeverly) from the Legal team that when a user expresses they do not want to be tracked, there is no obligation to delete cookies that already exist in the page.