### PR TITLE
fix(ec): pageview will not include action, product and impression

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -99,7 +99,7 @@ describe('ec events', () => {
         });
     });
 
-    it('can send a product detail view event', async () => {
+    it('will not include the product or action when sending a pageview event', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
         await coveoua('send', 'pageview');
@@ -109,6 +109,42 @@ describe('ec events', () => {
         expect(body).toEqual({
             ...defaultContextValues,
             t: 'pageview',
+        });
+    });
+
+    it('will include the product and action only when sending a detail event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
+
+        const [pageviewBody, eventBody] = getParsedBody();
+
+        expect(pageviewBody).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+        });
+
+        expect(eventBody).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pa: 'detail',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+        });
+    });
+
+    it('can send a product detail view event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
             pr1nm: 'wow',
             pr1id: 'something',
             pr1br: 'brand',
@@ -119,13 +155,13 @@ describe('ec events', () => {
     it('can send a product detail view event with custom values', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing', custom: {verycustom: 'value'}});
-        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
 
         const [body] = getParsedBody();
 
         expect(body).toEqual({
             ...defaultContextValues,
-            t: 'pageview',
+            t: 'event',
             pr1nm: 'wow',
             pr1id: 'something',
             pr1br: 'brand',
@@ -773,13 +809,13 @@ describe('ec events', () => {
     it('should append custom values to product', async () => {
         var partialProduct = {name: 'wow', custom: {verycustom: 'value'}};
         await coveoua('ec:addProduct', partialProduct);
-        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
 
         const [body] = getParsedBody();
 
         expect(body).toEqual({
             ...defaultContextValues,
-            t: 'pageview',
+            t: 'event',
             pr1nm: partialProduct.name,
             pr1verycustom: partialProduct.custom.verycustom,
         });
@@ -857,7 +893,7 @@ describe('ec events', () => {
 
         await coveoua('ec:addImpression', productImpression1);
         await coveoua('ec:addImpression', productImpression2);
-        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
 
         const [event] = getParsedBody();
 
@@ -883,7 +919,7 @@ describe('ec events', () => {
             il1pi2ps: productImpression2.position,
             sd: defaultContextValues.sd,
             sr: defaultContextValues.sr,
-            t: 'pageview',
+            t: 'event',
             tm: expect.any(Number),
             ua: defaultContextValues.ua,
             ul: defaultContextValues.ul,

--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -115,24 +115,35 @@ describe('ec events', () => {
     it('will include the product and action only when sending a detail event', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
-        await coveoua('send', 'pageview');
+        coveoua('send', 'pageview');
         await coveoua('send', 'event');
 
-        const [pageviewBody, eventBody] = getParsedBody();
+        coveoua('ec:addProduct', {name: 'wow2', id: 'something2', brand: 'brand2'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        coveoua('send', 'event');
+        await coveoua('send', 'pageview');
 
-        expect(pageviewBody).toEqual({
-            ...defaultContextValues,
-            t: 'pageview',
-        });
+        const [pageviewBody, eventBody, eventBody2, pageviewBody2] = getParsedBody();
 
-        expect(eventBody).toEqual({
-            ...defaultContextValues,
-            t: 'event',
-            pa: 'detail',
-            pr1nm: 'wow',
-            pr1id: 'something',
-            pr1br: 'brand',
-        });
+        expect(pageviewBody.pa).toBeUndefined();
+        expect(pageviewBody.pr1nm).toBeUndefined();
+        expect(pageviewBody.pr1id).toBeUndefined();
+        expect(pageviewBody.pr1br).toBeUndefined();
+
+        expect(eventBody.pa).toEqual('detail');
+        expect(eventBody.pr1nm).toEqual('wow');
+        expect(eventBody.pr1id).toEqual('something');
+        expect(eventBody.pr1br).toEqual('brand');
+
+        expect(eventBody2.pa).toEqual('detail');
+        expect(eventBody2.pr1nm).toEqual('wow2');
+        expect(eventBody2.pr1id).toEqual('something2');
+        expect(eventBody2.pr1br).toEqual('brand2');
+
+        expect(pageviewBody2.pa).toBeUndefined();
+        expect(pageviewBody2.pr1nm).toBeUndefined();
+        expect(pageviewBody2.pr1id).toBeUndefined();
+        expect(pageviewBody2.pr1br).toBeUndefined();
     });
 
     it('can send a product detail view event', async () => {

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -45,12 +45,12 @@ describe('EC plugin', () => {
             expect(result).toEqual({...defaultResult, pr1id: 'C0V30'});
         });
 
-        it('should append the product with the pageview event', () => {
+        it('should not append the product with the pageview event', () => {
             ec.addProduct({name: 'Relevance T-Shirt'});
 
-            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
 
-            expect(result).toEqual({...defaultResult, pr1nm: 'Relevance T-Shirt'});
+            expect(result).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
         });
 
         it('should not append the product with a random event type', () => {
@@ -61,14 +61,15 @@ describe('EC plugin', () => {
             expect(result).toEqual({});
         });
 
-        it('should keep the products until a valid event type is used', () => {
+        it('should keep the products until an event type is used', () => {
             ec.addProduct({id: 'P12345'});
 
             executeRegisteredHook('🎲', {});
             executeRegisteredHook('🐟', {});
-            executeRegisteredHook('💀', {});
+            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
+            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
             expect(result).toEqual({...defaultResult, pr1id: 'P12345'});
         });
 
@@ -117,6 +118,18 @@ describe('EC plugin', () => {
             const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
             expect(secondResult).toEqual({...defaultResult});
+        });
+
+        it('should not flush the products when the pageview is sent', () => {
+            ec.addProduct({name: 'boup'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult, pr1nm: 'boup'});
         });
 
         it('should convert position to number if possible', () => {
@@ -264,14 +277,14 @@ describe('EC plugin', () => {
             expect(result).toEqual({...defaultResult, il1pi1id: 'C0V30'});
         });
 
-        it('should append the impression with the pageview event', () => {
+        it('should not append the impression with the pageview event', () => {
             ec.addImpression({name: 'Relevance T-Shirt'});
 
-            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
 
             expect(result).toEqual({
                 ...defaultResult,
-                il1pi1nm: 'Relevance T-Shirt',
+                hitType: ECPluginEventTypes.pageview,
             });
         });
 
@@ -283,14 +296,15 @@ describe('EC plugin', () => {
             expect(result).toEqual({});
         });
 
-        it('should keep the impressions until a valid event type is used', () => {
+        it('should keep the impressions until an event type is used', () => {
             ec.addImpression({id: 'P12345'});
 
             executeRegisteredHook('🎲', {});
             executeRegisteredHook('🐟', {});
-            executeRegisteredHook('💀', {});
+            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
+            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
             expect(result).toEqual({...defaultResult, il1pi1id: 'P12345'});
         });
 
@@ -372,7 +386,7 @@ describe('EC plugin', () => {
             });
         });
 
-        it('should flush the products once they are sent', () => {
+        it('should flush the impressions once they are sent', () => {
             ec.addImpression({name: '🍟', price: 1.99});
             ec.addImpression({name: '🍿', price: 3});
 
@@ -383,6 +397,18 @@ describe('EC plugin', () => {
             const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
             expect(secondResult).toEqual({...defaultResult});
+        });
+
+        it('should not flush the impressions when a pageview is sent', () => {
+            ec.addImpression({name: 'bap'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult, il1pi1nm: 'bap'});
         });
 
         describe('when the position is invalid', () => {
@@ -480,6 +506,17 @@ describe('EC plugin', () => {
         });
     });
 
+    it('should not set an action with a pageview', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+        expect(result).toEqual({
+            ...defaultResult,
+            hitType: ECPluginEventTypes.pageview,
+        });
+    });
+
     it('should flush the action once it is sent', () => {
         ec.setAction('ok');
 
@@ -490,6 +527,18 @@ describe('EC plugin', () => {
         const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
         expect(secondResult).toEqual({...defaultResult});
+    });
+
+    it('should not flush the action with the pageview', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+        expect(result).not.toEqual({});
+
+        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(secondResult).toEqual({...defaultResult, action: 'ok'});
     });
 
     it('should be able to clear all the data', () => {

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -135,21 +135,31 @@ export class ECPlugin extends BasePlugin {
     }
 
     private addECDataToPayload(eventType: string, payload: any) {
+        const isPageView = eventType === ECPluginEventTypes.pageview;
         const ecPayload = {
             ...this.getLocationInformation(eventType, payload),
             ...this.getDefaultContextInformation(eventType),
-            ...(this.action ? {action: this.action} : {}),
-            ...(this.actionData || {}),
+            ...(isPageView
+                ? {}
+                : {
+                      ...(this.action ? {action: this.action} : {}),
+                      ...(this.actionData || {}),
+                  }),
         };
 
-        const productPayload = this.getProductPayload();
-        const impressionPayload = this.getImpressionPayload();
+        const productAndImpressionPayload = isPageView
+            ? {}
+            : {
+                  ...this.getProductPayload(),
+                  ...this.getImpressionPayload(),
+              };
 
-        this.clearData();
+        if (!isPageView) {
+            this.clearData();
+        }
 
         return {
-            ...impressionPayload,
-            ...productPayload,
+            ...productAndImpressionPayload,
             ...ecPayload,
             ...payload,
         };

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -135,31 +135,29 @@ export class ECPlugin extends BasePlugin {
     }
 
     private addECDataToPayload(eventType: string, payload: any) {
-        const isPageView = eventType === ECPluginEventTypes.pageview;
+        if (eventType === ECPluginEventTypes.pageview) {
+            return {
+                ...this.getLocationInformation(eventType, payload),
+                ...this.getDefaultContextInformation(eventType),
+                ...payload,
+            };
+        }
+
         const ecPayload = {
             ...this.getLocationInformation(eventType, payload),
             ...this.getDefaultContextInformation(eventType),
-            ...(isPageView
-                ? {}
-                : {
-                      ...(this.action ? {action: this.action} : {}),
-                      ...(this.actionData || {}),
-                  }),
+            ...(this.action ? {action: this.action} : {}),
+            ...(this.actionData || {}),
         };
 
-        const productAndImpressionPayload = isPageView
-            ? {}
-            : {
-                  ...this.getProductPayload(),
-                  ...this.getImpressionPayload(),
-              };
+        const productPayload = this.getProductPayload();
+        const impressionPayload = this.getImpressionPayload();
 
-        if (!isPageView) {
-            this.clearData();
-        }
+        this.clearData();
 
         return {
-            ...productAndImpressionPayload,
+            ...impressionPayload,
+            ...productPayload,
             ...ecPayload,
             ...payload,
         };


### PR DESCRIPTION
Jira: https://coveord.atlassian.net/browse/LENS-1826

The issue described in the Jira, Slack thread and discuss was that sometimes the "event" type event didn't include the product and product action / the "pageview" type event include the product and product action.

It would seems that the order of event that are sent is important, but to prevent the plugin's data to be cleared too soon OR that we include the data to a `pageview` event, I've added a pageview check.

One argument that could be made is to put the emphasis in the documentation that the "event" type should absolutely be sent before the pageview to prevent this problem. However, there's also an argument to be made that maybe the order shouldn't matter (especially when these events were historically coupled together, so more client's implementations might be broken then we think). 

Demo of the results:

https://github.com/coveo/coveo.analytics.js/assets/58052881/3d115b34-660a-421f-9e65-5d8183259ae5
