### PR TITLE
chore: update catalog-info owner to real-time-platform

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -68,7 +68,7 @@ spec:
   # the team. See:
   # - Field reference: https://backstage.io/docs/features/software-catalog/descriptor-format/#specowner-required
   # - List of valid teams: https://devportal.dep.cloud.coveo.com/catalog?filters%5Bkind%5D=group&filters%5Btype%5D=team&filters%5Buser%5D=all
-  owner: group:default/dataplatformfoundation
+  owner: group:default/real-time-platform
 
   # System that this component is part of. The system will need to be defined
   # somewhere in the catalog. In practice this means that it'll need to be


### PR DESCRIPTION
## Summary

The `dataplatformfoundation` DevPortal group is a legacy/redundant entity. The canonical team is `real-time-platform`, which has:
- Jira project: `CCC`
- Slack: `#support-dataplatform`
- Active component ownership in DevPortal

Top PR reviewers (tsteijvers, amartineau2, aperron, rphilippen, lbourdages) all belong to `real-time-platform`.

> Investigation done by GitHub Copilot based on commit/PR history cross-referenced with DevPortal catalog.