### PR TITLE
fix: make cajs less painful with nextjs

### DIFF
--- a/src/client/analyticsFetchClient.ts
+++ b/src/client/analyticsFetchClient.ts
@@ -1,7 +1,8 @@
 import {AnalyticsRequestClient, IAnalyticsRequestOptions, IAnalyticsClientOptions} from './analyticsRequestClient';
 import {AnyEventResponse, EventType, IRequestPayload} from '../events';
-import {fetch} from 'cross-fetch';
+import {crossFetch} from 'cross-fetch';
 
+const isoFetch = fetch ?? crossFetch;
 export class AnalyticsFetchClient implements AnalyticsRequestClient {
     constructor(private opts: IAnalyticsClientOptions) {}
 
@@ -25,7 +26,7 @@ export class AnalyticsFetchClient implements AnalyticsRequestClient {
         let response: Response;
 
         try {
-            response = await fetch(url, fetchData);
+            response = await isoFetch(url, fetchData);
         } catch (error) {
             console.error('An error has occured when sending the event.', error);
             return;

--- a/src/donottrack.ts
+++ b/src/donottrack.ts
@@ -4,13 +4,13 @@
 // gathering data of actions of an user as long as it is not associated to the
 // identity of that user, doNotTrack is not enabled here.
 
-import {hasNavigator} from './detector';
+import {hasNavigator, hasWindow} from './detector';
 
 const doNotTrackValues = ['1', 1, 'yes', true];
 
 export function doNotTrack(): boolean {
     return (
-        hasNavigator() &&
+        hasNavigator() && hasWindow() &&
         [
             (<any>navigator).globalPrivacyControl,
             (<any>navigator).doNotTrack,


### PR DESCRIPTION
cross-fetch is a little bit of a pain, as it directly refer `window` to get its fetch instance.
![image](https://github.com/coveo/coveo.analytics.js/assets/12366410/34d419b8-0dbd-4f5f-877d-6fb3e1e7bcd5)

Also, Node now has a navigator property, so it'll go 💥 on Node 21+ https://nodejs.org/api/globals.html#navigator_1