### PR TITLE
feat(SFINT-6714): Add conversationId to GeneratedAnswer events

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -58,6 +58,7 @@ describe('SearchPageClient', () => {
     ];
 
     const fakeStreamId = 'some-stream-id-123';
+    const fakeConversationId = 'some-conversation-id-123';
 
     let client: CoveoSearchPageClient;
 
@@ -1451,6 +1452,12 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, meta);
     });
 
+    it('should send proper payload for #logLikeGeneratedAnswer with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
+        await client.logLikeGeneratedAnswer(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, meta);
+    });
+
     it('should send proper payload for #makeLikeGeneratedAnswer', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
         const built = await client.makeLikeGeneratedAnswer(meta);
@@ -1461,6 +1468,12 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #logDislikeGeneratedAnswer', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logDislikeGeneratedAnswer(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #logDislikeGeneratedAnswer with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
         await client.logDislikeGeneratedAnswer(meta);
         expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, meta);
     });
@@ -1476,6 +1489,17 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #logOpenGeneratedAnswerSource', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+        };
+        await client.logOpenGeneratedAnswerSource(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
+    });
+
+    it('should send proper payload for #logOpenGeneratedAnswerSource with agent metadata', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            conversationId: fakeConversationId,
             citationId: 'some-document-id',
             permanentId: 'perm-id',
         };
@@ -1510,6 +1534,22 @@ describe('SearchPageClient', () => {
         });
     });
 
+    it('should send proper payload for #logGeneratedAnswerCitationClick with agent metadata', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            conversationId: fakeConversationId,
+            citationId: 'some-document-id',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+
+        await client.logGeneratedAnswerCitationClick(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.generatedAnswerCitationClick, fakeDocInfo, {
+            ...meta,
+            contentIDKey: meta.documentId.contentIdKey,
+            contentIDValue: meta.documentId.contentIdValue,
+        });
+    });
+
     it('should send proper payload for #makeGeneratedAnswerCitationClick', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
@@ -1530,6 +1570,17 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
     });
 
+    it('should send proper payload for #logGeneratedAnswerStreamEnd with agent metadata', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            conversationId: fakeConversationId,
+            answerGenerated: true,
+            answerTextIsEmpty: false,
+        };
+        await client.logGeneratedAnswerStreamEnd(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
+
     it('should send proper payload for #makeGeneratedAnswerStreamEnd', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
         const built = await client.makeGeneratedAnswerStreamEnd(meta);
@@ -1541,6 +1592,18 @@ describe('SearchPageClient', () => {
     it('should send proper payload for #logGeneratedAnswerSourceHover', async () => {
         const meta = {
             generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+            citationHoverTimeMs: 100,
+        };
+        await client.logGeneratedAnswerSourceHover(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerSourceHover with agent metadata', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            conversationId: fakeConversationId,
             citationId: 'some-document-id',
             permanentId: 'perm-id',
             citationHoverTimeMs: 100,
@@ -1568,6 +1631,12 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
     });
 
+    it('should send proper payload for #logGeneratedAnswerCopyToClipboard with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
+        await client.logGeneratedAnswerCopyToClipboard(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+    });
+
     it('should send proper payload for #makeGeneratedAnswerCopyToClipboard', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
         const built = await client.makeGeneratedAnswerCopyToClipboard(meta);
@@ -1578,6 +1647,12 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #logGeneratedAnswerHideAnswers', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerHideAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerHideAnswers with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
         await client.logGeneratedAnswerHideAnswers(meta);
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
     });
@@ -1596,6 +1671,12 @@ describe('SearchPageClient', () => {
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
     });
 
+    it('should send proper payload for #logGeneratedAnswerShowAnswers with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
+        await client.logGeneratedAnswerShowAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
+    });
+
     it('should send proper payload for #makeGeneratedAnswerShowAnswers', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
         const built = await client.makeGeneratedAnswerShowAnswers(meta);
@@ -1606,6 +1687,12 @@ describe('SearchPageClient', () => {
 
     it('should send proper payload for #logGeneratedAnswerExpand', async () => {
         const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerExpand(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerExpand with agent metadata', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, conversationId: fakeConversationId};
         await client.logGeneratedAnswerExpand(meta);
         expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, meta);
     });

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -551,14 +551,25 @@ export type PartialDocumentInformation = Omit<DocumentInformation, 'actionCause'
 interface AnswerGeneratedWithAnswerAPI {
     answerAPIStreamId: string;
     generativeQuestionAnsweringId?: never;
+    conversationId?: never;
 }
 
 interface AnswerGeneratedWithSearchAPI {
     answerAPIStreamId?: never;
     generativeQuestionAnsweringId: string;
+    conversationId?: never;
 }
 
-export type GeneratedAnswerBaseMeta = AnswerGeneratedWithAnswerAPI | AnswerGeneratedWithSearchAPI;
+interface AnswerGeneratedWithAgent {
+    answerAPIStreamId?: never;
+    generativeQuestionAnsweringId: string;
+    conversationId: string;
+}
+
+export type GeneratedAnswerBaseMeta =
+    | AnswerGeneratedWithAnswerAPI
+    | AnswerGeneratedWithSearchAPI
+    | AnswerGeneratedWithAgent;
 
 export type GeneratedAnswerStreamEndMeta = GeneratedAnswerBaseMeta & {
     answerGenerated: boolean;


### PR DESCRIPTION
## [SFINT-6714](https://coveord.atlassian.net/browse/SFINT-6714) :rocket:

### Proposed changes:

See related Jira for explanation

- Introduce a conversationId as part of the GeneratedAnswerBaseMeta to uniquely identify each GeneratedAnswer events as being potentially part of a conversation.
- For conversations, we will not require both the `conversationId` as well as the `generativeQuestionAnsweringId`.

### How to test

<!-- Steps to check how we can make sure this feature works. -->

### Checklist:

- [X] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
- [X] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[SFINT-6714]: https://coveord.atlassian.net/browse/SFINT-6714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ