### PR TITLE
fix(SFINT-5395): Wrapped sendEvent response in try/catch in analyticsFetchClient

### DIFF
--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -5,7 +5,7 @@ import {fetch} from 'cross-fetch';
 export class AnalyticsFetchClient implements AnalyticsRequestClient {
     constructor(private opts: IAnalyticsClientOptions) {}
 
-    public async sendEvent(eventType: EventType, payload: IRequestPayload): Promise<AnyEventResponse> {
+    public async sendEvent(eventType: EventType, payload: IRequestPayload): Promise<AnyEventResponse | undefined> {
         const {baseUrl, visitorIdProvider, preprocessRequest} = this.opts;
 
         const visitorIdParam = this.shouldAppendVisitorId(eventType) ? await this.getVisitorIdParam() : '';
@@ -22,25 +22,29 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
             ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'analyticsFetch') : {}),
         };
 
-        const response = await fetch(url, fetchData);
-        if (response.ok) {
-            const visit = (await response.json()) as AnyEventResponse;
+        try {
+            const response = await fetch(url, fetchData);
+            if (response.ok) {
+                const visit = (await response.json()) as AnyEventResponse;
 
-            if (visit.visitorId) {
-                visitorIdProvider.setCurrentVisitorId(visit.visitorId);
-            }
+                if (visit.visitorId) {
+                    visitorIdProvider.setCurrentVisitorId(visit.visitorId);
+                }
 
-            return visit;
-        } else {
-            try {
-                response.json();
-            } catch {
-                /* If you don't parse the response, it won't appear in the network tab. */
+                return visit;
+            } else {
+                try {
+                    response.json();
+                } catch {
+                    /* If you don't parse the response, it won't appear in the network tab. */
+                }
+                console.error(`An error has occured when sending the "${eventType}" event.`, response, payload);
+                throw new Error(
+                    `An error has occurred when sending the "${eventType}" event. Check the console logs for more details.`
+                );
             }
-            console.error(`An error has occured when sending the "${eventType}" event.`, response, payload);
-            throw new Error(
-                `An error has occurred when sending the "${eventType}" event. Check the console logs for more details.`
-            );
+        } catch (error) {
+            console.error('An error has occured when sending the event.', error);
         }
     }
 


### PR DESCRIPTION
[SFINT-5395](https://coveord.atlassian.net/browse/SFINT-5395)

Wrapped the sendEvent reponse in a try/catch block to prevent some issues we were encountering when the response would fail on the fetch call. 

For example, we had an issue where an ad blocker (Ublock) would prevent the analytics event when changing tab in the Salesforce HIP and would display an error modal.

![image-20240208-152347](https://github.com/coveo/coveo.analytics.js/assets/73316533/d7e0f1de-de9a-44b6-beba-81a3da0354e4)
