### PR TITLE
[UA-9043] Upgrade dependency, npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@types/uuid": "^9.0.0",
                 "cross-fetch": "^3.1.5",
-                "react-native-get-random-values": "^1.8.0",
+                "react-native-get-random-values": "^1.11.0",
                 "rollup-plugin-copy": "^3.5.0",
                 "uuid": "^9.0.0"
             },
@@ -3319,20 +3319,19 @@
             }
         },
         "node_modules/@react-native-community/cli-doctor": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.2.2.tgz",
-            "integrity": "sha512-49Ep2aQOF0PkbAR/TcyMjOm9XwBa8VQr+/Zzf4SJeYwiYLCT1NZRAVAVjYRXl0xqvq5S5mAGZZShS4AQl4WsZw==",
+            "version": "10.2.7",
+            "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.2.7.tgz",
+            "integrity": "sha512-MejE7m+63DxfKwFSvyZGfq+72jX0RSP9SdSmDbW0Bjz2NIEE3BsE8rNay+ByFbdSLsapRPvaZv2Jof+dK2Y/yg==",
             "peer": true,
             "dependencies": {
                 "@react-native-community/cli-config": "^10.1.1",
-                "@react-native-community/cli-platform-ios": "^10.2.1",
+                "@react-native-community/cli-platform-ios": "^10.2.5",
                 "@react-native-community/cli-tools": "^10.1.1",
                 "chalk": "^4.1.2",
                 "command-exists": "^1.2.8",
                 "envinfo": "^7.7.2",
                 "execa": "^1.0.0",
                 "hermes-profile-transformer": "^0.0.6",
-                "ip": "^1.1.5",
                 "node-stream-zip": "^1.9.1",
                 "ora": "^5.4.1",
                 "prompts": "^2.4.0",
@@ -3340,6 +3339,20 @@
                 "strip-ansi": "^5.2.0",
                 "sudo-prompt": "^9.0.0",
                 "wcwidth": "^1.0.1"
+            }
+        },
+        "node_modules/@react-native-community/cli-doctor/node_modules/@react-native-community/cli-platform-ios": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.2.5.tgz",
+            "integrity": "sha512-hq+FZZuSBK9z82GLQfzdNDl8vbFx5UlwCLFCuTtNCROgBoapFtVZQKRP2QBftYNrQZ0dLAb01gkwxagHsQCFyg==",
+            "peer": true,
+            "dependencies": {
+                "@react-native-community/cli-tools": "^10.1.1",
+                "chalk": "^4.1.2",
+                "execa": "^1.0.0",
+                "fast-xml-parser": "^4.0.12",
+                "glob": "^7.1.3",
+                "ora": "^5.4.1"
             }
         },
         "node_modules/@react-native-community/cli-doctor/node_modules/ansi-regex": {
@@ -3364,6 +3377,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@react-native-community/cli-doctor/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
         "node_modules/@react-native-community/cli-doctor/node_modules/chalk": {
@@ -3455,6 +3478,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@react-native-community/cli-doctor/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
+            "peer": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@react-native-community/cli-doctor/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3471,6 +3515,18 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@react-native-community/cli-doctor/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/@react-native-community/cli-doctor/node_modules/npm-run-path": {
@@ -3552,16 +3608,15 @@
             }
         },
         "node_modules/@react-native-community/cli-hermes": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.2.0.tgz",
-            "integrity": "sha512-urfmvNeR8IiO/Sd92UU3xPO+/qI2lwCWQnxOkWaU/i2EITFekE47MD6MZrfVulRVYRi5cuaFqKZO/ccOdOB/vQ==",
+            "version": "10.2.7",
+            "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.2.7.tgz",
+            "integrity": "sha512-MULfkgeLx1fietx10pLFLmlfRh0dcfX/HABXB5Tm0BzQDXy7ofFIJ/UxH+IF55NwPKXl6aEpTbPwbgsyJxqPiA==",
             "peer": true,
             "dependencies": {
                 "@react-native-community/cli-platform-android": "^10.2.0",
                 "@react-native-community/cli-tools": "^10.1.1",
                 "chalk": "^4.1.2",
-                "hermes-profile-transformer": "^0.0.6",
-                "ip": "^1.1.5"
+                "hermes-profile-transformer": "^0.0.6"
             }
         },
         "node_modules/@react-native-community/cli-hermes/node_modules/ansi-styles": {
@@ -8876,12 +8931,6 @@
             "dependencies": {
                 "loose-envify": "^1.0.0"
             }
-        },
-        "node_modules/ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
-            "peer": true
         },
         "node_modules/is-accessor-descriptor": {
             "version": "1.0.0",
@@ -15131,9 +15180,9 @@
             }
         },
         "node_modules/react-native-get-random-values": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
-            "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
+            "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
             "dependencies": {
                 "fast-base64-decode": "^1.0.0"
             },
@@ -21137,20 +21186,19 @@
             }
         },
         "@react-native-community/cli-doctor": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.2.2.tgz",
-            "integrity": "sha512-49Ep2aQOF0PkbAR/TcyMjOm9XwBa8VQr+/Zzf4SJeYwiYLCT1NZRAVAVjYRXl0xqvq5S5mAGZZShS4AQl4WsZw==",
+            "version": "10.2.7",
+            "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-10.2.7.tgz",
+            "integrity": "sha512-MejE7m+63DxfKwFSvyZGfq+72jX0RSP9SdSmDbW0Bjz2NIEE3BsE8rNay+ByFbdSLsapRPvaZv2Jof+dK2Y/yg==",
             "peer": true,
             "requires": {
                 "@react-native-community/cli-config": "^10.1.1",
-                "@react-native-community/cli-platform-ios": "^10.2.1",
+                "@react-native-community/cli-platform-ios": "^10.2.5",
                 "@react-native-community/cli-tools": "^10.1.1",
                 "chalk": "^4.1.2",
                 "command-exists": "^1.2.8",
                 "envinfo": "^7.7.2",
                 "execa": "^1.0.0",
                 "hermes-profile-transformer": "^0.0.6",
-                "ip": "^1.1.5",
                 "node-stream-zip": "^1.9.1",
                 "ora": "^5.4.1",
                 "prompts": "^2.4.0",
@@ -21160,6 +21208,20 @@
                 "wcwidth": "^1.0.1"
             },
             "dependencies": {
+                "@react-native-community/cli-platform-ios": {
+                    "version": "10.2.5",
+                    "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-10.2.5.tgz",
+                    "integrity": "sha512-hq+FZZuSBK9z82GLQfzdNDl8vbFx5UlwCLFCuTtNCROgBoapFtVZQKRP2QBftYNrQZ0dLAb01gkwxagHsQCFyg==",
+                    "peer": true,
+                    "requires": {
+                        "@react-native-community/cli-tools": "^10.1.1",
+                        "chalk": "^4.1.2",
+                        "execa": "^1.0.0",
+                        "fast-xml-parser": "^4.0.12",
+                        "glob": "^7.1.3",
+                        "ora": "^5.4.1"
+                    }
+                },
                 "ansi-regex": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -21173,6 +21235,16 @@
                     "peer": true,
                     "requires": {
                         "color-convert": "^2.0.1"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "peer": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
                     }
                 },
                 "chalk": {
@@ -21245,6 +21317,20 @@
                         "pump": "^3.0.0"
                     }
                 },
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "peer": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -21256,6 +21342,15 @@
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                     "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
                     "peer": true
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "peer": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
@@ -21317,16 +21412,15 @@
             }
         },
         "@react-native-community/cli-hermes": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.2.0.tgz",
-            "integrity": "sha512-urfmvNeR8IiO/Sd92UU3xPO+/qI2lwCWQnxOkWaU/i2EITFekE47MD6MZrfVulRVYRi5cuaFqKZO/ccOdOB/vQ==",
+            "version": "10.2.7",
+            "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-10.2.7.tgz",
+            "integrity": "sha512-MULfkgeLx1fietx10pLFLmlfRh0dcfX/HABXB5Tm0BzQDXy7ofFIJ/UxH+IF55NwPKXl6aEpTbPwbgsyJxqPiA==",
             "peer": true,
             "requires": {
                 "@react-native-community/cli-platform-android": "^10.2.0",
                 "@react-native-community/cli-tools": "^10.1.1",
                 "chalk": "^4.1.2",
-                "hermes-profile-transformer": "^0.0.6",
-                "ip": "^1.1.5"
+                "hermes-profile-transformer": "^0.0.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -25219,12 +25313,6 @@
             "requires": {
                 "loose-envify": "^1.0.0"
             }
-        },
-        "ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
-            "peer": true
         },
         "is-accessor-descriptor": {
             "version": "1.0.0",
@@ -30037,9 +30125,9 @@
             }
         },
         "react-native-get-random-values": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.8.0.tgz",
-            "integrity": "sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
+            "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
             "requires": {
                 "fast-base64-decode": "^1.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@types/uuid": "^9.0.0",
         "cross-fetch": "^3.1.5",
-        "react-native-get-random-values": "^1.8.0",
+        "react-native-get-random-values": "^1.11.0",
         "rollup-plugin-copy": "^3.5.0",
         "uuid": "^9.0.0"
     },


### PR DESCRIPTION
Partial fix for a vulnerability classified as high: https://github.com/coveo/coveo.analytics.js/security/dependabot/100 pulled in via the react dependency.

Upgraded the top level dependency (react-native-get-random-values), ran `npm audit fix`, reran all tests. Note that this is only a partial fix as the included package version of `ip` will still be `1.1.8` which is too low to suppress the warning. I've suppressed the warning to unblock deploy, since this codepath is not actually used in coveo.analytics.js (it's a react peer dependency, and this is not a server project).