### PR TITLE
fix: UA-9204 Increase url truncation limit

### DIFF
--- a/src/client/analytics.spec.ts
+++ b/src/client/analytics.spec.ts
@@ -278,8 +278,8 @@ describe('Analytics', () => {
         });
     });
 
-    describe('should truncate the maxlength for URL parameters at 128 characters for ua events', () => {
-        const desiredMax: number = 128;
+    describe('should truncate the maxlength for URL parameters at 1024 characters for ua events', () => {
+        const desiredMax: number = 1024;
         // Craft the URL so the truncation point falls in the %20 sequence
         const longUrl: string = 'http://coveo.com/?q=' + 'a'.repeat(desiredMax - 22) + '%20b';
         const expectedTruncatedLength = longUrl.lastIndexOf('%', desiredMax);

--- a/src/client/analytics.ts
+++ b/src/client/analytics.ts
@@ -606,10 +606,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
             eventType == EventType.search ||
             eventType == EventType.custom
         ) {
-            rest.originLevel3 = this.limit(rest.originLevel3, 128);
+            rest.originLevel3 = this.limit(rest.originLevel3, 1024);
         }
         if (eventType == EventType.view) {
-            rest.location = this.limit(rest.location, 128);
+            rest.location = this.limit(rest.location, 1024);
         }
         if (eventType == 'pageview' || eventType == 'event') {
             rest.referrer = this.limit(rest.referrer, 2048);


### PR DESCRIPTION
## [UA-9204](https://coveord.atlassian.net/browse/UA-9204) :rocket:

### Proposed changes:

The attached Jira is about this library truncating URLs in the middle of an escape sequence (e.g. cutting off within a sequence like `%20`). This has been addressed in #471. While looking at the truncation, we noticed the truncation for both `location` (view events) and `originLevel3` was set to `128`, while the schema and backing tables have a limit of `1024`.

This fix simply increases the truncation limit for these fields to 1024, to align. This still leverages the safe-guard against cutting of (UTF-8 multibyte) escape sequences.

### How to test

This change is basically changing a parameter to an already tested function. Unit tests have been updated accordingly.

### Checklist:

-   [X] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
-   [X] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[UA-9204]: https://coveord.atlassian.net/browse/UA-9204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ