### PR TITLE
feat(genQA): add new version of UA events for feedback submit

### DIFF
--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -4,6 +4,7 @@ import {NoopAnalytics} from '../client/noopAnalytics';
 import {
     CustomEventsTypes,
     GeneratedAnswerFeedbackReason,
+    GeneratedAnswerFeedbackReasonOption,
     GeneratedAnswerRephraseFormat,
     PartialDocumentInformation,
     SearchPageEvents,
@@ -1397,6 +1398,28 @@ describe('InsightClient', () => {
 
             await client.logGeneratedAnswerFeedbackSubmit(exampleGeneratedAnswerMetadata, baseCaseMetadata);
             expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmitV2', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                helpful: true,
+                readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+                correctness: {
+                    documented: <GeneratedAnswerFeedbackReasonOption>'no',
+                    correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+                    hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+                },
+                details: 'foo',
+                documentUrl: 'https://document.com',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmitV2(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmitV2, expectedMetadata);
         });
 
         it('should send proper payload for #rephraseGeneratedAnswer', async () => {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -652,6 +652,27 @@ describe('InsightClient', () => {
             await client.logCreateArticle(exampleCreateArticleMetadata);
             expectMatchCustomEventPayload(InsightEvents.createArticle, exampleCreateArticleMetadata);
         });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmitV2', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                helpful: true,
+                readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+                correctness: {
+                    documented: <GeneratedAnswerFeedbackReasonOption>'no',
+                    correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+                    hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+                },
+                details: 'foo',
+                documentUrl: 'https://document.com',
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmitV2(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generatedAnswerFeedbackSubmitV2,
+                exampleGeneratedAnswerMetadata
+            );
+        });
     });
 
     describe('when the case metadata is included', () => {

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -9,6 +9,7 @@ import {
     GeneratedAnswerBaseMeta,
     GeneratedAnswerCitationMeta,
     GeneratedAnswerFeedbackMeta,
+    GeneratedAnswerFeedbackMetaV2,
     GeneratedAnswerRephraseMeta,
     GeneratedAnswerSourceHoverMeta,
     GeneratedAnswerStreamEndMeta,
@@ -584,6 +585,18 @@ export class CoveoInsightClient {
     ) {
         return this.logCustomEvent(
             SearchPageEvents.generatedAnswerFeedbackSubmit,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
+                : generatedAnswerFeedbackMetadata
+        );
+    }
+
+    public logGeneratedAnswerFeedbackSubmitV2(
+        generatedAnswerFeedbackMetadata: GeneratedAnswerFeedbackMetaV2,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerFeedbackSubmitV2,
             metadata
                 ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
                 : generatedAnswerFeedbackMetadata

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1602,7 +1602,7 @@ describe('SearchPageClient', () => {
         expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCollapse, meta);
     });
 
-    it('should send proper payload for #logGeneratedAnswerFeedbackSubmiV2', async () => {
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmitV2', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             helpful: true,

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -7,6 +7,7 @@ import {
     StaticFilterToggleValueMetadata,
     GeneratedAnswerFeedbackReason,
     GeneratedAnswerRephraseFormat,
+    GeneratedAnswerFeedbackReasonOption,
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
@@ -1602,6 +1603,23 @@ describe('SearchPageClient', () => {
     });
 
     it('should send proper payload for #logGeneratedAnswerFeedbackSubmit', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            helpful: true,
+            readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+            correctness: {
+                documented: <GeneratedAnswerFeedbackReasonOption>'no',
+                correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+                hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+            },
+            details: 'a few additional details',
+            documentUrl: 'https://document.com',
+        };
+        await client.logGeneratedAnswerFeedbackSubmitV2(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmitV2, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmitV2', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             reason: <GeneratedAnswerFeedbackReason>'other',

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1602,7 +1602,7 @@ describe('SearchPageClient', () => {
         expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCollapse, meta);
     });
 
-    it('should send proper payload for #logGeneratedAnswerFeedbackSubmit', async () => {
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmiV2', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             helpful: true,
@@ -1619,7 +1619,7 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmitV2, meta);
     });
 
-    it('should send proper payload for #logGeneratedAnswerFeedbackSubmitV2', async () => {
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmit', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
             reason: <GeneratedAnswerFeedbackReason>'other',

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -42,6 +42,7 @@ import {
     GeneratedAnswerSourceHoverMeta,
     GeneratedAnswerBaseMeta,
     GeneratedAnswerRephraseMeta,
+    GeneratedAnswerFeedbackMetaV2,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -973,6 +974,15 @@ export class CoveoSearchPageClient {
 
     public async logGeneratedAnswerFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
         return (await this.makeGeneratedAnswerFeedbackSubmit(meta)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerFeedbackSubmitV2(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerFeedbackSubmitV2, metadata);
+    }
+    public async logGeneratedAnswerFeedbackSubmitV2(meta: GeneratedAnswerFeedbackMetaV2) {
+        return (await this.makeGeneratedAnswerFeedbackSubmitV2(meta)).log({
             searchUID: this.provider.getSearchUID(),
         });
     }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -346,6 +346,10 @@ export enum SearchPageEvents {
      * Identifies the search event that gets logged when a user clicks the rephrase button in a generated answer.
      */
     rephraseGeneratedAnswer = 'rephraseGeneratedAnswer',
+    /**
+     * Identifies the new version of custom event that gets logged when a user submits a feedback of a generated answer.
+     */
+    generatedAnswerFeedbackSubmitV2 = 'generatedAnswerFeedbackSubmitV2',
 }
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
@@ -393,6 +397,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.generatedAnswerExpand]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerCollapse]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerFeedbackSubmit]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerFeedbackSubmitV2]: 'generatedAnswer',
     [InsightEvents.expandToFullUI]: 'interface',
     [InsightEvents.openUserActions]: 'User Actions',
     [InsightEvents.showPrecedingSessions]: 'User Actions',
@@ -564,4 +569,20 @@ export interface GeneratedAnswerRephraseMeta extends GeneratedAnswerBaseMeta {
 export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {
     reason: GeneratedAnswerFeedbackReason;
     details?: string;
+}
+
+export type GeneratedAnswerFeedbackReasonOption = 'yes' | 'unknown' | 'no';
+
+export type GeneratedAnswerFeedbackReasonCorrectness = {
+    documented: GeneratedAnswerFeedbackReasonOption;
+    correctTopic: GeneratedAnswerFeedbackReasonOption;
+    hallucinationFree: GeneratedAnswerFeedbackReasonOption;
+};
+
+export interface GeneratedAnswerFeedbackMetaV2 extends GeneratedAnswerBaseMeta {
+    helpful: boolean;
+    readable: GeneratedAnswerFeedbackReasonOption;
+    correctness: GeneratedAnswerFeedbackReasonCorrectness;
+    details?: string;
+    documentUrl?: string;
 }


### PR DESCRIPTION
[SVCC-3816](https://coveord.atlassian.net/browse/SVCC-3816)

Add new analytic event for Feedback submit `logGeneratedAnswerFeedbackSubmitV2` to the search and insight clients.

This V2 event is added for the improvement of the current feedback modal.

[SVCC-3816]: https://coveord.atlassian.net/browse/SVCC-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ