### PR TITLE
feat(genQa): add answerTextIsEmpty to genQA meta data stream event

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -618,6 +618,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 answerGenerated: true,
+                answerTextIsEmpty: false,
             };
 
             await client.logGeneratedAnswerStreamEnd(exampleGeneratedAnswerMetadata);
@@ -1381,6 +1382,7 @@ describe('InsightClient', () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',
                 answerGenerated: true,
+                answerTextIsEmpty: false,
             };
             const expectedMetadata = {
                 ...exampleGeneratedAnswerMetadata,

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1494,13 +1494,13 @@ describe('SearchPageClient', () => {
     });
 
     it('should send proper payload for #logGeneratedAnswerStreamEnd', async () => {
-        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true};
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
         await client.logGeneratedAnswerStreamEnd(meta);
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
     });
 
     it('should send proper payload for #makeGeneratedAnswerStreamEnd', async () => {
-        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true};
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
         const built = await client.makeGeneratedAnswerStreamEnd(meta);
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -530,7 +530,7 @@ export interface GeneratedAnswerBaseMeta {
 
 export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
     answerGenerated: boolean;
-    answerTextIsEmpty: boolean;
+    answerTextIsEmpty?: boolean;
 }
 
 export interface GeneratedAnswerCitationMeta {

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -530,6 +530,7 @@ export interface GeneratedAnswerBaseMeta {
 
 export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
     answerGenerated: boolean;
+    answerTextIsEmpty: boolean;
 }
 
 export interface GeneratedAnswerCitationMeta {


### PR DESCRIPTION
[SVCC-3599](https://coveord.atlassian.net/browse/SVCC-3599)

add `answerTextIsEmpty` to generated answer stream event, in order  to check whether there was a message or not. 

As for now we cannot distinguish between getting an answer, no answer WITH message and no answer WITHOUT message.

[SVCC-3599]: https://coveord.atlassian.net/browse/SVCC-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ