### PR TITLE
fix: avoid using window in module exports

### DIFF
--- a/bundle/browser-fetch.ts
+++ b/bundle/browser-fetch.ts
@@ -1,3 +1,3 @@
 // This file is to prevent including a fetch polyfill from the "cross-fetch" dependency when building for a browser target.
 // Major browsers today provide fetch on the window object, so including a polyfill would needlessly increase the size of the bundle.
-export const fetch = window.fetch;
+export const fetch = globalThis.fetch;


### PR DESCRIPTION
## [CDX-1593](https://coveord.atlassian.net/browse/CDX-1593) :rocket:

### Proposed changes:

`dist/browser.mjs` is the exported file in `module`.

The module can be imported by both NodeJS & browsers alike nowadays and as a library.

For example, we recently encountered an issue consuming the library after migrating Headless to an ESM-first package, as we export both ESM for NodeJS and browsers.

To solve that non-breakingly, I propose using the isomorphic way to access the global object instead of runtime specific, such as window or process.
 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 
From our experience in Headless, this is 'good enough', even if other places of the code uses `window`

### How to test



### Checklist:

-   [ ] todo Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
  - Unusure about how to tests, 🤔
-   [ ] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events being miscategorized by UA.
  - Potentially no: If the library supports IE11, this change is not IE11 compatible, meaning events wouldn't be sent.


[CDX-1593]: https://coveord.atlassian.net/browse/CDX-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ