### PR TITLE
[UA-8748] Adjust DNT logic

### DIFF
--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -11,10 +11,11 @@ import {IAnalyticsRequestOptions} from './analyticsRequestClient';
 import {CookieAndLocalStorage, CookieStorage, NullStorage} from '../storage';
 import HistoryStore from '../history';
 import {mockFetch} from '../../tests/fetchMock';
-import {BrowserRuntime} from './runtimeEnvironment';
+import {BrowserRuntime, NoopRuntime} from './runtimeEnvironment';
 import * as doNotTrack from '../donottrack';
 import {Cookie} from '../cookieutils';
 import {CoveoLinkParam} from '../plugins/link';
+import {NoopAnalytics} from './noopAnalytics';
 
 const aVisitorId = '123';
 jest.mock('uuid', () => ({
@@ -663,7 +664,7 @@ describe('doNotTrack', () => {
 
         let client = new CoveoAnalyticsClient({});
 
-        expect(client.runtime).toBeInstanceOf(BrowserRuntime);
+        expect(client.runtime).toBeInstanceOf(NoopRuntime);
         expect(client.runtime.storage).toBeInstanceOf(NullStorage);
     });
 

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -182,9 +182,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             preprocessRequest: this.options.preprocessRequest,
         };
 
-        this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);
         if (doNotTrack()) {
-            this.runtime.storage = new NullStorage();
+            this.runtime = new NoopRuntime();
+        } else {
+            this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);
         }
 
         this.addEventTypeMapping(EventType.view, {newEventType: EventType.view, addClientIdParameter: true});


### PR DESCRIPTION
The existing logic for Do Not Track (DNT) in the basic coveoua AnalyticsClient was incorrect. The desired logic is:
- When a DNT header is present, no analytics events should be sent to the Coveo backend.
- When a DNT header is present, no cookies should be stored.
In collaboration with legal, we removed the requirement to *remove* already existing Cookies when a DNT header is found. There is no legal basis for this, and hidden removal of Cookies by software may be seen as intrusive.

The existing logic only removed the cookie, but did not disable the sending of analytics. This causes any integration using `coveoua` directly AND having a DNT header to initialize with a fresh clientId, but still send events. In practice this means, every time coveoua is initialized on a fresh page, the event will have a new clientID for clients with a DNT header. Needless to say, this causes bad downstream effects.