### PR TITLE
feat(SFINT-6734): logGeneratedAnswerOpenInlineLink method created in search analytics c…

### DIFF
--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -106,7 +106,7 @@ describe('SearchPageClient', () => {
                         Promise.resolve({...payload, customData: {...payload.customData, ...customDataFromMiddleware}}),
                 ],
             },
-            provider,
+            provider
         );
     };
 
@@ -153,7 +153,7 @@ describe('SearchPageClient', () => {
     const expectSearchEventToMatchDescription = (
         description: EventDescription,
         actionCause: SearchPageEvents,
-        meta = {},
+        meta = {}
     ) => {
         expectMatchDescription(description, actionCause, {...meta, genQaMetadata: 'bar'});
     };
@@ -179,7 +179,7 @@ describe('SearchPageClient', () => {
     const expectMatchCustomEventPayload = (
         actionCause: SearchPageEvents,
         meta = {},
-        eventType = CustomEventsTypes[actionCause],
+        eventType = CustomEventsTypes[actionCause]
     ) => {
         const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
@@ -1517,6 +1517,29 @@ describe('SearchPageClient', () => {
         await built.log({searchUID: provider.getSearchUID()});
         expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
         expectMatchDescription(built.description, SearchPageEvents.openGeneratedAnswerSource, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerOpenInlineLink', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            conversationId: fakeConversationId,
+            linkText: 'Read more',
+            linkURL: 'https://example.com',
+        };
+        await client.logGeneratedAnswerOpenInlineLink(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerOpenInlineLink, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerOpenInlineLink', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            linkText: 'Read more',
+            linkURL: 'https://example.com',
+        };
+        const built = await client.makeGeneratedAnswerOpenInlineLink(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerOpenInlineLink, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerOpenInlineLink, meta);
     });
 
     it('should send proper payload for #logGeneratedAnswerCitationClick', async () => {

--- a/src/searchPage/searchPageClient.spec.ts
+++ b/src/searchPage/searchPageClient.spec.ts
@@ -106,7 +106,7 @@ describe('SearchPageClient', () => {
                         Promise.resolve({...payload, customData: {...payload.customData, ...customDataFromMiddleware}}),
                 ],
             },
-            provider
+            provider,
         );
     };
 
@@ -153,7 +153,7 @@ describe('SearchPageClient', () => {
     const expectSearchEventToMatchDescription = (
         description: EventDescription,
         actionCause: SearchPageEvents,
-        meta = {}
+        meta = {},
     ) => {
         expectMatchDescription(description, actionCause, {...meta, genQaMetadata: 'bar'});
     };
@@ -179,7 +179,7 @@ describe('SearchPageClient', () => {
     const expectMatchCustomEventPayload = (
         actionCause: SearchPageEvents,
         meta = {},
-        eventType = CustomEventsTypes[actionCause]
+        eventType = CustomEventsTypes[actionCause],
     ) => {
         const body: string = lastCallBody(fetchMock);
         const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -44,6 +44,7 @@ import {
     GeneratedAnswerRephraseMeta,
     GeneratedAnswerFeedbackMetaV2,
     GeneratedAnswerCitationClickMeta,
+    GeneratedAnswerInlineLinkMeta,
 } from './searchPageEvents';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
@@ -80,10 +81,7 @@ export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
 export class CoveoSearchPageClient {
     public coveoAnalyticsClient: AnalyticsClient;
 
-    constructor(
-        private opts: Partial<SearchPageClientOptions>,
-        private provider: SearchPageClientProvider,
-    ) {
+    constructor(private opts: Partial<SearchPageClientOptions>, private provider: SearchPageClientProvider) {
         const shouldDisableAnalytics = opts.enableAnalytics === false || doNotTrack();
         this.coveoAnalyticsClient = shouldDisableAnalytics ? new NoopAnalytics() : new CoveoAnalyticsClient(opts);
     }
@@ -292,7 +290,7 @@ export class CoveoSearchPageClient {
         return this.makeCustomEvent(
             SearchPageEvents.triggerQuery,
             {query: this.provider.getSearchEventRequestPayload().queryText},
-            'queryPipelineTriggers',
+            'queryPipelineTriggers'
         );
     }
 
@@ -553,7 +551,7 @@ export class CoveoSearchPageClient {
     public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
         return this.makeCustomEvent(
             SearchPageEvents.expandSmartSnippetSuggestion,
-            'documentId' in snippet ? snippet : {documentId: snippet},
+            'documentId' in snippet ? snippet : {documentId: snippet}
         );
     }
 
@@ -564,12 +562,12 @@ export class CoveoSearchPageClient {
     public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
         return this.makeCustomEvent(
             SearchPageEvents.collapseSmartSnippetSuggestion,
-            'documentId' in snippet ? snippet : {documentId: snippet},
+            'documentId' in snippet ? snippet : {documentId: snippet}
         );
     }
 
     public async logCollapseSmartSnippetSuggestion(
-        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier,
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
     ) {
         return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
@@ -615,7 +613,7 @@ export class CoveoSearchPageClient {
             SearchPageEvents.openSmartSnippetSuggestionSource,
             info,
             {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
-            snippet,
+            snippet
         );
     }
 
@@ -629,7 +627,7 @@ export class CoveoSearchPageClient {
 
     public async logOpenSmartSnippetSuggestionSource(
         info: PartialDocumentInformation,
-        snippet: SmartSnippetSuggestionMeta,
+        snippet: SmartSnippetSuggestionMeta
     ) {
         return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log({
             searchUID: this.provider.getSearchUID(),
@@ -638,19 +636,19 @@ export class CoveoSearchPageClient {
 
     public makeOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
-        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
         return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetInlineLink,
             info,
             {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
-            identifierAndLink,
+            identifierAndLink
         );
     }
 
     public async logOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
-        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
     ) {
         return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log({
             searchUID: this.provider.getSearchUID(),
@@ -659,7 +657,7 @@ export class CoveoSearchPageClient {
 
     public makeOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
-        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
         return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetSuggestionInlineLink,
@@ -668,13 +666,13 @@ export class CoveoSearchPageClient {
                 contentIDKey: snippetAndLink.documentId.contentIdKey,
                 contentIDValue: snippetAndLink.documentId.contentIdValue,
             },
-            snippetAndLink,
+            snippetAndLink
         );
     }
 
     public async logOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
-        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
     ) {
         return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log({
             searchUID: this.provider.getSearchUID(),
@@ -739,7 +737,7 @@ export class CoveoSearchPageClient {
 
     private makeEventDescription(
         preparedEvent: PreparedEvent<unknown, unknown, AnyEventResponse>,
-        actionCause: SearchPageEvents,
+        actionCause: SearchPageEvents
     ): EventDescription {
         return {actionCause, customData: preparedEvent.payload?.customData};
     }
@@ -747,7 +745,7 @@ export class CoveoSearchPageClient {
     public async makeCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
-        eventType: string = CustomEventsTypes[event]!,
+        eventType: string = CustomEventsTypes[event]!
     ): Promise<EventBuilder<CustomEventResponse>> {
         this.coveoAnalyticsClient.getParameters;
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
@@ -766,7 +764,7 @@ export class CoveoSearchPageClient {
     public async logCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
-        eventType: string = CustomEventsTypes[event]!,
+        eventType: string = CustomEventsTypes[event]!
     ) {
         return (await this.makeCustomEvent(event, metadata, eventType)).log({searchUID: this.provider.getSearchUID()});
     }
@@ -774,7 +772,7 @@ export class CoveoSearchPageClient {
     public async makeCustomEventWithType(
         eventValue: string,
         eventType: string,
-        metadata?: Record<string, any>,
+        metadata?: Record<string, any>
     ): Promise<EventBuilder<CustomEventResponse>> {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
         const payload: CustomEventRequest = {
@@ -801,7 +799,7 @@ export class CoveoSearchPageClient {
 
     public async makeSearchEvent(
         event: SearchPageEvents,
-        metadata?: Record<string, any>,
+        metadata?: Record<string, any>
     ): Promise<EventBuilder<SearchEventResponse>> {
         const request = await this.getBaseSearchEventRequest(event, metadata);
         const preparedEvent = await this.coveoAnalyticsClient.makeSearchEvent(request);
@@ -815,7 +813,7 @@ export class CoveoSearchPageClient {
         event: SearchPageEvents,
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,
-        metadata?: Record<string, any>,
+        metadata?: Record<string, any>
     ): Promise<EventBuilder<ClickEventResponse>> {
         const request: PreparedClickEventRequest = {
             ...info,
@@ -834,7 +832,7 @@ export class CoveoSearchPageClient {
         event: SearchPageEvents,
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,
-        metadata?: Record<string, any>,
+        metadata?: Record<string, any>
     ) {
         return (await this.makeClickEvent(event, info, identifier, metadata)).log({
             searchUID: this.provider.getSearchUID(),
@@ -843,7 +841,7 @@ export class CoveoSearchPageClient {
 
     private async getBaseSearchEventRequest(
         event: SearchPageEvents,
-        metadata?: Record<string, any>,
+        metadata?: Record<string, any>
     ): Promise<PreparedSearchEventRequest> {
         return {
             ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
@@ -916,21 +914,31 @@ export class CoveoSearchPageClient {
         });
     }
 
+    public makeGeneratedAnswerOpenInlineLink(metadata: GeneratedAnswerInlineLinkMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerOpenInlineLink, metadata);
+    }
+
+    public async logGeneratedAnswerOpenInlineLink(metadata: GeneratedAnswerInlineLinkMeta) {
+        return (await this.makeGeneratedAnswerOpenInlineLink(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
     public makeGeneratedAnswerCitationClick(
         info: PartialDocumentInformation,
-        citation: GeneratedAnswerCitationClickMeta,
+        citation: GeneratedAnswerCitationClickMeta
     ) {
         return this.makeClickEvent(
             SearchPageEvents.generatedAnswerCitationClick,
             {...info, documentPosition: 1},
             {contentIDKey: citation.documentId.contentIdKey, contentIDValue: citation.documentId.contentIdValue},
-            citation,
+            citation
         );
     }
 
     public async logGeneratedAnswerCitationClick(
         info: PartialDocumentInformation,
-        citation: GeneratedAnswerCitationClickMeta,
+        citation: GeneratedAnswerCitationClickMeta
     ) {
         return (await this.makeGeneratedAnswerCitationClick(info, citation)).log({
             searchUID: this.provider.getSearchUID(),

--- a/src/searchPage/searchPageClient.ts
+++ b/src/searchPage/searchPageClient.ts
@@ -81,7 +81,10 @@ export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
 export class CoveoSearchPageClient {
     public coveoAnalyticsClient: AnalyticsClient;
 
-    constructor(private opts: Partial<SearchPageClientOptions>, private provider: SearchPageClientProvider) {
+    constructor(
+        private opts: Partial<SearchPageClientOptions>,
+        private provider: SearchPageClientProvider,
+    ) {
         const shouldDisableAnalytics = opts.enableAnalytics === false || doNotTrack();
         this.coveoAnalyticsClient = shouldDisableAnalytics ? new NoopAnalytics() : new CoveoAnalyticsClient(opts);
     }
@@ -290,7 +293,7 @@ export class CoveoSearchPageClient {
         return this.makeCustomEvent(
             SearchPageEvents.triggerQuery,
             {query: this.provider.getSearchEventRequestPayload().queryText},
-            'queryPipelineTriggers'
+            'queryPipelineTriggers',
         );
     }
 
@@ -551,7 +554,7 @@ export class CoveoSearchPageClient {
     public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
         return this.makeCustomEvent(
             SearchPageEvents.expandSmartSnippetSuggestion,
-            'documentId' in snippet ? snippet : {documentId: snippet}
+            'documentId' in snippet ? snippet : {documentId: snippet},
         );
     }
 
@@ -562,12 +565,12 @@ export class CoveoSearchPageClient {
     public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
         return this.makeCustomEvent(
             SearchPageEvents.collapseSmartSnippetSuggestion,
-            'documentId' in snippet ? snippet : {documentId: snippet}
+            'documentId' in snippet ? snippet : {documentId: snippet},
         );
     }
 
     public async logCollapseSmartSnippetSuggestion(
-        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier,
     ) {
         return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
     }
@@ -613,7 +616,7 @@ export class CoveoSearchPageClient {
             SearchPageEvents.openSmartSnippetSuggestionSource,
             info,
             {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
-            snippet
+            snippet,
         );
     }
 
@@ -627,7 +630,7 @@ export class CoveoSearchPageClient {
 
     public async logOpenSmartSnippetSuggestionSource(
         info: PartialDocumentInformation,
-        snippet: SmartSnippetSuggestionMeta
+        snippet: SmartSnippetSuggestionMeta,
     ) {
         return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log({
             searchUID: this.provider.getSearchUID(),
@@ -636,19 +639,19 @@ export class CoveoSearchPageClient {
 
     public makeOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
-        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta,
     ) {
         return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetInlineLink,
             info,
             {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
-            identifierAndLink
+            identifierAndLink,
         );
     }
 
     public async logOpenSmartSnippetInlineLink(
         info: PartialDocumentInformation,
-        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta,
     ) {
         return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log({
             searchUID: this.provider.getSearchUID(),
@@ -657,7 +660,7 @@ export class CoveoSearchPageClient {
 
     public makeOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
-        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta,
     ) {
         return this.makeClickEvent(
             SearchPageEvents.openSmartSnippetSuggestionInlineLink,
@@ -666,13 +669,13 @@ export class CoveoSearchPageClient {
                 contentIDKey: snippetAndLink.documentId.contentIdKey,
                 contentIDValue: snippetAndLink.documentId.contentIdValue,
             },
-            snippetAndLink
+            snippetAndLink,
         );
     }
 
     public async logOpenSmartSnippetSuggestionInlineLink(
         info: PartialDocumentInformation,
-        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta,
     ) {
         return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log({
             searchUID: this.provider.getSearchUID(),
@@ -737,7 +740,7 @@ export class CoveoSearchPageClient {
 
     private makeEventDescription(
         preparedEvent: PreparedEvent<unknown, unknown, AnyEventResponse>,
-        actionCause: SearchPageEvents
+        actionCause: SearchPageEvents,
     ): EventDescription {
         return {actionCause, customData: preparedEvent.payload?.customData};
     }
@@ -745,7 +748,7 @@ export class CoveoSearchPageClient {
     public async makeCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
-        eventType: string = CustomEventsTypes[event]!
+        eventType: string = CustomEventsTypes[event]!,
     ): Promise<EventBuilder<CustomEventResponse>> {
         this.coveoAnalyticsClient.getParameters;
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
@@ -764,7 +767,7 @@ export class CoveoSearchPageClient {
     public async logCustomEvent(
         event: SearchPageEvents,
         metadata?: Record<string, any>,
-        eventType: string = CustomEventsTypes[event]!
+        eventType: string = CustomEventsTypes[event]!,
     ) {
         return (await this.makeCustomEvent(event, metadata, eventType)).log({searchUID: this.provider.getSearchUID()});
     }
@@ -772,7 +775,7 @@ export class CoveoSearchPageClient {
     public async makeCustomEventWithType(
         eventValue: string,
         eventType: string,
-        metadata?: Record<string, any>
+        metadata?: Record<string, any>,
     ): Promise<EventBuilder<CustomEventResponse>> {
         const customData = {...this.provider.getBaseMetadata(), ...metadata};
         const payload: CustomEventRequest = {
@@ -799,7 +802,7 @@ export class CoveoSearchPageClient {
 
     public async makeSearchEvent(
         event: SearchPageEvents,
-        metadata?: Record<string, any>
+        metadata?: Record<string, any>,
     ): Promise<EventBuilder<SearchEventResponse>> {
         const request = await this.getBaseSearchEventRequest(event, metadata);
         const preparedEvent = await this.coveoAnalyticsClient.makeSearchEvent(request);
@@ -813,7 +816,7 @@ export class CoveoSearchPageClient {
         event: SearchPageEvents,
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,
-        metadata?: Record<string, any>
+        metadata?: Record<string, any>,
     ): Promise<EventBuilder<ClickEventResponse>> {
         const request: PreparedClickEventRequest = {
             ...info,
@@ -832,7 +835,7 @@ export class CoveoSearchPageClient {
         event: SearchPageEvents,
         info: PartialDocumentInformation,
         identifier: DocumentIdentifier,
-        metadata?: Record<string, any>
+        metadata?: Record<string, any>,
     ) {
         return (await this.makeClickEvent(event, info, identifier, metadata)).log({
             searchUID: this.provider.getSearchUID(),
@@ -841,7 +844,7 @@ export class CoveoSearchPageClient {
 
     private async getBaseSearchEventRequest(
         event: SearchPageEvents,
-        metadata?: Record<string, any>
+        metadata?: Record<string, any>,
     ): Promise<PreparedSearchEventRequest> {
         return {
             ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
@@ -926,19 +929,19 @@ export class CoveoSearchPageClient {
 
     public makeGeneratedAnswerCitationClick(
         info: PartialDocumentInformation,
-        citation: GeneratedAnswerCitationClickMeta
+        citation: GeneratedAnswerCitationClickMeta,
     ) {
         return this.makeClickEvent(
             SearchPageEvents.generatedAnswerCitationClick,
             {...info, documentPosition: 1},
             {contentIDKey: citation.documentId.contentIdKey, contentIDValue: citation.documentId.contentIdValue},
-            citation
+            citation,
         );
     }
 
     public async logGeneratedAnswerCitationClick(
         info: PartialDocumentInformation,
-        citation: GeneratedAnswerCitationClickMeta
+        citation: GeneratedAnswerCitationClickMeta,
     ) {
         return (await this.makeGeneratedAnswerCitationClick(info, citation)).log({
             searchUID: this.provider.getSearchUID(),

--- a/src/searchPage/searchPageEvents.ts
+++ b/src/searchPage/searchPageEvents.ts
@@ -311,6 +311,10 @@ export enum SearchPageEvents {
      */
     openGeneratedAnswerSource = 'openGeneratedAnswerSource',
     /**
+     * Identifies the custom event that gets logged when a user clicks an inline link in a generated answer.
+     */
+    generatedAnswerOpenInlineLink = 'generatedAnswerOpenInlineLink',
+    /**
      * Identified the custom event that gets logged when a generated answer stream is completed.
      */
     generatedAnswerStreamEnd = 'generatedAnswerStreamEnd',
@@ -398,6 +402,7 @@ export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents,
     [SearchPageEvents.likeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.dislikeGeneratedAnswer]: 'generatedAnswer',
     [SearchPageEvents.openGeneratedAnswerSource]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerOpenInlineLink]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerStreamEnd]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerSourceHover]: 'generatedAnswer',
     [SearchPageEvents.generatedAnswerCopyToClipboard]: 'generatedAnswer',
@@ -536,10 +541,12 @@ export interface SmartSnippetSuggestionMeta {
     documentId: SmartSnippetDocumentIdentifier;
 }
 
-export interface SmartSnippetLinkMeta {
+export interface LinkMeta {
     linkText: string;
     linkURL: string;
 }
+
+export interface SmartSnippetLinkMeta extends LinkMeta {}
 
 export interface SmartSnippetDocumentIdentifier {
     contentIdKey: string;
@@ -580,6 +587,8 @@ export type GeneratedAnswerCitationMeta = GeneratedAnswerBaseMeta & {
     permanentId: string;
     citationId: string;
 };
+
+export type GeneratedAnswerInlineLinkMeta = GeneratedAnswerBaseMeta & LinkMeta;
 
 export type GeneratedAnswerCitationClickMeta = GeneratedAnswerBaseMeta & {
     citationId: string;


### PR DESCRIPTION
## [SFINT-6734](https://coveord.atlassian.net/browse/SFINT-6734) :rocket:

### Proposed changes:

This PR Adds  support for logging generated answer inline link clicks as a UA custom event. 
his PR introduces a new generated answer event, `generatedAnswerOpenInlineLink`, exposed only through `CoveoSearchPageClient`. 
The event is logged as a custom event under the `generatedAnswer` event type, following the same search-client pattern already used for other generated answer analytics events.

### How to test

<!-- Steps to check how we can make sure this feature works. -->
```
npm run test
```

### Checklist:

- [x] Unit tests and/or functional tests are written and cover the proposed changes :exclamation:
- [x] The proposed change can't affect any current customer implementation that could lead to events being rejected from our APIs or events to be miscategorized by UA.


[SFINT-6734]: https://coveord.atlassian.net/browse/SFINT-6734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ