### PR TITLE
fix(do-not-track): window object can be undefined

### DIFF
--- a/src/donottrack.spec.ts
+++ b/src/donottrack.spec.ts
@@ -2,6 +2,7 @@ describe('doNotTrack', () => {
     let doNotTrack: () => boolean;
     function initModule(
         hasNav: boolean,
+        hasWin: boolean,
         options?: {
             navigatorGlobalPrivacyControl?: any;
             navigatorDoNotTrack?: any;
@@ -12,6 +13,7 @@ describe('doNotTrack', () => {
         jest.resetModules();
         jest.mock('./detector', () => ({
             hasNavigator: () => hasNav,
+            hasWindow: () => hasWin,
         }));
         if (hasNav) {
             Object.defineProperty(<any>navigator, 'globalPrivacyControl', {
@@ -32,6 +34,8 @@ describe('doNotTrack', () => {
                 },
                 configurable: true,
             });
+        }
+        if (hasWin) {
             Object.defineProperty(<any>window, 'doNotTrack', {
                 get() {
                     return options!.windowDoNotTrack;
@@ -41,30 +45,30 @@ describe('doNotTrack', () => {
         }
         doNotTrack = require('./donottrack').doNotTrack;
     }
-    describe('without a Navigator', () => {
+    describe('without a Navigator and without window', () => {
         it('should be false', () => {
-            initModule(false);
+            initModule(false, false);
 
             expect(doNotTrack()).toBeFalsy();
         });
     });
     describe('with a Navigator', () => {
         it('should respect GPC false', () => {
-            initModule(true, {
+            initModule(true, false, {
                 navigatorGlobalPrivacyControl: false,
             });
 
             expect(doNotTrack()).toBeFalsy();
         });
         it('should respect GPC true', () => {
-            initModule(true, {
+            initModule(true, false, {
                 navigatorGlobalPrivacyControl: true,
             });
 
             expect(doNotTrack()).toBeTruthy();
         });
         it('should respect GPC undefined', () => {
-            initModule(true, {
+            initModule(true, false, {
                 navigatorGlobalPrivacyControl: undefined,
             });
 
@@ -73,7 +77,7 @@ describe('doNotTrack', () => {
 
         [true, 'yes', '1'].forEach((value) => {
             it('should fallback on `navigator.doNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
+                initModule(true, false, {
                     navigatorDoNotTrack: value,
                 });
 
@@ -81,15 +85,8 @@ describe('doNotTrack', () => {
             });
 
             it('should fallback on `navigator.msDoNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
+                initModule(true, false, {
                     navigatorMsDoNotTrack: value,
-                });
-                expect(doNotTrack()).toBeTruthy();
-            });
-
-            it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
-                    windowDoNotTrack: value,
                 });
                 expect(doNotTrack()).toBeTruthy();
             });
@@ -97,7 +94,7 @@ describe('doNotTrack', () => {
 
         [false, 'no', '0', 'unspecified'].forEach((value) => {
             it('should fallback on `navigator.doNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
+                initModule(true, false, {
                     navigatorDoNotTrack: value,
                 });
 
@@ -105,18 +102,43 @@ describe('doNotTrack', () => {
             });
 
             it('should fallback on `navigator.msDoNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
+                initModule(true, false, {
                     navigatorMsDoNotTrack: value,
                 });
                 expect(doNotTrack()).toBeFalsy();
             });
+        });
+    });
 
+    describe('with a Window', () => {
+        [true, 'yes', '1'].forEach((value) => {
             it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
-                initModule(true, {
+                initModule(false, true, {
+                    windowDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeTruthy();
+            });
+        });
+
+        [false, 'no', '0', 'unspecified'].forEach((value) => {
+            it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(false, true, {
                     windowDoNotTrack: value,
                 });
                 expect(doNotTrack()).toBeFalsy();
             });
+        });
+    });
+
+    describe('with a Navigator and a Window', () => {
+        it('should fallback on `window.doNotTrack` if all navigator properties are falsy', () => {
+            initModule(true, true, {
+                navigatorDoNotTrack: false,
+                navigatorGlobalPrivacyControl: undefined,
+                navigatorMsDoNotTrack: '0',
+                windowDoNotTrack: 1,
+            });
+            expect(doNotTrack()).toBeTruthy();
         });
     });
 });

--- a/src/donottrack.ts
+++ b/src/donottrack.ts
@@ -1,23 +1,22 @@
 // Read the Mozilla Do Not Track Field Guide
 // (https://developer.mozilla.org/en-US/docs/Web/Security/Do_not_track_field_guide),
 // for information on how to use the donottrack
-// gathering data of actions of an user as long as it is not associated to the
+// gathering data of actions of a user as long as it is not associated to the
 // identity of that user, doNotTrack is not enabled here.
 
-import {hasNavigator} from './detector';
+import {hasNavigator, hasWindow} from './detector';
 
 const doNotTrackValues = ['1', 1, 'yes', true];
 
 export function doNotTrack(): boolean {
-    return (
-        hasNavigator() &&
-        [
-            (<any>navigator).globalPrivacyControl,
-            (<any>navigator).doNotTrack,
-            (<any>navigator).msDoNotTrack,
-            (<any>window).doNotTrack,
-        ].some((value) => doNotTrackValues.indexOf(value) !== -1)
-    );
+    const checks: any[] = [];
+    if (hasWindow()) {
+        checks.push((<any>window).doNotTrack);
+    }
+    if (hasNavigator()) {
+        checks.push((<any>navigator).doNotTrack, (<any>navigator).msDoNotTrack, (<any>navigator).globalPrivacyControl);
+    }
+    return checks.some((value) => doNotTrackValues.indexOf(value) !== -1);
 }
 
 export default doNotTrack;


### PR DESCRIPTION
## [ADUI-10326](https://coveord.atlassian.net/browse/ADUI-10326) :rocket:

### Proposed changes:

<!-- Describe the big picture of your changes here. -->

The `doNotTrack` function wasn't checking if the window object was defined. In some environment (e.g., node) it can be undefined which made it impossible to create an `CoveoAnalyticsClient`.

I changed the logic of the function to check the properties of the navigator and window object only if they exists

### How to test

The test coverage is adequate

### Checklist:

-   [x] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
-   [x] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[ADUI-10326]: https://coveord.atlassian.net/browse/ADUI-10326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ