### PR TITLE
feat(SFINT-5992): logic added to start sending UA click events on document suggestion click

### DIFF
--- a/src/caseAssist/caseAssistActions.ts
+++ b/src/caseAssist/caseAssistActions.ts
@@ -9,7 +9,8 @@ export enum CaseAssistActions {
     enterInterface = 'ticket_create_start',
     fieldUpdate = 'ticket_field_update',
     fieldSuggestionClick = 'ticket_classification_click',
-    suggestionClick = 'suggestion_click',
+    documentSuggestionClick = 'documentSuggestionClick',
+    documentSuggestionQuickview = 'documentSuggestionQuickview',
     suggestionRate = 'suggestion_rate',
     nextCaseStep = 'ticket_next_stage',
     caseCancelled = 'ticket_cancel',
@@ -78,12 +79,14 @@ export interface FieldSuggestion {
 export interface DocumentSuggestion {
     suggestionId: string;
     responseId: string;
+    permanentId: string;
     suggestion: {
         documentUri: string;
         documentUriHash: string;
         documentTitle: string;
         documentUrl: string;
         documentPosition: number;
+        sourceName: string;
     };
     fromQuickview?: boolean;
     openDocument?: boolean;

--- a/src/caseAssist/caseAssistClient.spec.ts
+++ b/src/caseAssist/caseAssistClient.spec.ts
@@ -122,11 +122,11 @@ describe('CaseAssistClient', () => {
             customData,
             language: exampleLanguage,
             clientId: exampleClientId,
-            ...doc,
             originContext: exampleOriginContext,
             originLevel1: exampleSearchHub,
             originLevel2: exampleOriginLevel2,
             originLevel3: exampleOriginLevel3,
+            ...doc,
         });
     };
 


### PR DESCRIPTION
## [SFINT-5992](https://coveord.atlassian.net/browse/SFINT-5992) :rocket:

### Proposed changes:

As per of the [RFC](https://coveord.atlassian.net/wiki/x/HYCdIgE) we want to improve the reporting of document suggestions by starting to send UA Click event when the document suggestions are clicked instead of sending Collect events that were later on translated to UA Custom events.

The collect events on document suggestions clicks are now replaced by the following UA Click events:

- on document suggestion click:  UA Click event with action cause documentSuggestionClick

- on document suggestion quickview:  UA Click event with action cause documentSuggestionQuickview

More info on the following RFC: [Improving Reporting & Analytics for document suggestion](https://coveord.atlassian.net/wiki/x/HYCdIgE)

<!-- Describe the big picture of your changes here. -->


### Demo:


https://github.com/user-attachments/assets/8445dfca-2e90-4e13-b1df-4b2a2f747e1b



<!-- Steps to check how we can make sure this feature works. -->



### Example Payload:
```
{
  "language": "en",
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
  "documentUri": "https://community.lithium.com/community:lithosphere/category:Developer/board:studio/thread:768344/message:768541",
  "documentUriHash": "osvetCW1ñ6BOFrQe",
  "documentTitle": "Re: liqlAdmin in khoros aurora graphql API",
  "documentUrl": "https://community.khoros.com/discussions/studio/liqladmin-in-khoros-aurora-graphql-api/768344/replies/768541",
  "documentPosition": 2,
  "sourceName": "Coveo Sample - Lithium Community",
  "originContext": "Search",
  "originLevel1": "case-assist-cookbook",
  "originLevel2": "default",
  "originLevel3": "https://business-platform-9228-dev-ed.scratch.my.salesforce-setup.com/",
  "customData": {
    "contentIDKey": "permanentId",
    "contentIDValue": "544798197564619f4e26869c15c54bf4e40ca80cece09d2600505ec008d7",
    "coveoQuanticVersion": "3.14.2"
  },
  "anonymous": false,
  "clientId": "dccae341-5527-44cd-87c5-f4cfc30850ed",
  "actionCause": "documentSuggestionClick",
  "searchQueryUid": "34e57a3b-4f14-4d3b-a2a9-f66e5cd769bd"
}
```
### Checklist:

-   [ ]  Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
-   [ ] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[SFINT-5992]: https://coveord.atlassian.net/browse/SFINT-5992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ