### PR TITLE
[UA-9498] Upgrade rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
                 "lint-staged": "^13.2.1",
                 "prettier": "^2.8.7",
                 "rimraf": "^3.0.2",
-                "rollup": "^3.20.2",
+                "rollup": "^3.29.5",
                 "rollup-plugin-copy": "^3.5.0",
                 "rollup-plugin-serve": "^1.0.1",
                 "rollup-plugin-typescript2": "^0.34.0",
@@ -15186,9 +15186,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "3.21.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.4.tgz",
-            "integrity": "sha512-N5LxpvDolOm9ueiCp4NfB80omMDqb45ShtsQw2+OT3f11uJ197dv703NZvznYHP6RWR85wfxanXurXKG3ux2GQ==",
+            "version": "3.29.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+            "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -28883,9 +28883,9 @@
             }
         },
         "rollup": {
-            "version": "3.21.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.4.tgz",
-            "integrity": "sha512-N5LxpvDolOm9ueiCp4NfB80omMDqb45ShtsQw2+OT3f11uJ197dv703NZvznYHP6RWR85wfxanXurXKG3ux2GQ==",
+            "version": "3.29.5",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+            "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "lint-staged": "^13.2.1",
         "prettier": "^2.8.7",
         "rimraf": "^3.0.2",
-        "rollup": "^3.20.2",
+        "rollup": "^3.29.5",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-typescript2": "^0.34.0",


### PR DESCRIPTION
## [UA-9498](https://coveord.atlassian.net/browse/UA-9498) :rocket:

### Proposed changes:

Upgrade rollup to deal with CVE-2024-47068

### How to test

All tests still work, build still works.

### Checklist:

-   [ ] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
-   [ ] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.
