### PR TITLE
Revert "fix(ec): pageview will not include action, product and impression"

### DIFF
--- a/functional/ec-events.spec.ts
+++ b/functional/ec-events.spec.ts
@@ -99,7 +99,7 @@ describe('ec events', () => {
         });
     });
 
-    it('will not include the product or action when sending a pageview event', async () => {
+    it('can send a product detail view event', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
         await coveoua('send', 'pageview');
@@ -109,53 +109,6 @@ describe('ec events', () => {
         expect(body).toEqual({
             ...defaultContextValues,
             t: 'pageview',
-        });
-    });
-
-    it('will include the product and action only when sending a detail event', async () => {
-        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
-        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
-        coveoua('send', 'pageview');
-        await coveoua('send', 'event');
-
-        coveoua('ec:addProduct', {name: 'wow2', id: 'something2', brand: 'brand2'});
-        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
-        coveoua('send', 'event');
-        await coveoua('send', 'pageview');
-
-        const [pageviewBody, eventBody, eventBody2, pageviewBody2] = getParsedBody();
-
-        expect(pageviewBody.pa).toBeUndefined();
-        expect(pageviewBody.pr1nm).toBeUndefined();
-        expect(pageviewBody.pr1id).toBeUndefined();
-        expect(pageviewBody.pr1br).toBeUndefined();
-
-        expect(eventBody.pa).toEqual('detail');
-        expect(eventBody.pr1nm).toEqual('wow');
-        expect(eventBody.pr1id).toEqual('something');
-        expect(eventBody.pr1br).toEqual('brand');
-
-        expect(eventBody2.pa).toEqual('detail');
-        expect(eventBody2.pr1nm).toEqual('wow2');
-        expect(eventBody2.pr1id).toEqual('something2');
-        expect(eventBody2.pr1br).toEqual('brand2');
-
-        expect(pageviewBody2.pa).toBeUndefined();
-        expect(pageviewBody2.pr1nm).toBeUndefined();
-        expect(pageviewBody2.pr1id).toBeUndefined();
-        expect(pageviewBody2.pr1br).toBeUndefined();
-    });
-
-    it('can send a product detail view event', async () => {
-        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
-        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
-        await coveoua('send', 'event');
-
-        const [body] = getParsedBody();
-
-        expect(body).toEqual({
-            ...defaultContextValues,
-            t: 'event',
             pr1nm: 'wow',
             pr1id: 'something',
             pr1br: 'brand',
@@ -166,13 +119,13 @@ describe('ec events', () => {
     it('can send a product detail view event with custom values', async () => {
         coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand'});
         coveoua('ec:setAction', 'detail', {storeid: 'amazing', custom: {verycustom: 'value'}});
-        await coveoua('send', 'event');
+        await coveoua('send', 'pageview');
 
         const [body] = getParsedBody();
 
         expect(body).toEqual({
             ...defaultContextValues,
-            t: 'event',
+            t: 'pageview',
             pr1nm: 'wow',
             pr1id: 'something',
             pr1br: 'brand',
@@ -820,13 +773,13 @@ describe('ec events', () => {
     it('should append custom values to product', async () => {
         var partialProduct = {name: 'wow', custom: {verycustom: 'value'}};
         await coveoua('ec:addProduct', partialProduct);
-        await coveoua('send', 'event');
+        await coveoua('send', 'pageview');
 
         const [body] = getParsedBody();
 
         expect(body).toEqual({
             ...defaultContextValues,
-            t: 'event',
+            t: 'pageview',
             pr1nm: partialProduct.name,
             pr1verycustom: partialProduct.custom.verycustom,
         });
@@ -904,7 +857,7 @@ describe('ec events', () => {
 
         await coveoua('ec:addImpression', productImpression1);
         await coveoua('ec:addImpression', productImpression2);
-        await coveoua('send', 'event');
+        await coveoua('send', 'pageview');
 
         const [event] = getParsedBody();
 
@@ -930,7 +883,7 @@ describe('ec events', () => {
             il1pi2ps: productImpression2.position,
             sd: defaultContextValues.sd,
             sr: defaultContextValues.sr,
-            t: 'event',
+            t: 'pageview',
             tm: expect.any(Number),
             ua: defaultContextValues.ua,
             ul: defaultContextValues.ul,

--- a/src/plugins/ec.spec.ts
+++ b/src/plugins/ec.spec.ts
@@ -45,12 +45,12 @@ describe('EC plugin', () => {
             expect(result).toEqual({...defaultResult, pr1id: 'C0V30'});
         });
 
-        it('should not append the product with the pageview event', () => {
+        it('should append the product with the pageview event', () => {
             ec.addProduct({name: 'Relevance T-Shirt'});
 
-            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(result).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
+            expect(result).toEqual({...defaultResult, pr1nm: 'Relevance T-Shirt'});
         });
 
         it('should not append the product with a random event type', () => {
@@ -61,15 +61,14 @@ describe('EC plugin', () => {
             expect(result).toEqual({});
         });
 
-        it('should keep the products until an event type is used', () => {
+        it('should keep the products until a valid event type is used', () => {
             ec.addProduct({id: 'P12345'});
 
             executeRegisteredHook('🎲', {});
             executeRegisteredHook('🐟', {});
-            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            executeRegisteredHook('💀', {});
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
             expect(result).toEqual({...defaultResult, pr1id: 'P12345'});
         });
 
@@ -118,18 +117,6 @@ describe('EC plugin', () => {
             const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
             expect(secondResult).toEqual({...defaultResult});
-        });
-
-        it('should not flush the products when the pageview is sent', () => {
-            ec.addProduct({name: 'boup'});
-
-            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
-
-            expect(result).not.toEqual({});
-
-            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
-
-            expect(secondResult).toEqual({...defaultResult, pr1nm: 'boup'});
         });
 
         it('should convert position to number if possible', () => {
@@ -277,14 +264,14 @@ describe('EC plugin', () => {
             expect(result).toEqual({...defaultResult, il1pi1id: 'C0V30'});
         });
 
-        it('should not append the impression with the pageview event', () => {
+        it('should append the impression with the pageview event', () => {
             ec.addImpression({name: 'Relevance T-Shirt'});
 
-            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
             expect(result).toEqual({
                 ...defaultResult,
-                hitType: ECPluginEventTypes.pageview,
+                il1pi1nm: 'Relevance T-Shirt',
             });
         });
 
@@ -296,15 +283,14 @@ describe('EC plugin', () => {
             expect(result).toEqual({});
         });
 
-        it('should keep the impressions until an event type is used', () => {
+        it('should keep the impressions until a valid event type is used', () => {
             ec.addImpression({id: 'P12345'});
 
             executeRegisteredHook('🎲', {});
             executeRegisteredHook('🐟', {});
-            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            executeRegisteredHook('💀', {});
             const result = executeRegisteredHook(ECPluginEventTypes.event, {});
 
-            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
             expect(result).toEqual({...defaultResult, il1pi1id: 'P12345'});
         });
 
@@ -386,7 +372,7 @@ describe('EC plugin', () => {
             });
         });
 
-        it('should flush the impressions once they are sent', () => {
+        it('should flush the products once they are sent', () => {
             ec.addImpression({name: '🍟', price: 1.99});
             ec.addImpression({name: '🍿', price: 3});
 
@@ -397,18 +383,6 @@ describe('EC plugin', () => {
             const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
             expect(secondResult).toEqual({...defaultResult});
-        });
-
-        it('should not flush the impressions when a pageview is sent', () => {
-            ec.addImpression({name: 'bap'});
-
-            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
-
-            expect(result).not.toEqual({});
-
-            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
-
-            expect(secondResult).toEqual({...defaultResult, il1pi1nm: 'bap'});
         });
 
         describe('when the position is invalid', () => {
@@ -506,17 +480,6 @@ describe('EC plugin', () => {
         });
     });
 
-    it('should not set an action with a pageview', () => {
-        ec.setAction('ok');
-
-        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
-
-        expect(result).toEqual({
-            ...defaultResult,
-            hitType: ECPluginEventTypes.pageview,
-        });
-    });
-
     it('should flush the action once it is sent', () => {
         ec.setAction('ok');
 
@@ -527,18 +490,6 @@ describe('EC plugin', () => {
         const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
 
         expect(secondResult).toEqual({...defaultResult});
-    });
-
-    it('should not flush the action with the pageview', () => {
-        ec.setAction('ok');
-
-        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
-
-        expect(result).not.toEqual({});
-
-        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
-
-        expect(secondResult).toEqual({...defaultResult, action: 'ok'});
     });
 
     it('should be able to clear all the data', () => {

--- a/src/plugins/ec.ts
+++ b/src/plugins/ec.ts
@@ -135,14 +135,6 @@ export class ECPlugin extends BasePlugin {
     }
 
     private addECDataToPayload(eventType: string, payload: any) {
-        if (eventType === ECPluginEventTypes.pageview) {
-            return {
-                ...this.getLocationInformation(eventType, payload),
-                ...this.getDefaultContextInformation(eventType),
-                ...payload,
-            };
-        }
-
         const ecPayload = {
             ...this.getLocationInformation(eventType, payload),
             ...this.getDefaultContextInformation(eventType),


### PR DESCRIPTION
Reverts coveo/coveo.analytics.js#458

I'm going to revert this change as it alters a contract on collect that we have always respected (although not recommended). In collect protocol, you can:

1. send an isolated pageview event (`t:pageview`, no `pa`)
2. send an isolated generic event (`t:event`, with `pa`)
3. send an event with a type of `pageview`, but which also includes product information, to compress communication.

Although they're maybe not the best idea conceptually, these two-for-one events have been historically supported as api in customer implementations. The UA write service prioritizes the generic event information and will create a detail event for these (and ignore the pageview aspect). The change above effectively REMOVED the product information altogether on these events, leading to irretrievable information loss for the few dozen customers that implemented this way. If anything at all, any pageview event which carries product information should be "upgraded" to a generic event.
 
 The original issue LENS-1826 still stands, but we cannot fix this by altering our api contracts.