### PR TITLE
feat(genqa): add logCitationClick event

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -72,7 +72,7 @@ export interface PreparedSearchEventRequest extends Omit<SearchEventRequest, 'se
 
 export interface DocumentInformation {
     documentUri?: string;
-    documentUriHash: string;
+    documentUriHash?: string;
     collectionName?: string;
     sourceName: string;
     documentPosition: number;

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -557,7 +557,7 @@ describe('InsightClient', () => {
                 contentIDValue: meta.documentId.contentIdValue,
             };
 
-            await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta, baseCaseMetadata);
+            await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta);
             expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, expectedMetadata);
         });
 
@@ -1346,6 +1346,23 @@ describe('InsightClient', () => {
 
             await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata, baseCaseMetadata);
             expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCitationClick', async () => {
+            const meta = {
+                generativeQuestionAnsweringId: '123',
+                citationId: 'bar',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            const expectedMetadata = {
+                ...meta,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, expectedMetadata);
         });
 
         it('should send proper payload for #generatedAnswerSourceHover', async () => {

--- a/src/insight/insightClient.spec.ts
+++ b/src/insight/insightClient.spec.ts
@@ -544,6 +544,23 @@ describe('InsightClient', () => {
             expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, exampleGeneratedAnswerMetadata);
         });
 
+        it('should send proper payload for #generatedAnswerCitationClick', async () => {
+            const meta = {
+                generativeQuestionAnsweringId: '123',
+                citationId: 'bar',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            const expectedMetadata = {
+                ...meta,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, expectedMetadata);
+        });
+
         it('should send proper payload for #generatedAnswerSourceHover', async () => {
             const exampleGeneratedAnswerMetadata = {
                 generativeQuestionAnsweringId: '123',

--- a/src/insight/insightClient.ts
+++ b/src/insight/insightClient.ts
@@ -7,6 +7,7 @@ import {
     DocumentIdentifier,
     FacetStateMetadata,
     GeneratedAnswerBaseMeta,
+    GeneratedAnswerCitationClickMeta,
     GeneratedAnswerCitationMeta,
     GeneratedAnswerFeedbackMeta,
     GeneratedAnswerFeedbackMetaV2,
@@ -517,6 +518,19 @@ export class CoveoInsightClient {
             metadata
                 ? {...generateMetadataToSend(metadata, false), ...generatedAnswerSourceMetadata}
                 : generatedAnswerSourceMetadata
+        );
+    }
+
+    public logGeneratedAnswerCitationClick(
+        info: PartialDocumentInformation,
+        citation: GeneratedAnswerCitationClickMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.generatedAnswerCitationClick,
+            {...info, documentPosition: 1},
+            {contentIDKey: citation.documentId.contentIdKey, contentIDValue: citation.documentId.contentIdValue},
+            metadata ? {...generateMetadataToSend(metadata, false), ...citation} : citation
         );
     }
 

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -1494,6 +1494,35 @@ describe('SearchPageClient', () => {
         expectMatchDescription(built.description, SearchPageEvents.openGeneratedAnswerSource, meta);
     });
 
+    it('should send proper payload for #logGeneratedAnswerCitationClick', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+
+        await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, {
+            ...meta,
+            contentIDKey: meta.documentId.contentIdKey,
+            contentIDValue: meta.documentId.contentIdValue,
+        });
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerCitationClick', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            contentIDKey: 'permanentid',
+            contentIDValue: 'foo',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+        const built = await client.makeGeneratedAnswerCitationClick(fakeDocInfo, meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCitationClick, meta);
+    });
+
     it('should send proper payload for #logGeneratedAnswerStreamEnd', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
         await client.logGeneratedAnswerStreamEnd(meta);

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -43,6 +43,7 @@ import {
     GeneratedAnswerBaseMeta,
     GeneratedAnswerRephraseMeta,
     GeneratedAnswerFeedbackMetaV2,
+    GeneratedAnswerCitationClickMeta,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -908,6 +909,27 @@ export class CoveoSearchPageClient {
 
     public async logOpenGeneratedAnswerSource(metadata: GeneratedAnswerCitationMeta) {
         return (await this.makeOpenGeneratedAnswerSource(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerCitationClick(
+        info: PartialDocumentInformation,
+        citation: GeneratedAnswerCitationClickMeta
+    ) {
+        return this.makeClickEvent(
+            SearchPageEvents.generatedAnswerCitationClick,
+            {...info, documentPosition: 1},
+            {contentIDKey: citation.documentId.contentIdKey, contentIDValue: citation.documentId.contentIdValue},
+            citation
+        );
+    }
+
+    public async logGeneratedAnswerCitationClick(
+        info: PartialDocumentInformation,
+        citation: GeneratedAnswerCitationClickMeta
+    ) {
+        return (await this.makeGeneratedAnswerCitationClick(info, citation)).log({
             searchUID: this.provider.getSearchUID(),
         });
     }

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -350,6 +350,10 @@ export enum SearchPageEvents {
      * Identifies the new version of custom event that gets logged when a user submits a feedback of a generated answer.
      */
     generatedAnswerFeedbackSubmitV2 = 'generatedAnswerFeedbackSubmitV2',
+    /**
+     * Identifies the click event that gets logged when the user clicks on a generated answer citation.
+     */
+    generatedAnswerCitationClick = 'generatedAnswerCitationClick',
 }
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
@@ -559,6 +563,16 @@ export type GeneratedAnswerStreamEndMeta = GeneratedAnswerBaseMeta & {
 export type GeneratedAnswerCitationMeta = GeneratedAnswerBaseMeta & {
     permanentId: string;
     citationId: string;
+};
+
+export type GeneratedAnswerCitationClickMeta = GeneratedAnswerBaseMeta & {
+    citationId: string;
+    documentId: GeneratedAnswerDocumentIdentifier;
+};
+
+type GeneratedAnswerDocumentIdentifier = {
+    contentIdKey: string;
+    contentIdValue: string;
 };
 
 export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';


### PR DESCRIPTION
[SVCC-4171](https://coveord.atlassian.net/browse/SVCC-4171) :rocket:

### Proposed changes:

<!-- Describe the big picture of your changes here. -->

- Add a new `logGeneratedAnswerCitationClick` event to Insight & search client
- This new method should make the click event assume a document position of 1 .
- The click event payload should look like this:
```
{
    "language": "en",
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
    "collectionName": "default", -- Deprecated
    "documentAuthor": "unknown", -- Available in stream response?
    "documentPosition": 1,  -- Hardcoded to 1
    "documentTitle": "Relevance Generative Answering", -- In stream API response
    "documentUri": "https://levelup.coveo.com/learn/courses/relevance-generative-answering",  -- In stream API response as URI
    "documentUriHash": "bK2L18lxLvsUB5h4", - Depecreated
    "documentUrl": "https://levelup.coveo.com/learn/courses/relevance-generative-answering", -- In stream API response as Click URI
    "sourceName": "Level Up",   -- Needs to be added stream API response
    "queryPipeline": "Customer Zero Community search - RGA Update V3",
    "originContext": "buildersearchpage", -- Same as custom event
    "originLevel1": "Connect RGA V3 Testing", -- Same as custom event
    "originLevel2": "default", -- Same as custom event
    "originLevel3": "https://search.cloud.coveo.com/builder/", -- Same as custom event
    "customData": {
        "coveoHeadlessVersion": "2.78.0", -- Inherited
        "generativeQuestionAnsweringId": "queryStream01_coveosearch_1ffa0550-3d4b-4d09-9574-8c4225b1edf9",
--TO ADD"contentIDKey": "permanentid",
--TO ADD"contentIDValue": "29bd12f1-12fb-4ac4-9463-66e37a0cb686",
        "coveoAtomicVersion": "2.77.1" -- Inherited
--From Stream API"citationId": "42.20035$https://levelup.coveo.com/learn/courses/relevance-generative-answering-3541ae00-8d76-4b85-aa02-75478f4b6a6e",
    },
    "facetState": [],
    "anonymous": false,
    "clientId": "d4a6b215-241a-40f2-ad82-4890895843ad",
    "actionCause": "openGeneratedAnswerSource", -- New actionCause
    "searchQueryUid": "6549c762-4b4d-466d-ba16-bfe3b8d21928" -- From search event
}
```

### How to test

<!-- Steps to check how we can make sure this feature works. -->

### Checklist:

-   [x] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
-   [x] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[SVCC-4171]: https://coveord.atlassian.net/browse/SVCC-4171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ